### PR TITLE
Add deployment support to VCF Automation Orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/@mgovedarov/mcp-vcf-orchestrator)](https://www.npmjs.com/package/@mgovedarov/mcp-vcf-orchestrator)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-An [MCP](https://modelcontextprotocol.io/) server that exposes VCF Automation Orchestrator (vRO) REST API operations as tools. Enables AI assistants to list, create, delete, and run workflows, actions, configuration elements, and extensibility subscriptions via natural language.
+An [MCP](https://modelcontextprotocol.io/) server that exposes VCF Automation Orchestrator (vRO) and Service Broker REST API operations as tools. Enables AI assistants to list, create, delete, and run workflows, actions, configuration elements, extensibility subscriptions, catalog items, and deployments via natural language.
 
 Supports **VCF 9 Automation** and **Aria Automation 8.x**.
 
@@ -149,6 +149,15 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `list-catalog-items` | List available Service Broker catalog items, optionally searched by name |
 | `get-catalog-item` | Get catalog item details including type, source, and project assignments |
 
+### Deployments
+
+| Tool | Description |
+|------|-------------|
+| `list-deployments` | List deployments, optionally filtered by name/keyword or project ID |
+| `get-deployment` | Get deployment details including status, project, and catalog item info |
+| `create-deployment` | Deploy a catalog item by providing its ID, a deployment name, and a project ID |
+| `delete-deployment` | Delete a deployment (irreversible) |
+
 ### Extensibility Subscriptions
 
 | Tool | Description |
@@ -221,6 +230,33 @@ Assistant calls: create-subscription(
   priority: 10
 )
   → Subscription created: Post-Provision VM Hardening (ENABLED)
+```
+
+### List and deploy a catalog item
+
+```
+User: What catalog items are available in the Service Broker?
+
+Assistant calls: list-catalog-items()
+  → Lists all catalog items with IDs and types
+
+User: Deploy "Ubuntu 22.04 Server" to project "dev-team" and name it
+      "build-agent-01".
+
+Assistant calls: get-catalog-item(id: "...")
+  → Shows inputs required: size, diskGb
+Assistant calls: create-deployment(
+  catalogItemId: "...",
+  deploymentName: "build-agent-01",
+  projectId: "<dev-team-project-id>",
+  inputs: {size: "medium", diskGb: 80}
+)
+  → Deployment request submitted. ID: ... Status: CREATE_IN_PROGRESS
+
+User: Check all deployments in the dev-team project.
+
+Assistant calls: list-deployments(projectId: "<dev-team-project-id>")
+  → Lists deployments with status
 ```
 
 ### Manage existing subscriptions

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # TODO
 
 1. [x] List catalog items, get catalog item
-2. [ ] Add support for deployments - list, delete, create from catalog item
+2. [x] Add support for deployments - list, delete, create from catalog item
 3. [ ] Add support for templates - list, create, delete
 4. [x] Add delete operations for workflows, actions, and configuration elements
 5. [ ] Add package import/export support

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { registerConfigTools } from "./tools/config-tools.js";
 import { registerCategoryTools } from "./tools/category-tools.js";
 import { registerSubscriptionTools } from "./tools/subscription-tools.js";
 import { registerCatalogTools } from "./tools/catalog-tools.js";
+import { registerDeploymentTools } from "./tools/deployment-tools.js";
 
 function getRequiredEnv(name: string): string {
   const value = process.env[name];
@@ -49,6 +50,7 @@ async function main(): Promise<void> {
         "Use list-event-topics to discover available event topics before creating extensibility subscriptions.",
         "Use list-subscriptions to see existing event-driven triggers.",
         "Use list-catalog-items to browse the Service Broker catalog; use get-catalog-item to inspect a specific item by ID.",
+        "Use list-deployments to see existing deployments; use create-deployment to deploy a catalog item, providing the catalogItemId, deploymentName, and projectId.",
       ].join(" "),
     }
   );
@@ -60,6 +62,7 @@ async function main(): Promise<void> {
   registerCategoryTools(server, client);
   registerSubscriptionTools(server, client);
   registerCatalogTools(server, client);
+  registerDeploymentTools(server, client);
 
   // Connect via stdio transport
   const transport = new StdioServerTransport();

--- a/src/tools/action-tools.ts
+++ b/src/tools/action-tools.ts
@@ -186,13 +186,24 @@ export function registerActionTools(
     {
       title: "Delete Action",
       description:
-        "Delete an action (scriptable task) from VCF Automation Orchestrator. This action is irreversible.",
+        "Delete an action (scriptable task) from VCF Automation Orchestrator. This action is irreversible. Set confirm to true to proceed.",
       inputSchema: z.object({
         id: z.string().describe("The action ID to delete"),
+        confirm: z.boolean().describe("Must be set to true to confirm deletion. If false, the deletion will not proceed."),
       }),
       annotations: { readOnlyHint: false, destructiveHint: true },
     },
-    async ({ id }): Promise<CallToolResult> => {
+    async ({ id, confirm }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Confirm deletion of action ${id} by setting confirm to true. This action is irreversible.`,
+            },
+          ],
+        };
+      }
       try {
         await client.deleteAction(id);
         return {

--- a/src/tools/config-tools.ts
+++ b/src/tools/config-tools.ts
@@ -185,13 +185,24 @@ export function registerConfigTools(
     {
       title: "Delete Configuration Element",
       description:
-        "Delete a configuration element from VCF Automation Orchestrator. This action is irreversible.",
+        "Delete a configuration element from VCF Automation Orchestrator. This action is irreversible. Set confirm to true to proceed.",
       inputSchema: z.object({
         id: z.string().describe("The configuration element ID to delete"),
+        confirm: z.boolean().describe("Must be set to true to confirm deletion. If false, the deletion will not proceed."),
       }),
       annotations: { readOnlyHint: false, destructiveHint: true },
     },
-    async ({ id }): Promise<CallToolResult> => {
+    async ({ id, confirm }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Confirm deletion of configuration element ${id} by setting confirm to true. This action is irreversible.`,
+            },
+          ],
+        };
+      }
       try {
         await client.deleteConfiguration(id);
         return {

--- a/src/tools/deployment-tools.ts
+++ b/src/tools/deployment-tools.ts
@@ -1,0 +1,203 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { VroClient } from "../vro-client.js";
+
+export function registerDeploymentTools(
+  server: McpServer,
+  client: VroClient
+): void {
+  server.registerTool(
+    "list-deployments",
+    {
+      title: "List Deployments",
+      description:
+        "List deployments in VCF Automation. Optionally filter by name/keyword search or by project ID.",
+      inputSchema: z.object({
+        search: z
+          .string()
+          .optional()
+          .describe("Search deployments by name or keyword"),
+        projectId: z
+          .string()
+          .optional()
+          .describe("Filter deployments by project ID"),
+      }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ search, projectId }): Promise<CallToolResult> => {
+      try {
+        const result = await client.listDeployments(search, projectId);
+        const items = result.content ?? [];
+        if (items.length === 0) {
+          return {
+            content: [{ type: "text", text: "No deployments found." }],
+          };
+        }
+        const lines = items.map((d) => {
+          let line = `• ${d.name} (id: ${d.id})`;
+          if (d.status) line += ` [${d.status}]`;
+          if (d.projectName) line += ` — project: ${d.projectName}`;
+          else if (d.projectId) line += ` — projectId: ${d.projectId}`;
+          return line;
+        });
+        const total = result.totalElements ?? items.length;
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Found ${total} deployment(s):\n\n${lines.join("\n")}`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to list deployments: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "get-deployment",
+    {
+      title: "Get Deployment",
+      description:
+        "Get detailed information about a specific deployment by its ID.",
+      inputSchema: z.object({
+        id: z.string().describe("The deployment ID"),
+      }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ id }): Promise<CallToolResult> => {
+      try {
+        const d = await client.getDeployment(id);
+        let text = `Deployment: ${d.name}\nID: ${d.id}\n`;
+        if (d.status) text += `Status: ${d.status}\n`;
+        if (d.description) text += `Description: ${d.description}\n`;
+        if (d.projectName) text += `Project: ${d.projectName}\n`;
+        else if (d.projectId) text += `Project ID: ${d.projectId}\n`;
+        if (d.catalogItemId) text += `Catalog Item ID: ${d.catalogItemId}\n`;
+        if (d.catalogItemVersion) text += `Catalog Item Version: ${d.catalogItemVersion}\n`;
+        if (d.ownedBy) text += `Owned By: ${d.ownedBy}\n`;
+        if (d.createdBy) text += `Created By: ${d.createdBy}\n`;
+        if (d.createdAt) text += `Created At: ${d.createdAt}\n`;
+        if (d.lastUpdatedBy) text += `Last Updated By: ${d.lastUpdatedBy}\n`;
+        if (d.lastUpdatedAt) text += `Last Updated At: ${d.lastUpdatedAt}\n`;
+        return { content: [{ type: "text", text }] };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to get deployment: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "delete-deployment",
+    {
+      title: "Delete Deployment",
+      description: "Delete a deployment by its ID. Set confirm to true to proceed.",
+      inputSchema: z.object({
+        id: z.string().describe("The deployment ID to delete"),
+        confirm: z.boolean().describe("Must be set to true to confirm deletion. If false, the deletion will not proceed."),
+      }),
+      annotations: { destructiveHint: true },
+    },
+    async ({ id, confirm }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [{ type: "text", text: `Confirm deletion of deployment ${id} by setting confirm to true. This action is irreversible.` }],
+        };
+      }
+      try {
+        await client.deleteDeployment(id);
+        return {
+          content: [{ type: "text", text: `Deployment ${id} deleted successfully.` }],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to delete deployment: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "create-deployment",
+    {
+      title: "Create Deployment",
+      description:
+        "Create a new deployment from a catalog item. Use list-catalog-items to find the catalog item ID, and list-deployments to verify afterwards.",
+      inputSchema: z.object({
+        catalogItemId: z
+          .string()
+          .describe("The catalog item ID to deploy"),
+        deploymentName: z
+          .string()
+          .describe("Name for the new deployment"),
+        projectId: z
+          .string()
+          .describe("The project ID in which to create the deployment"),
+        version: z
+          .string()
+          .optional()
+          .describe("Catalog item version to deploy (defaults to latest)"),
+        reason: z
+          .string()
+          .optional()
+          .describe("Reason or comment for the deployment request"),
+        inputs: z
+          .record(z.unknown())
+          .optional()
+          .describe("Catalog item input parameters as a key/value object"),
+      }),
+      annotations: { destructiveHint: false },
+    },
+    async ({ catalogItemId, deploymentName, projectId, version, reason, inputs }): Promise<CallToolResult> => {
+      try {
+        const deployment = await client.createDeploymentFromCatalogItem({
+          catalogItemId,
+          deploymentName,
+          projectId,
+          version,
+          reason,
+          inputs,
+        });
+        let text = `Deployment request submitted.\n`;
+        if (deployment.id) text += `ID: ${deployment.id}\n`;
+        if (deployment.name) text += `Name: ${deployment.name}\n`;
+        if (deployment.status) text += `Status: ${deployment.status}\n`;
+        return { content: [{ type: "text", text }] };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to create deployment: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/src/tools/subscription-tools.ts
+++ b/src/tools/subscription-tools.ts
@@ -321,13 +321,24 @@ export function registerSubscriptionTools(
     {
       title: "Delete Subscription",
       description:
-        "Delete an extensibility subscription from the VCF Automation Event Broker.",
+        "Delete an extensibility subscription from the VCF Automation Event Broker. Set confirm to true to proceed.",
       inputSchema: z.object({
         id: z.string().describe("The subscription ID to delete"),
+        confirm: z.boolean().describe("Must be set to true to confirm deletion. If false, the deletion will not proceed."),
       }),
       annotations: { readOnlyHint: false, destructiveHint: true },
     },
-    async ({ id }): Promise<CallToolResult> => {
+    async ({ id, confirm }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Confirm deletion of subscription ${id} by setting confirm to true. This action is irreversible.`,
+            },
+          ],
+        };
+      }
       try {
         await client.deleteSubscription(id);
         return {

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -254,13 +254,24 @@ export function registerWorkflowTools(
     {
       title: "Delete Workflow",
       description:
-        "Delete a workflow from VCF Automation Orchestrator. This action is irreversible.",
+        "Delete a workflow from VCF Automation Orchestrator. This action is irreversible. Set confirm to true to proceed.",
       inputSchema: z.object({
         id: z.string().describe("The workflow ID to delete"),
+        confirm: z.boolean().describe("Must be set to true to confirm deletion. If false, the deletion will not proceed."),
       }),
       annotations: { readOnlyHint: false, destructiveHint: true },
     },
-    async ({ id }): Promise<CallToolResult> => {
+    async ({ id, confirm }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Confirm deletion of workflow ${id} by setting confirm to true. This action is irreversible.`,
+            },
+          ],
+        };
+      }
       try {
         await client.deleteWorkflow(id);
         return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,6 +212,30 @@ export interface CatalogItemList {
   numberOfElements?: number;
 }
 
+// --- Deployments ---
+
+export interface Deployment {
+  id: string;
+  name: string;
+  description?: string;
+  status?: string; // e.g. "CREATE_SUCCESSFUL" | "DELETE_IN_PROGRESS" | "UPDATE_FAILED" etc.
+  projectId?: string;
+  projectName?: string;
+  catalogItemId?: string;
+  catalogItemVersion?: string;
+  ownedBy?: string;
+  createdAt?: string;
+  createdBy?: string;
+  lastUpdatedAt?: string;
+  lastUpdatedBy?: string;
+}
+
+export interface DeploymentList {
+  content: Deployment[];
+  totalElements?: number;
+  numberOfElements?: number;
+}
+
 // --- Client config ---
 
 export interface VroClientConfig {

--- a/src/vro-client.ts
+++ b/src/vro-client.ts
@@ -16,6 +16,8 @@ import type {
   EventTopicList,
   CatalogItem,
   CatalogItemList,
+  Deployment,
+  DeploymentList,
 } from "./types.js";
 
 /**
@@ -30,6 +32,7 @@ export class VroClient {
   private baseUrl: string;
   private eventBrokerBaseUrl: string;
   private catalogBaseUrl: string;
+  private deploymentBaseUrl: string;
   private sessionUrl: string;
   private loginHeader: string;
   private token: string | null = null;
@@ -38,6 +41,7 @@ export class VroClient {
     this.baseUrl = `https://${config.host}/vco/api`;
     this.eventBrokerBaseUrl = `https://${config.host}/event-broker/api`;
     this.catalogBaseUrl = `https://${config.host}/catalog/api`;
+    this.deploymentBaseUrl = `https://${config.host}/deployment/api`;
     this.sessionUrl = `https://${config.host}/cloudapi/1.0.0/sessions`;
     // Basic Auth credential: username@organization:password
     this.loginHeader =
@@ -496,6 +500,56 @@ export class VroClient {
   async getCatalogItem(id: string): Promise<CatalogItem> {
     return this.get<CatalogItem>(
       `/items/${encodeURIComponent(id)}`,
+      this.catalogBaseUrl
+    );
+  }
+
+  // --- Deployments ---
+
+  async listDeployments(search?: string, projectId?: string): Promise<DeploymentList> {
+    const params: string[] = [];
+    if (search) {
+      params.push(`$search=${encodeURIComponent(search)}`);
+    }
+    if (projectId) {
+      params.push(`projectId=${encodeURIComponent(projectId)}`);
+    }
+    const path = params.length > 0 ? `/deployments?${params.join("&")}` : "/deployments";
+    return this.get<DeploymentList>(path, this.deploymentBaseUrl);
+  }
+
+  async getDeployment(id: string): Promise<Deployment> {
+    return this.get<Deployment>(
+      `/deployments/${encodeURIComponent(id)}`,
+      this.deploymentBaseUrl
+    );
+  }
+
+  async deleteDeployment(id: string): Promise<void> {
+    await this.del<unknown>(
+      `/deployments/${encodeURIComponent(id)}`,
+      this.deploymentBaseUrl
+    );
+  }
+
+  async createDeploymentFromCatalogItem(params: {
+    catalogItemId: string;
+    deploymentName: string;
+    projectId: string;
+    version?: string;
+    reason?: string;
+    inputs?: Record<string, unknown>;
+  }): Promise<Deployment> {
+    const body: Record<string, unknown> = {
+      deploymentName: params.deploymentName,
+      projectId: params.projectId,
+    };
+    if (params.version !== undefined) body.version = params.version;
+    if (params.reason !== undefined) body.reason = params.reason;
+    if (params.inputs !== undefined) body.inputs = params.inputs;
+    return this.post<Deployment>(
+      `/items/${encodeURIComponent(params.catalogItemId)}/request`,
+      body,
       this.catalogBaseUrl
     );
   }


### PR DESCRIPTION
- Enhance README with deployment tools and examples.
- Update TODO to reflect deployment feature completion.
- Implement deployment tools: list, get, create, and delete deployments.
- Modify existing tools to require confirmation for irreversible actions.
- Introduce new types for deployments in the type definitions.