### PR TITLE
Add run-workflow-and-wait workflow execution loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ trigger: "vcfa-orchestrator"
 
 # VCF Orchestrator Agent
 
-This custom agent is designed to assist with managing VCF Automation Orchestrator workflows, workflow executions, actions, configurations, resource elements, subscriptions, catalog items, deployments, templates, packages, and plugins via natural language commands. It loads the MCP server tools automatically and exposes commands like \`list-workflows\`, \`create-workflow\`, \`run-workflow\`, \`list-workflow-executions\`, \`list-deployments\`, and related artifact import/export commands.
+This custom agent is designed to assist with managing VCF Automation Orchestrator workflows, workflow executions, actions, configurations, resource elements, subscriptions, catalog items, deployments, templates, packages, and plugins via natural language commands. It loads the MCP server tools automatically and exposes commands like \`list-workflows\`, \`create-workflow\`, \`run-workflow\`, \`run-workflow-and-wait\`, \`list-workflow-executions\`, \`list-deployments\`, and related artifact import/export commands.
 
 ## When to Use
 
@@ -20,7 +20,7 @@ This custom agent is designed to assist with managing VCF Automation Orchestrato
 
 ## Commands
 
-- Workflows: \`list-workflows\`, \`get-workflow\`, \`create-workflow\`, \`run-workflow\`, \`list-workflow-executions\`, \`get-workflow-execution\`, \`export-workflow-file\`, \`import-workflow-file\`, \`delete-workflow\`
+- Workflows: \`list-workflows\`, \`get-workflow\`, \`create-workflow\`, \`run-workflow\`, \`run-workflow-and-wait\`, \`list-workflow-executions\`, \`get-workflow-execution\`, \`export-workflow-file\`, \`import-workflow-file\`, \`delete-workflow\`
 - Actions: \`list-actions\`, \`get-action\`, \`create-action\`, \`export-action-file\`, \`import-action-file\`, \`delete-action\`
 - Configuration elements: \`list-configurations\`, \`get-configuration\`, \`create-configuration\`, \`update-configuration\`, \`export-configuration-file\`, \`import-configuration-file\`, \`delete-configuration\`
 - Resource elements: \`list-resource-elements\`, \`export-resource-element\`, \`import-resource-element\`, \`update-resource-element\`, \`delete-resource-element\`

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `create-workflow` | Create a new empty workflow in a category |
 | `delete-workflow` | Delete a workflow (irreversible) |
 | `run-workflow` | Execute a workflow with optional input parameters |
+| `run-workflow-and-wait` | Validate inputs, execute a workflow, wait for completion, and return outputs or diagnostics |
 | `list-workflow-executions` | List past and current executions for a workflow, with optional status filter |
 | `get-workflow-execution` | Check execution status and retrieve outputs |
 | `export-workflow-file` | Export a workflow artifact to a `.workflow` file under `VCFA_WORKFLOW_DIR` |
@@ -239,6 +240,9 @@ Assistant calls: run-workflow(id: "...", inputs: [{name: "vm", type: "VC:Virtual
   → Returns execution ID
 Assistant calls: get-workflow-execution(workflowId: "...", executionId: "...")
   → Returns state: "completed", outputs
+
+Assistant can also call: run-workflow-and-wait(id: "...", inputs: [{name: "vm", value: "..."}])
+  → Validates inputs, waits up to 5 minutes by default, and returns outputs or failure diagnostics
 ```
 
 ### Create a custom action

--- a/TODO.md
+++ b/TODO.md
@@ -14,4 +14,4 @@
 12. [x] Implement import/export for actions, config elements and resource elements
 13. [ ] Add workflow artifact authoring/scaffolding tools that generate valid `.workflow` files from structured metadata, inputs/outputs, scriptable task definitions, scripts, and bindings so automation developers do not have to hand-build UTF-16 workflow XML archives
 14. [ ] Add local artifact validation/preflight tools for `.workflow`, `.action`, `.vsoconf`, and package files that verify archive structure, encoding, parameter bindings, action references, supported vRO types, and import safety before uploading to VCFA
-15. [ ] Improve workflow execution tooling with a `run-workflow-and-wait` development loop that validates inputs against `get-workflow`, polls until completion or timeout, and returns outputs plus useful failure details/log excerpts for rapid iteration
+15. [x] Improve workflow execution tooling with a `run-workflow-and-wait` development loop that validates inputs against `get-workflow`, polls until completion or timeout, and returns outputs plus useful failure details/log excerpts for rapid iteration

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -25,6 +25,7 @@ import type {
   Workflow,
   WorkflowExecution,
   WorkflowExecutionList,
+  WorkflowExecutionLogs,
   WorkflowList,
 } from "../types.js";
 import { ActionClient } from "./action-client.js";
@@ -99,9 +100,22 @@ export class VroClient {
 
   getWorkflowExecution(
     workflowId: string,
-    executionId: string
+    executionId: string,
+    options?: { showDetails?: boolean }
   ): Promise<WorkflowExecution> {
-    return this.workflows.getWorkflowExecution(workflowId, executionId);
+    return this.workflows.getWorkflowExecution(workflowId, executionId, options);
+  }
+
+  getWorkflowExecutionLogs(
+    workflowId: string,
+    executionId: string,
+    options?: { maxResult?: number }
+  ): Promise<WorkflowExecutionLogs> {
+    return this.workflows.getWorkflowExecutionLogs(
+      workflowId,
+      executionId,
+      options
+    );
   }
 
   listWorkflowExecutions(

--- a/src/client/workflow-client.ts
+++ b/src/client/workflow-client.ts
@@ -5,6 +5,7 @@ import type {
   Workflow,
   WorkflowExecution,
   WorkflowExecutionList,
+  WorkflowExecutionLogs,
   WorkflowList,
 } from "../types.js";
 import { parseAttrs } from "./attrs.js";
@@ -82,10 +83,31 @@ export class WorkflowClient {
 
   getWorkflowExecution(
     workflowId: string,
-    executionId: string
+    executionId: string,
+    options?: { showDetails?: boolean }
   ): Promise<WorkflowExecution> {
+    const params: string[] = [];
+    if (options?.showDetails) {
+      params.push("showDetails=true");
+    }
+    const query = params.length > 0 ? `?${params.join("&")}` : "";
     return this.http.get<WorkflowExecution>(
-      `/workflows/${encodeURIComponent(workflowId)}/executions/${encodeURIComponent(executionId)}`
+      `/workflows/${encodeURIComponent(workflowId)}/executions/${encodeURIComponent(executionId)}${query}`
+    );
+  }
+
+  getWorkflowExecutionLogs(
+    workflowId: string,
+    executionId: string,
+    options?: { maxResult?: number }
+  ): Promise<WorkflowExecutionLogs> {
+    const params: string[] = [];
+    if (options?.maxResult !== undefined) {
+      params.push(`maxResult=${options.maxResult}`);
+    }
+    const query = params.length > 0 ? `?${params.join("&")}` : "";
+    return this.http.get<WorkflowExecutionLogs>(
+      `/workflows/${encodeURIComponent(workflowId)}/executions/${encodeURIComponent(executionId)}/logs${query}`
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ async function main(): Promise<void> {
         "This server connects to a VCF Automation instance.",
         "Use list-categories before creating workflows, actions, or configuration elements to find the target category ID.",
         "Use get-workflow to inspect a workflow's input parameters before running it with run-workflow.",
+        "Use run-workflow-and-wait for rapid development loops that validate workflow inputs, wait for completion, and return outputs or diagnostics.",
         "After starting a workflow execution with run-workflow, use get-workflow-execution to poll for completion and retrieve outputs.",
         "Use export-workflow-file to save a workflow artifact under VCFA_WORKFLOW_DIR; use import-workflow-file to upload a .workflow artifact from VCFA_WORKFLOW_DIR into a workflow category.",
         "Use export-action-file to save an action artifact under VCFA_ACTION_DIR; use import-action-file to upload a .action artifact from VCFA_ACTION_DIR into an action category by category name.",

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -1,8 +1,19 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import type { VroParameter, Workflow, WorkflowExecution } from "../types.js";
+import type {
+  SimpleParameter,
+  VroParameter,
+  Workflow,
+  WorkflowExecution,
+  WorkflowExecutionLog,
+  WorkflowExecutionStackItem,
+} from "../types.js";
 import type { VroClient } from "../vro-client.js";
+
+const DEFAULT_WORKFLOW_WAIT_TIMEOUT_SECONDS = 300;
+const DEFAULT_WORKFLOW_POLL_INTERVAL_SECONDS = 2;
+const DEFAULT_WORKFLOW_LOG_LIMIT = 20;
 
 const workflowExecutionStatusMap = {
   running: "RUNNING",
@@ -22,6 +33,290 @@ export function getWorkflowOutputParameters(workflow: Workflow): VroParameter[] 
 
 export function getExecutionOutputParameters(execution: WorkflowExecution): VroParameter[] {
   return execution.outputParameters ?? execution["output-parameters"] ?? [];
+}
+
+export function unwrapVroParameterValue(parameter: VroParameter): unknown {
+  const value = parameter.value;
+  if (value === undefined || value === null || typeof value !== "object") {
+    return value;
+  }
+
+  const byType = value[parameter.type];
+  if (hasValueProperty(byType)) {
+    return byType.value;
+  }
+
+  const entries = Object.values(value);
+  if (entries.length === 1 && hasValueProperty(entries[0])) {
+    return entries[0].value;
+  }
+
+  return value;
+}
+
+function hasValueProperty(value: unknown): value is { value: unknown } {
+  return typeof value === "object" && value !== null && "value" in value;
+}
+
+function getWorkflowExecutionStackItems(
+  execution: WorkflowExecution
+): WorkflowExecutionStackItem[] {
+  return (
+    execution.executionStack ??
+    execution["execution-stack"] ??
+    execution.workflowItem ??
+    execution["workflow-item"] ??
+    []
+  );
+}
+
+function normalizeExecutionState(state: string | undefined): string {
+  return (state ?? "").replaceAll("-", "_").toUpperCase();
+}
+
+function isCompletedState(state: string | undefined): boolean {
+  return normalizeExecutionState(state) === "COMPLETED";
+}
+
+function isFailureState(state: string | undefined): boolean {
+  return ["FAILED", "CANCELED", "CANCELLED"].includes(
+    normalizeExecutionState(state)
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function stringifyValue(value: unknown): string {
+  const json = JSON.stringify(value);
+  return json === undefined ? String(value) : json;
+}
+
+function validateParameterValue(type: string, value: unknown): string | null {
+  if (value === undefined) {
+    return "is missing a value";
+  }
+
+  const normalizedType = type.toLowerCase();
+  if (normalizedType === "string" && typeof value !== "string") {
+    return `must be a string for type ${type}`;
+  }
+  if (
+    normalizedType === "number" &&
+    (typeof value !== "number" || !Number.isFinite(value))
+  ) {
+    return `must be a finite number for type ${type}`;
+  }
+  if (normalizedType === "boolean" && typeof value !== "boolean") {
+    return `must be a boolean for type ${type}`;
+  }
+  if (normalizedType.startsWith("array/") && !Array.isArray(value)) {
+    return `must be an array for type ${type}`;
+  }
+
+  return null;
+}
+
+function validateWorkflowRunInputs(
+  workflow: Workflow,
+  inputs: { name: string; type?: string; value?: unknown }[] = []
+): { errors: string[]; inputs: SimpleParameter[] } {
+  const errors: string[] = [];
+  const definitions = getWorkflowInputParameters(workflow);
+  const definitionsByName = new Map(definitions.map((p) => [p.name, p]));
+  const seen = new Set<string>();
+  const normalizedInputs: SimpleParameter[] = [];
+
+  for (const input of inputs) {
+    if (seen.has(input.name)) {
+      errors.push(`Duplicate input: ${input.name}`);
+      continue;
+    }
+    seen.add(input.name);
+
+    const definition = definitionsByName.get(input.name);
+    if (!definition) {
+      errors.push(`Unknown input: ${input.name}`);
+      continue;
+    }
+
+    if (input.type !== undefined && input.type !== definition.type) {
+      errors.push(
+        `Input ${input.name} type ${input.type} does not match workflow type ${definition.type}`
+      );
+    }
+
+    const valueError = validateParameterValue(definition.type, input.value);
+    if (valueError) {
+      errors.push(`Input ${input.name} ${valueError}`);
+    }
+
+    normalizedInputs.push({
+      name: input.name,
+      type: definition.type,
+      value: input.value,
+    });
+  }
+
+  for (const definition of definitions) {
+    if (definition.value === undefined && !seen.has(definition.name)) {
+      errors.push(
+        `Missing required input: ${definition.name} (${definition.type})`
+      );
+    }
+  }
+
+  return { errors, inputs: normalizedInputs };
+}
+
+function formatValidationErrors(workflow: Workflow, errors: string[]): string {
+  return [
+    `Workflow input validation failed for ${workflow.name} (${workflow.id}).`,
+    "",
+    ...errors.map((error) => `• ${error}`),
+  ].join("\n");
+}
+
+function formatOutputParameters(execution: WorkflowExecution): string {
+  const outputs = getExecutionOutputParameters(execution);
+  if (outputs.length === 0) {
+    return "Output Parameters: none";
+  }
+
+  const lines = outputs.map(
+    (p) =>
+      `  • ${p.name} (${p.type}): ${stringifyValue(unwrapVroParameterValue(p))}`
+  );
+  return `Output Parameters:\n${lines.join("\n")}`;
+}
+
+function formatExecutionHeader(
+  title: string,
+  workflow: Workflow,
+  execution: WorkflowExecution,
+  elapsedMs?: number
+): string {
+  let text = `${title}\nWorkflow: ${workflow.name}\nWorkflow ID: ${workflow.id}\nExecution ID: ${execution.id}\nState: ${execution.state}\n`;
+  if (execution["start-date"]) text += `Started: ${execution["start-date"]}\n`;
+  if (execution["end-date"]) text += `Ended: ${execution["end-date"]}\n`;
+  if (execution["started-by"]) text += `Started by: ${execution["started-by"]}\n`;
+  if (elapsedMs !== undefined) {
+    text += `Elapsed wait: ${Math.round(elapsedMs / 1000)}s\n`;
+  }
+  return text.trimEnd();
+}
+
+function formatStackItem(item: WorkflowExecutionStackItem): string {
+  const label =
+    item.displayName ?? item.name ?? item.workflowDisplayName ?? item.href ?? "Unnamed item";
+  const details: string[] = [];
+  if (item.name && item.name !== label) details.push(`name: ${item.name}`);
+  if (item.workflowDisplayName) {
+    details.push(`workflow: ${item.workflowDisplayName}`);
+  }
+  return details.length > 0 ? `${label} (${details.join(", ")})` : label;
+}
+
+function formatLogEntry(log: WorkflowExecutionLog): string {
+  const prefix = [
+    log["time-stamp"],
+    log.severity ? `[${log.severity}]` : undefined,
+    log.origin,
+  ].filter(Boolean);
+  const shortDescription = log["short-description"];
+  const longDescription = log["long-description"];
+  const description =
+    shortDescription && longDescription && shortDescription !== longDescription
+      ? `${shortDescription} — ${longDescription}`
+      : shortDescription ?? longDescription ?? "(no description)";
+  return `${prefix.length > 0 ? `${prefix.join(" ")} ` : ""}${description}`;
+}
+
+function appendDiagnostics(
+  text: string,
+  execution: WorkflowExecution,
+  logs: WorkflowExecutionLog[],
+  warnings: string[]
+): string {
+  let result = text;
+  if (execution["business-state"]) {
+    result += `\nBusiness state: ${execution["business-state"]}`;
+  }
+  if (execution["current-item-display-name"]) {
+    result += `\nCurrent item: ${execution["current-item-display-name"]}`;
+  } else if (execution["current-item-for-display"]) {
+    result += `\nCurrent item: ${execution["current-item-for-display"]}`;
+  }
+  if (execution["content-exception"]) {
+    result += `\n\nError: ${execution["content-exception"]}`;
+  }
+
+  const stackItems = getWorkflowExecutionStackItems(execution);
+  if (stackItems.length > 0) {
+    result += `\n\nExecution Stack:\n${stackItems
+      .slice(0, 5)
+      .map((item) => `  • ${formatStackItem(item)}`)
+      .join("\n")}`;
+  }
+
+  if (logs.length > 0) {
+    result += `\n\nLog Excerpts:\n${logs
+      .map((log) => `  • ${formatLogEntry(log)}`)
+      .join("\n")}`;
+  }
+
+  if (warnings.length > 0) {
+    result += `\n\nWarnings:\n${warnings
+      .map((warning) => `  • ${warning}`)
+      .join("\n")}`;
+  }
+
+  return result;
+}
+
+async function collectExecutionDiagnostics(
+  client: VroClient,
+  workflowId: string,
+  execution: WorkflowExecution,
+  logLimit: number
+): Promise<{
+  execution: WorkflowExecution;
+  logs: WorkflowExecutionLog[];
+  warnings: string[];
+}> {
+  const warnings: string[] = [];
+  let detailedExecution = execution;
+
+  try {
+    detailedExecution = await client.getWorkflowExecution(
+      workflowId,
+      execution.id,
+      { showDetails: true }
+    );
+  } catch (error) {
+    warnings.push(`Unable to fetch detailed execution data: ${errorMessage(error)}`);
+  }
+
+  let logs: WorkflowExecutionLog[] = [];
+  if (logLimit > 0) {
+    try {
+      logs =
+        (
+          await client.getWorkflowExecutionLogs(workflowId, execution.id, {
+            maxResult: logLimit,
+          })
+        ).logs ?? [];
+    } catch (error) {
+      warnings.push(`Unable to fetch execution logs: ${errorMessage(error)}`);
+    }
+  }
+
+  return { execution: detailedExecution, logs, warnings };
 }
 
 export function registerWorkflowTools(
@@ -213,6 +508,177 @@ export function registerWorkflowTools(
             {
               type: "text",
               text: `Failed to run workflow: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "run-workflow-and-wait",
+    {
+      title: "Run Workflow and Wait",
+      description:
+        "Validate inputs, execute a workflow, poll until completion/failure/timeout, and return outputs or useful failure diagnostics.",
+      inputSchema: z.object({
+        id: z.string().describe("The workflow ID to execute"),
+        inputs: z
+          .array(
+            z.object({
+              name: z.string().describe("Parameter name"),
+              type: z
+                .string()
+                .optional()
+                .describe(
+                  "Optional parameter type. If omitted, the workflow definition type is used."
+                ),
+              value: z.unknown().describe("Parameter value"),
+            })
+          )
+          .optional()
+          .describe("Input parameters for the workflow execution"),
+        timeoutSeconds: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Maximum time to wait for completion (default: 300)"),
+        pollIntervalSeconds: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Seconds between execution status polls (default: 2)"),
+        logLimit: z
+          .number()
+          .int()
+          .nonnegative()
+          .optional()
+          .describe("Maximum execution log entries to include on failure or timeout (default: 20)"),
+      }),
+      annotations: { readOnlyHint: false },
+    },
+    async ({
+      id,
+      inputs,
+      timeoutSeconds,
+      pollIntervalSeconds,
+      logLimit,
+    }): Promise<CallToolResult> => {
+      let startedExecution: WorkflowExecution | undefined;
+      try {
+        const workflow = await client.getWorkflow(id);
+        const validation = validateWorkflowRunInputs(workflow, inputs ?? []);
+        if (validation.errors.length > 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: formatValidationErrors(workflow, validation.errors),
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const timeoutMs = Math.max(
+          0,
+          (timeoutSeconds ?? DEFAULT_WORKFLOW_WAIT_TIMEOUT_SECONDS) * 1000
+        );
+        const pollIntervalMs = Math.max(
+          0,
+          (pollIntervalSeconds ?? DEFAULT_WORKFLOW_POLL_INTERVAL_SECONDS) * 1000
+        );
+        const maxLogs = Math.max(0, logLimit ?? DEFAULT_WORKFLOW_LOG_LIMIT);
+        const waitStartedAt = Date.now();
+        const deadline = waitStartedAt + timeoutMs;
+
+        startedExecution = await client.runWorkflow(id, validation.inputs);
+        if (!startedExecution.id) {
+          throw new Error("Workflow execution did not return an execution ID");
+        }
+
+        let lastExecution = startedExecution;
+        while (true) {
+          lastExecution = await client.getWorkflowExecution(
+            id,
+            startedExecution.id
+          );
+
+          if (isCompletedState(lastExecution.state)) {
+            const elapsedMs = Date.now() - waitStartedAt;
+            const text = [
+              formatExecutionHeader(
+                "Workflow execution completed.",
+                workflow,
+                lastExecution,
+                elapsedMs
+              ),
+              "",
+              formatOutputParameters(lastExecution),
+            ].join("\n");
+            return { content: [{ type: "text", text }] };
+          }
+
+          if (isFailureState(lastExecution.state)) {
+            const elapsedMs = Date.now() - waitStartedAt;
+            const diagnostics = await collectExecutionDiagnostics(
+              client,
+              id,
+              lastExecution,
+              maxLogs
+            );
+            const text = appendDiagnostics(
+              formatExecutionHeader(
+                "Workflow execution failed.",
+                workflow,
+                diagnostics.execution,
+                elapsedMs
+              ),
+              diagnostics.execution,
+              diagnostics.logs,
+              diagnostics.warnings
+            );
+            return { content: [{ type: "text", text }], isError: true };
+          }
+
+          const remainingMs = deadline - Date.now();
+          if (remainingMs <= 0) {
+            const elapsedMs = Date.now() - waitStartedAt;
+            const diagnostics = await collectExecutionDiagnostics(
+              client,
+              id,
+              lastExecution,
+              maxLogs
+            );
+            const text = appendDiagnostics(
+              formatExecutionHeader(
+                "Workflow execution timed out while waiting.",
+                workflow,
+                diagnostics.execution,
+                elapsedMs
+              ) +
+                `\nTimeout: ${Math.round(timeoutMs / 1000)}s\nThe remote workflow was not canceled.`,
+              diagnostics.execution,
+              diagnostics.logs,
+              diagnostics.warnings
+            );
+            return { content: [{ type: "text", text }], isError: true };
+          }
+
+          await sleep(Math.min(pollIntervalMs, remainingMs));
+        }
+      } catch (error) {
+        const prefix = startedExecution?.id
+          ? `Workflow execution ${startedExecution.id} started, but the wait loop failed`
+          : "Failed to run workflow and wait";
+        return {
+          content: [
+            {
+              type: "text",
+              text: `${prefix}: ${errorMessage(error)}`,
             },
           ],
           isError: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,11 +61,28 @@ export interface WorkflowExecution {
   "start-date"?: string;
   "end-date"?: string;
   "started-by"?: string;
+  "business-state"?: string;
   "content-exception"?: string;
+  "current-item-display-name"?: string;
+  "current-item-for-display"?: string;
   "output-parameters"?: VroParameter[];
   outputParameters?: VroParameter[];
+  "execution-stack"?: WorkflowExecutionStackItem[];
+  executionStack?: WorkflowExecutionStackItem[];
+  "workflow-item"?: WorkflowExecutionStackItem[];
+  workflowItem?: WorkflowExecutionStackItem[];
   href?: string;
   name?: string;
+}
+
+export interface WorkflowExecutionStackItem {
+  name?: string;
+  displayName?: string;
+  workflowDisplayName?: string;
+  href?: string;
+  parameter?: VroParameter[];
+  attributes?: VroParameter[];
+  "workflow-attributes"?: VroParameter[];
 }
 
 export interface WorkflowExecutionList {
@@ -73,6 +90,21 @@ export interface WorkflowExecutionList {
   relations?: {
     link: WorkflowExecution[];
   };
+}
+
+export interface WorkflowExecutionLog {
+  severity?: string;
+  userName?: string;
+  user?: string;
+  origin?: string;
+  "short-description"?: string;
+  "long-description"?: string;
+  "time-stamp"?: string;
+  "time-stamp-val"?: number;
+}
+
+export interface WorkflowExecutionLogs {
+  logs?: WorkflowExecutionLog[];
 }
 
 // --- Actions ---

--- a/test/vro-client.test.mjs
+++ b/test/vro-client.test.mjs
@@ -39,6 +39,52 @@ test("bodyless 202 responses with Location return an execution id", async () => 
   assert.equal(calls.length, 2);
 });
 
+test("getWorkflowExecution can request detailed execution data", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    return Response.json({ id: "execution-1", state: "RUNNING" });
+  };
+
+  const client = new VroClient(config());
+  const execution = await client.getWorkflowExecution("workflow 1", "exec/1", {
+    showDetails: true,
+  });
+
+  assert.equal(execution.id, "execution-1");
+  assert.equal(
+    calls[1].url,
+    "https://vcfa.example.test/vco/api/workflows/workflow%201/executions/exec%2F1?showDetails=true"
+  );
+  assert.equal(calls[1].init.method, "GET");
+});
+
+test("getWorkflowExecutionLogs calls workflow execution logs endpoint", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    return Response.json({
+      logs: [{ severity: "INFO", "short-description": "hello" }],
+    });
+  };
+
+  const client = new VroClient(config());
+  const logs = await client.getWorkflowExecutionLogs(
+    "workflow-1",
+    "execution-1",
+    { maxResult: 3 }
+  );
+
+  assert.equal(logs.logs[0]["short-description"], "hello");
+  assert.equal(
+    calls[1].url,
+    "https://vcfa.example.test/vco/api/workflows/workflow-1/executions/execution-1/logs?maxResult=3"
+  );
+  assert.equal(calls[1].init.method, "GET");
+});
+
 test("createConfiguration sends singular attribute payload", async () => {
   const calls = [];
   globalThis.fetch = async (url, init) => {

--- a/test/workflow-tools.test.mjs
+++ b/test/workflow-tools.test.mjs
@@ -4,7 +4,19 @@ import {
   getExecutionOutputParameters,
   getWorkflowInputParameters,
   getWorkflowOutputParameters,
+  registerWorkflowTools,
 } from "../dist/tools/workflow-tools.js";
+
+function registeredWorkflowTools(client) {
+  const handlers = new Map();
+  const server = {
+    registerTool(name, _config, handler) {
+      handlers.set(name, handler);
+    },
+  };
+  registerWorkflowTools(server, client);
+  return handlers;
+}
 
 test("workflow parameter helpers accept camelCase response fields", () => {
   const workflow = {
@@ -34,4 +46,187 @@ test("workflow parameter helpers fall back to kebab-case response fields", () =>
   assert.deepEqual(getWorkflowInputParameters(workflow), workflow["input-parameters"]);
   assert.deepEqual(getWorkflowOutputParameters(workflow), workflow["output-parameters"]);
   assert.deepEqual(getExecutionOutputParameters(execution), execution["output-parameters"]);
+});
+
+test("run-workflow-and-wait rejects strict validation errors before running", async () => {
+  let runCalls = 0;
+  const handlers = registeredWorkflowTools({
+    getWorkflow: async () => ({
+      id: "workflow-1",
+      name: "Workflow",
+      inputParameters: [
+        { name: "projectName", type: "string" },
+        { name: "count", type: "number" },
+      ],
+    }),
+    runWorkflow: async () => {
+      runCalls += 1;
+      return { id: "execution-1", state: "running" };
+    },
+  });
+
+  const result = await handlers.get("run-workflow-and-wait")({
+    id: "workflow-1",
+    inputs: [
+      { name: "projectName", type: "string", value: 123 },
+      { name: "projectName", type: "string", value: "duplicate" },
+      { name: "extra", type: "string", value: "unused" },
+    ],
+  });
+
+  assert.equal(result.isError, true);
+  assert.equal(runCalls, 0);
+  assert.match(result.content[0].text, /Input projectName must be a string/);
+  assert.match(result.content[0].text, /Duplicate input: projectName/);
+  assert.match(result.content[0].text, /Unknown input: extra/);
+  assert.match(result.content[0].text, /Missing required input: count/);
+});
+
+test("run-workflow-and-wait fills omitted input types and returns outputs", async () => {
+  let runInputs;
+  let polls = 0;
+  const handlers = registeredWorkflowTools({
+    getWorkflow: async () => ({
+      id: "workflow-1",
+      name: "Workflow",
+      inputParameters: [{ name: "name", type: "string" }],
+    }),
+    runWorkflow: async (_id, inputs) => {
+      runInputs = inputs;
+      return { id: "execution-1", state: "running" };
+    },
+    getWorkflowExecution: async () => {
+      polls += 1;
+      if (polls === 1) {
+        return { id: "execution-1", state: "running" };
+      }
+      return {
+        id: "execution-1",
+        state: "COMPLETED",
+        outputParameters: [
+          { name: "result", type: "string", value: { string: { value: "ok" } } },
+        ],
+      };
+    },
+  });
+
+  const result = await handlers.get("run-workflow-and-wait")({
+    id: "workflow-1",
+    inputs: [{ name: "name", value: "web-server-01" }],
+    timeoutSeconds: 1,
+    pollIntervalSeconds: 0,
+  });
+
+  assert.equal(result.isError, undefined);
+  assert.deepEqual(runInputs, [
+    { name: "name", type: "string", value: "web-server-01" },
+  ]);
+  assert.match(result.content[0].text, /Workflow execution completed/);
+  assert.match(result.content[0].text, /result \(string\): "ok"/);
+});
+
+test("run-workflow-and-wait reports failure diagnostics and log excerpts", async () => {
+  const handlers = registeredWorkflowTools({
+    getWorkflow: async () => ({
+      id: "workflow-1",
+      name: "Workflow",
+      inputParameters: [],
+    }),
+    runWorkflow: async () => ({ id: "execution-1", state: "running" }),
+    getWorkflowExecution: async (_workflowId, _executionId, options) => {
+      if (options?.showDetails) {
+        return {
+          id: "execution-1",
+          state: "FAILED",
+          "content-exception": "boom",
+          "current-item-display-name": "Scriptable task",
+          "execution-stack": [
+            { name: "item1", displayName: "Validate input" },
+          ],
+        };
+      }
+      return { id: "execution-1", state: "FAILED" };
+    },
+    getWorkflowExecutionLogs: async () => ({
+      logs: [
+        {
+          severity: "ERROR",
+          "short-description": "Script failed",
+          "long-description": "Line 3: boom",
+        },
+      ],
+    }),
+  });
+
+  const result = await handlers.get("run-workflow-and-wait")({
+    id: "workflow-1",
+    timeoutSeconds: 1,
+    pollIntervalSeconds: 0,
+  });
+
+  assert.equal(result.isError, true);
+  assert.match(result.content[0].text, /Workflow execution failed/);
+  assert.match(result.content[0].text, /Error: boom/);
+  assert.match(result.content[0].text, /Current item: Scriptable task/);
+  assert.match(result.content[0].text, /Validate input/);
+  assert.match(result.content[0].text, /Script failed/);
+});
+
+test("run-workflow-and-wait times out without canceling the workflow", async () => {
+  const handlers = registeredWorkflowTools({
+    getWorkflow: async () => ({
+      id: "workflow-1",
+      name: "Workflow",
+      inputParameters: [],
+    }),
+    runWorkflow: async () => ({ id: "execution-1", state: "running" }),
+    getWorkflowExecution: async (_workflowId, _executionId, options) => ({
+      id: "execution-1",
+      state: "running",
+      ...(options?.showDetails
+        ? { "current-item-for-display": "Waiting for task" }
+        : {}),
+    }),
+    getWorkflowExecutionLogs: async () => ({ logs: [] }),
+  });
+
+  const result = await handlers.get("run-workflow-and-wait")({
+    id: "workflow-1",
+    timeoutSeconds: 0,
+    pollIntervalSeconds: 0,
+  });
+
+  assert.equal(result.isError, true);
+  assert.match(result.content[0].text, /Workflow execution timed out/);
+  assert.match(result.content[0].text, /State: running/);
+  assert.match(result.content[0].text, /The remote workflow was not canceled/);
+  assert.match(result.content[0].text, /Current item: Waiting for task/);
+});
+
+test("run-workflow-and-wait reports log fetch warnings", async () => {
+  const handlers = registeredWorkflowTools({
+    getWorkflow: async () => ({
+      id: "workflow-1",
+      name: "Workflow",
+      inputParameters: [],
+    }),
+    runWorkflow: async () => ({ id: "execution-1", state: "running" }),
+    getWorkflowExecution: async (_workflowId, _executionId, options) => ({
+      id: "execution-1",
+      state: "FAILED",
+      ...(options?.showDetails ? { "content-exception": "boom" } : {}),
+    }),
+    getWorkflowExecutionLogs: async () => {
+      throw new Error("logs unavailable");
+    },
+  });
+
+  const result = await handlers.get("run-workflow-and-wait")({
+    id: "workflow-1",
+    timeoutSeconds: 1,
+    pollIntervalSeconds: 0,
+  });
+
+  assert.equal(result.isError, true);
+  assert.match(result.content[0].text, /Unable to fetch execution logs: logs unavailable/);
 });


### PR DESCRIPTION
## Summary
- Add a new `run-workflow-and-wait` workflow tool for strict input validation, execution polling, timeout handling, and diagnostic output.
- Extend the workflow client with detailed execution reads and execution log retrieval.
- Update server instructions, README tool docs, and the repo TODO to reflect the new workflow development loop.
- Add tests for validation, success, failure, timeout, log retrieval, and the new client endpoints.

## Testing
- `npm test` passed, including the new workflow tool coverage and client endpoint tests.