### PR TITLE
Add workflow artifact scaffolding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,18 @@ npm run build
 
 Set the following environment variables (see `.env.example`):
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `VCFA_HOST` | Yes | VCFA hostname (e.g. `vcfa.example.com`) |
-| `VCFA_USERNAME` | Yes | Username without organization (e.g. `admin`) |
-| `VCFA_ORGANIZATION` | Yes | Organization/tenant (e.g. `System` or `vsphere.local`) |
-| `VCFA_PASSWORD` | Yes | Password |
-| `VCFA_IGNORE_TLS` | No | Set to `true` to skip TLS certificate verification (lab environments) |
-| `VCFA_PACKAGE_DIR` | No | Directory used for package import/export files (defaults to a temp directory) |
-| `VCFA_RESOURCE_DIR` | No | Directory used for resource element import/export files (defaults to a temp directory) |
-| `VCFA_WORKFLOW_DIR` | No | Directory used for workflow artifact import/export files (defaults to a temp directory) |
-| `VCFA_ACTION_DIR` | No | Directory used for action artifact import/export files (defaults to a temp directory) |
-| `VCFA_CONFIGURATION_DIR` | No | Directory used for configuration artifact import/export files (defaults to a temp directory) |
+| Variable                 | Required | Description                                                                                  |
+| ------------------------ | -------- | -------------------------------------------------------------------------------------------- |
+| `VCFA_HOST`              | Yes      | VCFA hostname (e.g. `vcfa.example.com`)                                                      |
+| `VCFA_USERNAME`          | Yes      | Username without organization (e.g. `admin`)                                                 |
+| `VCFA_ORGANIZATION`      | Yes      | Organization/tenant (e.g. `System` or `vsphere.local`)                                       |
+| `VCFA_PASSWORD`          | Yes      | Password                                                                                     |
+| `VCFA_IGNORE_TLS`        | No       | Set to `true` to skip TLS certificate verification (lab environments)                        |
+| `VCFA_PACKAGE_DIR`       | No       | Directory used for package import/export files (defaults to a temp directory)                |
+| `VCFA_RESOURCE_DIR`      | No       | Directory used for resource element import/export files (defaults to a temp directory)       |
+| `VCFA_WORKFLOW_DIR`      | No       | Directory used for workflow artifact import/export files (defaults to a temp directory)      |
+| `VCFA_ACTION_DIR`        | No       | Directory used for action artifact import/export files (defaults to a temp directory)        |
+| `VCFA_CONFIGURATION_DIR` | No       | Directory used for configuration artifact import/export files (defaults to a temp directory) |
 
 The server authenticates by POSTing to `https://{VCFA_HOST}/cloudapi/1.0.0/sessions` with Basic Auth as `{VCFA_USERNAME}@{VCFA_ORGANIZATION}:{VCFA_PASSWORD}` and uses the returned bearer token for all VCFA API calls.
 
@@ -114,275 +114,320 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 ### Workflows
 
-| Tool | Description |
-|------|-------------|
-| `list-workflows` | List workflows, optionally filtered by name |
-| `get-workflow` | Get workflow details including input/output parameters |
-| `create-workflow` | Create a new empty workflow in a category |
-| `delete-workflow` | Delete a workflow (irreversible) |
-| `run-workflow` | Execute a workflow with optional input parameters |
-| `run-workflow-and-wait` | Validate inputs, execute a workflow, wait for completion, and return outputs or diagnostics |
-| `list-workflow-executions` | List past and current executions for a workflow, with optional status filter |
-| `get-workflow-execution` | Check execution status and retrieve outputs |
-| `export-workflow-file` | Export a workflow artifact to a `.workflow` file under `VCFA_WORKFLOW_DIR` |
-| `scaffold-workflow-file` | Generate a local `.workflow` artifact from structured metadata and linear scriptable tasks |
-| `import-workflow-file` | Import a `.workflow` artifact from `VCFA_WORKFLOW_DIR` into a workflow category |
+| Tool                       | Description                                                                                 |
+| -------------------------- | ------------------------------------------------------------------------------------------- |
+| `list-workflows`           | List workflows, optionally filtered by name                                                 |
+| `get-workflow`             | Get workflow details including input/output parameters                                      |
+| `create-workflow`          | Create a new empty workflow in a category                                                   |
+| `delete-workflow`          | Delete a workflow (irreversible)                                                            |
+| `run-workflow`             | Execute a workflow with optional input parameters                                           |
+| `run-workflow-and-wait`    | Validate inputs, execute a workflow, wait for completion, and return outputs or diagnostics |
+| `list-workflow-executions` | List past and current executions for a workflow, with optional status filter                |
+| `get-workflow-execution`   | Check execution status and retrieve outputs                                                 |
+| `export-workflow-file`     | Export a workflow artifact to a `.workflow` file under `VCFA_WORKFLOW_DIR`                  |
+| `scaffold-workflow-file`   | Generate a local `.workflow` artifact from structured metadata and linear scriptable tasks  |
+| `import-workflow-file`     | Import a `.workflow` artifact from `VCFA_WORKFLOW_DIR` into a workflow category             |
 
 ### Actions
 
-| Tool | Description |
-|------|-------------|
-| `list-actions` | List actions (scriptable tasks), optionally filtered by name |
-| `get-action` | Get action details including script content and parameters |
-| `create-action` | Create a new action with script content |
-| `export-action-file` | Export an action artifact to a `.action` file under `VCFA_ACTION_DIR` |
+| Tool                 | Description                                                                |
+| -------------------- | -------------------------------------------------------------------------- |
+| `list-actions`       | List actions (scriptable tasks), optionally filtered by name               |
+| `get-action`         | Get action details including script content and parameters                 |
+| `create-action`      | Create a new action with script content                                    |
+| `export-action-file` | Export an action artifact to a `.action` file under `VCFA_ACTION_DIR`      |
 | `import-action-file` | Import a `.action` artifact from `VCFA_ACTION_DIR` into an action category |
-| `delete-action` | Delete an action (irreversible) |
+| `delete-action`      | Delete an action (irreversible)                                            |
 
 ### Configuration Elements
 
-| Tool | Description |
-|------|-------------|
-| `list-configurations` | List configuration elements, optionally filtered by name |
-| `get-configuration` | Get configuration element details and attributes |
-| `create-configuration` | Create a new configuration element with attributes |
-| `update-configuration` | Update a configuration element's name, description, or attributes |
-| `export-configuration-file` | Export a configuration artifact to a `.vsoconf` file under `VCFA_CONFIGURATION_DIR` |
+| Tool                        | Description                                                                              |
+| --------------------------- | ---------------------------------------------------------------------------------------- |
+| `list-configurations`       | List configuration elements, optionally filtered by name                                 |
+| `get-configuration`         | Get configuration element details and attributes                                         |
+| `create-configuration`      | Create a new configuration element with attributes                                       |
+| `update-configuration`      | Update a configuration element's name, description, or attributes                        |
+| `export-configuration-file` | Export a configuration artifact to a `.vsoconf` file under `VCFA_CONFIGURATION_DIR`      |
 | `import-configuration-file` | Import a `.vsoconf` artifact from `VCFA_CONFIGURATION_DIR` into a configuration category |
-| `delete-configuration` | Delete a configuration element (irreversible) |
+| `delete-configuration`      | Delete a configuration element (irreversible)                                            |
 
 ### Resource Elements
 
-| Tool | Description |
-|------|-------------|
-| `list-resource-elements` | List resource elements, optionally filtered by name |
-| `export-resource-element` | Export a resource element by ID to a file under `VCFA_RESOURCE_DIR` |
-| `import-resource-element` | Import a resource element file from `VCFA_RESOURCE_DIR` into a resource category |
+| Tool                      | Description                                                                                 |
+| ------------------------- | ------------------------------------------------------------------------------------------- |
+| `list-resource-elements`  | List resource elements, optionally filtered by name                                         |
+| `export-resource-element` | Export a resource element by ID to a file under `VCFA_RESOURCE_DIR`                         |
+| `import-resource-element` | Import a resource element file from `VCFA_RESOURCE_DIR` into a resource category            |
 | `update-resource-element` | Replace an existing resource element's binary content from a file under `VCFA_RESOURCE_DIR` |
-| `delete-resource-element` | Delete a resource element, optionally forcing deletion when it is referenced |
+| `delete-resource-element` | Delete a resource element, optionally forcing deletion when it is referenced                |
 
 ### Categories
 
-| Tool | Description |
-|------|-------------|
+| Tool              | Description                                                                                                               |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `list-categories` | List categories by type (`WorkflowCategory`, `ActionCategory`, `ConfigurationElementCategory`, `ResourceElementCategory`) |
 
 ### Catalog Items
 
-| Tool | Description |
-|------|-------------|
+| Tool                 | Description                                                              |
+| -------------------- | ------------------------------------------------------------------------ |
 | `list-catalog-items` | List available Service Broker catalog items, optionally searched by name |
-| `get-catalog-item` | Get catalog item details including type, source, and project assignments |
+| `get-catalog-item`   | Get catalog item details including type, source, and project assignments |
 
 ### Deployments
 
-| Tool | Description |
-|------|-------------|
-| `list-deployments` | List deployments, optionally filtered by name/keyword or project ID |
-| `get-deployment` | Get deployment details including status, project, and catalog item info |
-| `create-deployment` | Deploy a catalog item by providing its ID, a deployment name, and a project ID |
-| `delete-deployment` | Delete a deployment (irreversible) |
-| `list-deployment-actions` | List deployment-level day-2 actions available for a deployment |
-| `run-deployment-action` | Submit a deployment-level day-2 action request with optional inputs and reason |
+| Tool                      | Description                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------ |
+| `list-deployments`        | List deployments, optionally filtered by name/keyword or project ID            |
+| `get-deployment`          | Get deployment details including status, project, and catalog item info        |
+| `create-deployment`       | Deploy a catalog item by providing its ID, a deployment name, and a project ID |
+| `delete-deployment`       | Delete a deployment (irreversible)                                             |
+| `list-deployment-actions` | List deployment-level day-2 actions available for a deployment                 |
+| `run-deployment-action`   | Submit a deployment-level day-2 action request with optional inputs and reason |
 
 ### Blueprint Templates
 
-| Tool | Description |
-|------|-------------|
-| `list-templates` | List blueprint templates, optionally filtered by name/keyword or project ID |
-| `get-template` | Get template details including status, project, validity, and full YAML content |
-| `create-template` | Create a new blueprint template with optional YAML content |
-| `delete-template` | Delete a blueprint template (irreversible) |
+| Tool              | Description                                                                     |
+| ----------------- | ------------------------------------------------------------------------------- |
+| `list-templates`  | List blueprint templates, optionally filtered by name/keyword or project ID     |
+| `get-template`    | Get template details including status, project, validity, and full YAML content |
+| `create-template` | Create a new blueprint template with optional YAML content                      |
+| `delete-template` | Delete a blueprint template (irreversible)                                      |
 
 ### vRO Packages
 
-| Tool | Description |
-|------|-------------|
-| `list-packages` | List vRO packages on the Orchestrator instance, optionally filtered by name |
-| `get-package` | Get details of a specific package by its fully-qualified name |
-| `export-package` | Export a package as a ZIP file under `VCFA_PACKAGE_DIR` |
-| `import-package` | Import a package file from `VCFA_PACKAGE_DIR` into the Orchestrator instance |
+| Tool             | Description                                                                         |
+| ---------------- | ----------------------------------------------------------------------------------- |
+| `list-packages`  | List vRO packages on the Orchestrator instance, optionally filtered by name         |
+| `get-package`    | Get details of a specific package by its fully-qualified name                       |
+| `export-package` | Export a package as a ZIP file under `VCFA_PACKAGE_DIR`                             |
+| `import-package` | Import a package file from `VCFA_PACKAGE_DIR` into the Orchestrator instance        |
 | `delete-package` | Delete a package after confirmation, optionally deleting all its contained elements |
 
 ### vRO Plugins
 
-| Tool | Description |
-|------|-------------|
+| Tool           | Description                                                                      |
+| -------------- | -------------------------------------------------------------------------------- |
 | `list-plugins` | List installed plugins on the Orchestrator instance, optionally filtered by name |
 
 ### Extensibility Subscriptions
 
-| Tool | Description |
-|------|-------------|
-| `list-event-topics` | List available event topics from the Event Broker |
-| `list-subscriptions` | List extensibility subscriptions, optionally filtered by project ID |
-| `get-subscription` | Get subscription details including constraints, blocking, and priority |
+| Tool                  | Description                                                                      |
+| --------------------- | -------------------------------------------------------------------------------- |
+| `list-event-topics`   | List available event topics from the Event Broker                                |
+| `list-subscriptions`  | List extensibility subscriptions, optionally filtered by project ID              |
+| `get-subscription`    | Get subscription details including constraints, blocking, and priority           |
 | `create-subscription` | Create a new subscription linking an event topic to a vRO workflow or ABX action |
-| `update-subscription` | Update a subscription (enable/disable, re-target, change priority) |
-| `delete-subscription` | Delete a subscription |
+| `update-subscription` | Update a subscription (enable/disable, re-target, change priority)               |
+| `delete-subscription` | Delete a subscription                                                            |
 
 ## Examples
 
-These examples show natural language prompts you can use with an AI assistant connected to this MCP server.
+These examples show developer-oriented prompts you can use with an AI assistant connected to this MCP server. The interesting bit is not just one tool call; it is the assistant chaining discovery, validation, execution, diagnostics, local artifact work, and guarded changes.
 
-### Discover and run a workflow
+### Debug a workflow run without memorizing its schema
 
 ```
-User: Find workflows related to "snapshot" and show me their parameters.
+User: Find the workflow we use to resize a deployment, show me the inputs,
+      then run it for deployment dep-123 with size large and wait for the result.
 
-Assistant calls: list-workflows(filter: "snapshot")
-  → Returns matching workflows with IDs
+Assistant calls: list-workflows(filter: "resize")
+  → Finds candidate workflows and IDs
 Assistant calls: get-workflow(id: "...")
-  → Returns input/output parameters
-
-User: Run the "Create a snapshot" workflow on the VM named "web-server-01".
-
-Assistant calls: run-workflow(id: "...", inputs: [{name: "vm", type: "VC:VirtualMachine", value: "..."}])
-  → Returns execution ID
-Assistant calls: get-workflow-execution(workflowId: "...", executionId: "...")
-  → Returns state: "completed", outputs
-
-Assistant can also call: run-workflow-and-wait(id: "...", inputs: [{name: "vm", value: "..."}])
-  → Validates inputs, waits up to 5 minutes by default, and returns outputs or failure diagnostics
-```
-
-### Create a custom action
-
-```
-User: Create an action in the com.example.util module that takes a VM name
-      and returns its IP address.
-
-Assistant calls: create-action(
-  moduleName: "com.example.util",
-  name: "getVmIpAddress",
-  script: "var vm = VcPlugin.getAllVirtualMachines(null, 'xpath:name=\"' + vmName + '\"')[0]; return vm.guest.ipAddress;",
-  inputParameters: [{name: "vmName", type: "string", description: "Name of the VM"}],
-  returnType: "string"
+  → Reads required input names and vRO types
+Assistant calls: run-workflow-and-wait(
+  id: "...",
+  inputs: [
+    {name: "deploymentId", value: "dep-123"},
+    {name: "size", value: "large"}
+  ],
+  timeoutSeconds: 600,
+  logLimit: 30
 )
-  → Action created: getVmIpAddress (id: ...)
+  → Validates inputs before running, polls until completion, and returns outputs.
+    If the workflow fails, the response includes current item, stack, log excerpts,
+    and warnings when diagnostics cannot be fetched.
 ```
 
-### Set up an extensibility subscription
+### Scaffold, import, and test a workflow artifact
 
 ```
-User: I want to run a vRO workflow every time a VM is provisioned.
-      Which event topics are available for compute provisioning?
+User: Create a simple workflow artifact called Echo Message. It should take
+      message as a string and return result as a string. Save it locally,
+      import it into the Dev workflows category, and run it once.
 
-Assistant calls: list-event-topics()
-  → Shows topics including "compute.provision.post" (blockable)
-
-User: Create a subscription that triggers workflow "Post-Provision Hardening"
-      on the compute.provision.post event. Make it blocking with priority 10.
-
-Assistant calls: list-workflows(filter: "Post-Provision Hardening")
-  → Returns workflow ID
-Assistant calls: create-subscription(
-  name: "Post-Provision VM Hardening",
-  eventTopicId: "compute.provision.post",
-  runnableType: "extensibility.vro",
-  runnableId: "<workflow-id>",
-  blocking: true,
-  priority: 10
+Assistant calls: scaffold-workflow-file(
+  fileName: "echo-message.workflow",
+  workflow: {
+    name: "Echo Message",
+    inputs: [{name: "message", type: "string", description: "Text to echo"}],
+    outputs: [{name: "result", type: "string", description: "Echo result"}],
+    tasks: [{
+      displayName: "Echo",
+      script: "result = message;",
+      inBindings: [{name: "message", type: "string", source: "message"}],
+      outBindings: [{name: "result", type: "string", target: "result"}]
+    }]
+  }
 )
-  → Subscription created: Post-Provision VM Hardening (ENABLED)
-```
+  → Writes echo-message.workflow under VCFA_WORKFLOW_DIR as an importable ZIP
+    with UTF-16 workflow-content
 
-### Browse and manage blueprint templates
-
-```
-User: List all blueprint templates in the system.
-
-Assistant calls: list-templates()
-  → Lists templates with IDs, status, and project names
-
-User: Show me the YAML content of the "Ubuntu OS Provisioning" template.
-
-Assistant calls: get-template(id: "...")
-  → Returns full blueprint YAML content and metadata
-
-User: Create a new blank blueprint template called "Web Tier" in the dev project.
-
-Assistant calls: create-template(
-  name: "Web Tier",
-  projectId: "<dev-project-id>",
-  description: "Blueprint for web tier VMs"
+Assistant calls: list-categories(type: "WorkflowCategory", filter: "Dev")
+  → Finds the target workflow category ID
+Assistant calls: import-workflow-file(
+  categoryId: "<dev-workflow-category-id>",
+  fileName: "echo-message.workflow",
+  overwrite: true,
+  confirm: true
 )
-  → Template created: Web Tier (id: ...) [DRAFT]
-
-User: Delete the "linux test" template.
-
-Assistant calls: delete-template(id: "...", confirm: true)
-  → Template deleted successfully.
+  → Imports the local artifact
+Assistant calls: list-workflows(filter: "Echo Message")
+Assistant calls: run-workflow-and-wait(
+  id: "<workflow-id>",
+  inputs: [{name: "message", value: "hello"}]
+)
+  → Returns result: "hello"
 ```
 
-### List and deploy a catalog item
+### Export, review, and promote vRO artifacts safely
 
 ```
-User: What catalog items are available in the Service Broker?
+User: Export the Netbox package and the IPAM workflow before I change them.
+      Then import the updated workflow artifact from my local workflow directory.
 
-Assistant calls: list-catalog-items()
-  → Lists all catalog items with IDs and types
+Assistant calls: list-packages(filter: "netbox")
+Assistant calls: export-package(
+  name: "com.example.netbox",
+  fileName: "com.example.netbox.package",
+  overwrite: true
+)
+  → Saves the package under VCFA_PACKAGE_DIR
 
-User: Deploy "Ubuntu 22.04 Server" to project "dev-team" and name it
-      "build-agent-01".
+Assistant calls: list-workflows(filter: "IPAM")
+Assistant calls: export-workflow-file(
+  id: "<workflow-id>",
+  fileName: "ipam-before-change.workflow",
+  overwrite: true
+)
+  → Saves the current workflow under VCFA_WORKFLOW_DIR
 
+Assistant calls: import-workflow-file(
+  categoryId: "<workflow-category-id>",
+  fileName: "ipam-updated.workflow",
+  overwrite: true,
+  confirm: true
+)
+  → Uploads only after confirmation and only from VCFA_WORKFLOW_DIR
+```
+
+### Deploy from the catalog and run day-2 actions
+
+```
+User: Find the Ubuntu catalog item, deploy a medium build agent in project
+      project-dev-123, then show me the actions available after it is created.
+
+Assistant calls: list-catalog-items(search: "Ubuntu")
+  → Lists matching Service Broker catalog items
 Assistant calls: get-catalog-item(id: "...")
-  → Shows inputs required: size, diskGb
+  → Shows item metadata, source, projects, and useful context
 Assistant calls: create-deployment(
   catalogItemId: "...",
   deploymentName: "build-agent-01",
-  projectId: "<dev-team-project-id>",
+  projectId: "project-dev-123",
+  reason: "Temporary CI build agent",
   inputs: {size: "medium", diskGb: 80}
 )
-  → Deployment request submitted. ID: ... Status: CREATE_IN_PROGRESS
-
-User: Check all deployments in the dev-team project.
-
-Assistant calls: list-deployments(projectId: "<dev-team-project-id>")
-  → Lists deployments with status
-
-User: Restart my app deployment.
-
+  → Deployment request submitted
+Assistant calls: list-deployments(search: "build-agent-01", projectId: "project-dev-123")
+  → Confirms current deployment state
 Assistant calls: list-deployment-actions(deploymentId: "<deployment-id>")
-  → Lists available day-2 actions and any visible input hints
+  → Shows day-2 actions and input hints
 Assistant calls: run-deployment-action(
   deploymentId: "<deployment-id>",
-  actionId: "<restart-action-id>",
-  reason: "Restart requested by owner",
+  actionId: "<power-or-reboot-action-id>",
+  reason: "Developer requested reboot after bootstrap",
   confirm: true
 )
-  → Deployment action request submitted. ID: ... Status: INPROGRESS
+  → Submits the action only after confirmation
 ```
 
-### Manage existing subscriptions
+### Create a reusable vRO action
 
 ```
-User: Show me all extensibility subscriptions and disable the one for
-      network tagging.
+User: Create a utility action that normalizes deployment names for our
+      provisioning workflows.
+
+Assistant calls: create-action(
+  moduleName: "com.example.naming",
+  name: "normalizeDeploymentName",
+  script: "return name.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-');",
+  inputParameters: [{name: "name", type: "string", description: "Raw deployment name"}],
+  returnType: "string"
+)
+  → Creates the action in the target module
+
+User: Show me what was created.
+
+Assistant calls: list-actions(filter: "normalizeDeploymentName")
+Assistant calls: get-action(id: "<action-id>")
+  → Returns the script, inputs, module, and return type for review
+```
+
+### Review and create blueprint templates
+
+```
+User: Show me the current Ubuntu template YAML, then create a starter template
+      for a small web tier in project project-dev-123.
+
+Assistant calls: list-templates(search: "Ubuntu")
+  → Finds matching Cloud Assembly blueprint templates
+Assistant calls: get-template(id: "<ubuntu-template-id>")
+  → Returns status, project metadata, validity, and YAML content
+Assistant calls: create-template(
+  name: "Web Tier Starter",
+  projectId: "project-dev-123",
+  description: "Starter web tier blueprint for development",
+  content: "formatVersion: 1\ninputs: {}\nresources: {}"
+)
+  → Creates a draft blueprint template that can be refined in Cloud Assembly
+```
+
+### Wire a vRO workflow to an event topic
+
+```
+User: Run the workflow "Post-Provision Hardening" whenever compute provisioning
+      completes. Make it blocking if the event topic supports blocking.
+
+Assistant calls: list-event-topics()
+  → Finds the provisioning topic and whether it is blockable
+Assistant calls: list-workflows(filter: "Post-Provision Hardening")
+  → Finds the vRO workflow ID
+Assistant calls: create-subscription(
+  name: "Post-Provision Hardening",
+  eventTopicId: "<provisioning-topic-id>",
+  runnableType: "extensibility.vro",
+  runnableId: "<workflow-id>",
+  blocking: true,
+  priority: 10,
+  description: "Run hardening workflow after VM provisioning"
+)
+  → Creates an enabled subscription
+
+User: Disable that hook while I test a new version.
 
 Assistant calls: list-subscriptions()
-  → Lists all subscriptions with status
-Assistant calls: get-subscription(id: "...")
-  → Shows full details for the network tagging subscription
-Assistant calls: update-subscription(id: "...", disabled: true)
-  → Subscription updated: DISABLED
+Assistant calls: update-subscription(id: "<subscription-id>", disabled: true)
+  → Disables the subscription without deleting it
 ```
 
-### Inspect and manage configuration elements
+### Manage runtime configuration and resource files
 
 ```
-User: Find configuration elements related to "SMTP" and show me their
-      attributes.
+User: Create a Netbox configuration element and upload a logo resource used by
+      the provisioning workflows.
 
-Assistant calls: list-configurations(filter: "SMTP")
-  → Returns matching config elements
-Assistant calls: get-configuration(id: "...")
-  → Shows attributes: smtpHost (string), smtpPort (number), useTls (boolean)
-
-User: Create a new configuration element for Netbox integration settings
-      under the Library category.
-
-Assistant calls: list-categories(type: "ConfigurationElementCategory", filter: "Library")
+Assistant calls: list-categories(type: "ConfigurationElementCategory", filter: "Integrations")
   → Returns category ID
 Assistant calls: create-configuration(
   categoryId: "<category-id>",
@@ -393,57 +438,46 @@ Assistant calls: create-configuration(
     {name: "apiToken", type: "string", value: "your-token-here"}
   ]
 )
-  → Configuration element created: Netbox Settings (id: ...)
-```
+  → Creates a typed configuration element
 
-### End-to-end: build a provisioning hook
-
-```
-User: I need a complete compute provisioning hook that assigns a custom
-      hostname. Create the action, then wire it up with a subscription
-      on the compute.allocation.pre event.
-
-Assistant calls: create-action(
-  moduleName: "com.example.naming",
-  name: "generateHostname",
-  script: "var prefix = inputProperties.get('customProperties').get('prefix') || 'vm'; ...",
-  inputParameters: [{name: "inputProperties", type: "Properties"}],
-  returnType: "Properties"
+Assistant calls: list-categories(type: "ResourceElementCategory", filter: "Assets")
+Assistant calls: import-resource-element(
+  categoryId: "<resource-category-id>",
+  fileName: "portal-logo.png",
+  confirm: true
 )
-  → Action created
+  → Imports a local file from VCFA_RESOURCE_DIR
 
-Assistant calls: list-event-topics()
-  → Confirms compute.allocation.pre is available and blockable
+User: Rotate the Netbox token and replace the logo without changing workflow code.
 
-Assistant calls: create-subscription(
-  name: "Custom Hostname Generator",
-  eventTopicId: "compute.allocation.pre",
-  runnableType: "extensibility.abx",
-  runnableId: "<action-id>",
-  blocking: true,
-  priority: 5,
-  description: "Assigns custom hostnames during VM provisioning"
+Assistant calls: list-configurations(filter: "Netbox Settings")
+Assistant calls: update-configuration(
+  id: "<config-id>",
+  attributes: [
+    {name: "netboxUrl", type: "string", value: "https://netbox.example.com"},
+    {name: "apiToken", type: "string", value: "new-token"}
+  ]
 )
-  → Subscription created and ENABLED
+Assistant calls: update-resource-element(
+  id: "<resource-id>",
+  fileName: "portal-logo-v2.png",
+  confirm: true
+)
+  → Updates shared runtime data safely from local artifact directories
 ```
 
-### List installed plugins
+### Inspect platform capabilities before writing code
 
 ```
-User: What plugins are installed on the Orchestrator?
+User: Before I write a workflow that talks to NSX and vCenter, show me the
+      installed plugins and any actions that already do VM lookup.
 
 Assistant calls: list-plugins()
-  → Found 12 plugin(s):
-     • vCenter Plugin (com.vmware.library.vc) v8.0.0 — vCenter Server integration
-     • SSH Plugin (com.vmware.library.ssh) v2.0.0 — SSH remote execution
-     ...
-
-User: Show me only plugins related to NSX.
-
 Assistant calls: list-plugins(filter: "nsx")
-  → Found 2 plugin(s):
-     • NSX-T Plugin (com.vmware.library.nsx-t) v3.2.0
-     • NSX ALB Plugin (com.vmware.library.nsxalb) v1.0.0
+Assistant calls: list-actions(filter: "getAllMachines")
+Assistant calls: get-action(id: "<candidate-action-id>")
+  → Shows installed plugin coverage and reusable library action code before
+    generating or importing new workflow artifacts
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `list-workflow-executions` | List past and current executions for a workflow, with optional status filter |
 | `get-workflow-execution` | Check execution status and retrieve outputs |
 | `export-workflow-file` | Export a workflow artifact to a `.workflow` file under `VCFA_WORKFLOW_DIR` |
+| `scaffold-workflow-file` | Generate a local `.workflow` artifact from structured metadata and linear scriptable tasks |
 | `import-workflow-file` | Import a `.workflow` artifact from `VCFA_WORKFLOW_DIR` into a workflow category |
 
 ### Actions

--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,6 @@
 10. [x] Refactor vro-client.ts into separate modules
 11. [x] Add support for resource elements
 12. [x] Implement import/export for actions, config elements and resource elements
-13. [ ] Add workflow artifact authoring/scaffolding tools that generate valid `.workflow` files from structured metadata, inputs/outputs, scriptable task definitions, scripts, and bindings so automation developers do not have to hand-build UTF-16 workflow XML archives
+13. [x] Add workflow artifact authoring/scaffolding tools that generate valid `.workflow` files from structured metadata, inputs/outputs, scriptable task definitions, scripts, and bindings so automation developers do not have to hand-build UTF-16 workflow XML archives
 14. [ ] Add local artifact validation/preflight tools for `.workflow`, `.action`, `.vsoconf`, and package files that verify archive structure, encoding, parameter bindings, action references, supported vRO types, and import safety before uploading to VCFA
 15. [x] Improve workflow execution tooling with a `run-workflow-and-wait` development loop that validates inputs against `get-workflow`, polls until completion or timeout, and returns outputs plus useful failure details/log excerpts for rapid iteration

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "fflate": "^0.8.2",
         "zod": "^3.24.0"
       },
       "bin": {
@@ -952,6 +953,12 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "homepage": "https://github.com/mgovedarov/mcp-vcf-orchestrator#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "fflate": "^0.8.2",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -13,6 +13,7 @@ import type {
   DeploymentRequest,
   EventTopicList,
   ResourceElementList,
+  ScaffoldWorkflowFileParams,
   SimpleParameter,
   Subscription,
   SubscriptionList,
@@ -151,6 +152,10 @@ export class VroClient {
     overwrite = true,
   ): Promise<void> {
     return this.workflows.importWorkflowFile(categoryId, fileName, overwrite);
+  }
+
+  scaffoldWorkflowFile(params: ScaffoldWorkflowFileParams): Promise<string> {
+    return this.workflows.scaffoldWorkflowFile(params);
   }
 
   listActions(filter?: string): Promise<ActionList> {

--- a/src/client/workflow-artifact.ts
+++ b/src/client/workflow-artifact.ts
@@ -1,0 +1,372 @@
+import { zipSync } from "fflate";
+import { randomUUID } from "node:crypto";
+import type {
+  WorkflowArtifactBinding,
+  WorkflowArtifactParameter,
+  WorkflowArtifactSpec,
+  WorkflowArtifactTask,
+} from "../types.js";
+
+const DEFAULT_WORKFLOW_VERSION = "1.0.0";
+const DEFAULT_WORKFLOW_API_VERSION = "6.0.0";
+const IDENTIFIER_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+interface NormalizedWorkflowArtifactTask extends WorkflowArtifactTask {
+  name: string;
+  displayName: string;
+  description: string;
+  inBindings: WorkflowArtifactBinding[];
+  outBindings: WorkflowArtifactBinding[];
+}
+
+interface NormalizedSpec {
+  id: string;
+  name: string;
+  description: string;
+  version: string;
+  apiVersion: string;
+  inputs: WorkflowArtifactParameter[];
+  outputs: WorkflowArtifactParameter[];
+  attributes: WorkflowArtifactParameter[];
+  tasks: NormalizedWorkflowArtifactTask[];
+}
+
+export function buildWorkflowArtifact(spec: WorkflowArtifactSpec): Uint8Array {
+  const normalized = normalizeWorkflowArtifactSpec(spec);
+  return zipSync({
+    "workflow-info": utf8Bytes(buildWorkflowInfo(normalized)),
+    "workflow-content": utf16LeWithBom(renderWorkflowContentXml(normalized)),
+  });
+}
+
+export function buildWorkflowContent(spec: WorkflowArtifactSpec): Uint8Array {
+  return utf16LeWithBom(
+    renderWorkflowContentXml(normalizeWorkflowArtifactSpec(spec)),
+  );
+}
+
+export function buildWorkflowContentXml(spec: WorkflowArtifactSpec): string {
+  return renderWorkflowContentXml(normalizeWorkflowArtifactSpec(spec));
+}
+
+export function buildWorkflowInfo(spec: WorkflowArtifactSpec): string {
+  const normalized = normalizeWorkflowArtifactSpec(spec);
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    `<workflow-info id="${escapeXmlAttribute(normalized.id)}" name="${escapeXmlAttribute(
+      normalized.name,
+    )}" version="${escapeXmlAttribute(normalized.version)}" />`,
+    "",
+  ].join("\n");
+}
+
+export function normalizeWorkflowArtifactSpec(
+  spec: WorkflowArtifactSpec,
+): NormalizedSpec {
+  const errors: string[] = [];
+  const id = nonEmpty(spec.id) ?? randomUUID();
+  const name = nonEmpty(spec.name);
+  if (!name) {
+    errors.push("Workflow name is required");
+  }
+
+  const inputs = normalizeParameters(spec.inputs ?? [], "input", errors);
+  const outputs = normalizeParameters(spec.outputs ?? [], "output", errors);
+  const attributes = normalizeParameters(
+    spec.attributes ?? [],
+    "attribute",
+    errors,
+  );
+
+  validateUniqueNames(
+    "workflow parameter",
+    [...inputs, ...outputs, ...attributes],
+    errors,
+  );
+
+  const inputOrAttributeTypes = new Map<string, string>();
+  for (const parameter of [...inputs, ...attributes]) {
+    inputOrAttributeTypes.set(parameter.name, parameter.type);
+  }
+
+  const outputOrAttributeTypes = new Map<string, string>();
+  for (const parameter of [...outputs, ...attributes]) {
+    outputOrAttributeTypes.set(parameter.name, parameter.type);
+  }
+
+  if (!Array.isArray(spec.tasks) || spec.tasks.length === 0) {
+    errors.push("At least one workflow task is required");
+  }
+
+  const taskNames = new Set<string>();
+  const tasks = (spec.tasks ?? []).map((task, index) => {
+    const taskName = nonEmpty(task.name) ?? `item${index + 1}`;
+    if (taskNames.has(taskName)) {
+      errors.push(`Duplicate task name: ${taskName}`);
+    }
+    taskNames.add(taskName);
+
+    const script = task.script ?? "";
+    if (!nonEmpty(script)) {
+      errors.push(`Task ${taskName} script is required`);
+    }
+
+    const inBindings = normalizeBindings(
+      task.inBindings ?? [],
+      "input",
+      taskName,
+      inputOrAttributeTypes,
+      errors,
+    );
+    const outBindings = normalizeBindings(
+      task.outBindings ?? [],
+      "output",
+      taskName,
+      outputOrAttributeTypes,
+      errors,
+    );
+
+    return {
+      ...task,
+      name: taskName,
+      displayName: nonEmpty(task.displayName) ?? taskName,
+      description: task.description ?? "",
+      script,
+      inBindings,
+      outBindings,
+    };
+  });
+
+  if (errors.length > 0) {
+    throw new Error(`Invalid workflow artifact spec:\n${errors.join("\n")}`);
+  }
+
+  return {
+    id,
+    name: name ?? "",
+    description: spec.description ?? "",
+    version: nonEmpty(spec.version) ?? DEFAULT_WORKFLOW_VERSION,
+    apiVersion: nonEmpty(spec.apiVersion) ?? DEFAULT_WORKFLOW_API_VERSION,
+    inputs,
+    outputs,
+    attributes,
+    tasks,
+  };
+}
+
+function normalizeParameters(
+  parameters: WorkflowArtifactParameter[],
+  label: string,
+  errors: string[],
+): WorkflowArtifactParameter[] {
+  validateUniqueNames(label, parameters, errors);
+  return parameters.map((parameter, index) => {
+    const name = nonEmpty(parameter.name);
+    const type = nonEmpty(parameter.type);
+    if (!name) {
+      errors.push(`${label} parameter at index ${index} is missing a name`);
+    } else if (!IDENTIFIER_PATTERN.test(name)) {
+      errors.push(
+        `${label} parameter ${name} must be a valid script identifier`,
+      );
+    }
+    if (!type) {
+      errors.push(`${label} parameter ${name ?? index} is missing a type`);
+    }
+    return {
+      name: name ?? "",
+      type: type ?? "",
+      description: parameter.description,
+    };
+  });
+}
+
+function normalizeBindings(
+  bindings: WorkflowArtifactBinding[],
+  direction: "input" | "output",
+  taskName: string,
+  availableTypes: Map<string, string>,
+  errors: string[],
+): NormalizedWorkflowArtifactTask["inBindings"] {
+  return bindings.map((binding, index) => {
+    const bindingName = nonEmpty(binding.name);
+    const bindingType = nonEmpty(binding.type);
+    const reference = nonEmpty(
+      direction === "input" ? binding.source : binding.target,
+    );
+    const referenceLabel = direction === "input" ? "source" : "target";
+
+    if (!bindingName) {
+      errors.push(
+        `${taskName} ${direction} binding at index ${index} is missing a name`,
+      );
+    } else if (!IDENTIFIER_PATTERN.test(bindingName)) {
+      errors.push(
+        `${taskName} ${direction} binding ${bindingName} must be a valid script identifier`,
+      );
+    }
+
+    if (!bindingType) {
+      errors.push(
+        `${taskName} ${direction} binding ${bindingName ?? index} is missing a type`,
+      );
+    }
+
+    if (!reference) {
+      errors.push(
+        `${taskName} ${direction} binding ${bindingName ?? index} is missing a ${referenceLabel}`,
+      );
+    } else {
+      const declaredType = availableTypes.get(reference);
+      if (!declaredType) {
+        errors.push(
+          `${taskName} ${direction} binding ${bindingName ?? index} references unknown ${referenceLabel} ${reference}`,
+        );
+      } else if (bindingType && declaredType !== bindingType) {
+        errors.push(
+          `${taskName} ${direction} binding ${bindingName ?? index} type ${bindingType} does not match ${reference} type ${declaredType}`,
+        );
+      }
+    }
+
+    return {
+      ...binding,
+      name: bindingName ?? "",
+      type: bindingType ?? "",
+      source: direction === "input" ? (reference ?? "") : binding.source,
+      target: direction === "output" ? (reference ?? "") : binding.target,
+    };
+  });
+}
+
+function validateUniqueNames(
+  label: string,
+  values: { name?: string }[],
+  errors: string[],
+): void {
+  const seen = new Set<string>();
+  for (const value of values) {
+    const name = nonEmpty(value.name);
+    if (!name) continue;
+    if (seen.has(name)) {
+      errors.push(`Duplicate ${label} name: ${name}`);
+    }
+    seen.add(name);
+  }
+}
+
+function renderWorkflowContentXml(spec: NormalizedSpec): string {
+  const rootTaskName = spec.tasks[0]?.name ?? "item1";
+  return [
+    '<?xml version="1.0" encoding="UTF-16"?>',
+    `<workflow xmlns="http://vmware.com/vco/workflow" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://vmware.com/vco/workflow http://vmware.com/vco/workflow/Workflow-v4.xsd" root-name="${escapeXmlAttribute(rootTaskName)}" object-name="workflow:name=generic" id="${escapeXmlAttribute(spec.id)}" version="${escapeXmlAttribute(spec.version)}" api-version="${escapeXmlAttribute(spec.apiVersion)}" restartMode="1" resumeFromFailedMode="0">`,
+    `  <display-name>${cdata(spec.name)}</display-name>`,
+    `  <description>${cdata(spec.description)}</description>`,
+    renderParameterSection("input", spec.inputs),
+    renderParameterSection("output", spec.outputs),
+    renderAttributes(spec.attributes),
+    ...spec.tasks.map((task, index) =>
+      renderTask(task, spec.tasks[index + 1]?.name),
+    ),
+    "  <presentation />",
+    "  <workflow-note />",
+    "</workflow>",
+    "",
+  ].join("\n");
+}
+
+function renderParameterSection(
+  elementName: "input" | "output",
+  parameters: WorkflowArtifactParameter[],
+): string {
+  if (parameters.length === 0) {
+    return `  <${elementName} />`;
+  }
+
+  return [
+    `  <${elementName}>`,
+    ...parameters.map(
+      (parameter) =>
+        `    <param name="${escapeXmlAttribute(parameter.name)}" type="${escapeXmlAttribute(parameter.type)}"><description>${cdata(parameter.description ?? "")}</description></param>`,
+    ),
+    `  </${elementName}>`,
+  ].join("\n");
+}
+
+function renderAttributes(attributes: WorkflowArtifactParameter[]): string {
+  if (attributes.length === 0) {
+    return "  <attrib />";
+  }
+
+  return [
+    "  <attrib>",
+    ...attributes.map(
+      (attribute) =>
+        `    <param name="${escapeXmlAttribute(attribute.name)}" type="${escapeXmlAttribute(attribute.type)}" scope="local"><description>${cdata(attribute.description ?? "")}</description></param>`,
+    ),
+    "  </attrib>",
+  ].join("\n");
+}
+
+function renderTask(
+  task: NormalizedWorkflowArtifactTask,
+  nextTaskName?: string,
+): string {
+  const flowAttrs = nextTaskName
+    ? ` out-name="${escapeXmlAttribute(nextTaskName)}"`
+    : ' end-mode="1"';
+  return [
+    `  <workflow-item name="${escapeXmlAttribute(task.name)}" type="task"${flowAttrs}>`,
+    `    <display-name>${cdata(task.displayName)}</display-name>`,
+    `    <description>${cdata(task.description)}</description>`,
+    renderBindings("in-binding", task.inBindings, "source"),
+    renderBindings("out-binding", task.outBindings, "target"),
+    `    <script encoded="false">${cdata(task.script)}</script>`,
+    "  </workflow-item>",
+  ].join("\n");
+}
+
+function renderBindings(
+  elementName: "in-binding" | "out-binding",
+  bindings: WorkflowArtifactBinding[],
+  referenceKey: "source" | "target",
+): string {
+  if (bindings.length === 0) {
+    return `    <${elementName} />`;
+  }
+
+  return [
+    `    <${elementName}>`,
+    ...bindings.map((binding) => {
+      const exportName =
+        referenceKey === "source" ? binding.source : binding.target;
+      return `      <bind name="${escapeXmlAttribute(binding.name)}" type="${escapeXmlAttribute(binding.type)}" export-name="${escapeXmlAttribute(exportName ?? "")}" />`;
+    }),
+    `    </${elementName}>`,
+  ].join("\n");
+}
+
+function cdata(value: string): string {
+  return `<![CDATA[${value.replaceAll("]]>", "]]]]><![CDATA[>")}]]>`;
+}
+
+function escapeXmlAttribute(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function utf16LeWithBom(value: string): Uint8Array {
+  return new Uint8Array([0xff, 0xfe, ...Buffer.from(value, "utf16le")]);
+}
+
+function utf8Bytes(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}

--- a/src/client/workflow-client.ts
+++ b/src/client/workflow-client.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { extname } from "node:path";
 import type {
+  ScaffoldWorkflowFileParams,
   SimpleParameter,
   Workflow,
   WorkflowExecution,
@@ -16,6 +17,7 @@ import {
   rejectSymlink,
   resolveFileInDirectory,
 } from "./files.js";
+import { buildWorkflowArtifact } from "./workflow-artifact.js";
 
 export class WorkflowClient {
   constructor(private http: VroHttpClient) {}
@@ -213,6 +215,27 @@ export class WorkflowClient {
     }
     const buffer = Buffer.from(await res.arrayBuffer());
     await writeFile(destPath, buffer, { flag: overwrite ? "w" : "wx" });
+    return destPath;
+  }
+
+  async scaffoldWorkflowFile(
+    params: ScaffoldWorkflowFileParams,
+  ): Promise<string> {
+    const destPath = await this.resolveWorkflowPath(params.fileName);
+    const existingFile = await getExistingFile(destPath);
+    if (existingFile?.isSymbolicLink()) {
+      throw new Error("Workflow scaffold target must not be a symbolic link");
+    }
+    if (existingFile && !params.overwrite) {
+      throw new Error(
+        `Workflow file already exists: ${params.fileName}. Set overwrite to true to replace it.`,
+      );
+    }
+
+    const artifact = buildWorkflowArtifact(params.workflow);
+    await writeFile(destPath, artifact, {
+      flag: params.overwrite ? "w" : "wx",
+    });
     return destPath;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ async function main(): Promise<void> {
         "Use run-workflow-and-wait for rapid development loops that validate workflow inputs, wait for completion, and return outputs or diagnostics.",
         "After starting a workflow execution with run-workflow, use get-workflow-execution to poll for completion and retrieve outputs.",
         "Use export-workflow-file to save a workflow artifact under VCFA_WORKFLOW_DIR; use import-workflow-file to upload a .workflow artifact from VCFA_WORKFLOW_DIR into a workflow category.",
+        "Use scaffold-workflow-file to generate a local .workflow artifact from structured workflow metadata and linear scriptable tasks before importing it.",
         "Use export-action-file to save an action artifact under VCFA_ACTION_DIR; use import-action-file to upload a .action artifact from VCFA_ACTION_DIR into an action category by category name.",
         "Use export-configuration-file to save a configuration artifact under VCFA_CONFIGURATION_DIR; use import-configuration-file to upload a .vsoconf artifact from VCFA_CONFIGURATION_DIR into a configuration category.",
         "Use list-event-topics to discover available event topics before creating extensibility subscriptions.",

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -932,6 +932,134 @@ export function registerWorkflowTools(
   );
 
   server.registerTool(
+    "scaffold-workflow-file",
+    {
+      title: "Scaffold Workflow File",
+      description:
+        "Generate a local importable .workflow artifact under VCFA_WORKFLOW_DIR from structured metadata, linear scriptable tasks, scripts, and bindings. Use import-workflow-file to upload it afterwards.",
+      inputSchema: z.object({
+        fileName: z
+          .string()
+          .describe("Workflow file name to save under VCFA_WORKFLOW_DIR"),
+        overwrite: z
+          .boolean()
+          .optional()
+          .describe("Overwrite the file if it already exists (default: false)"),
+        workflow: z.object({
+          id: z
+            .string()
+            .optional()
+            .describe("Optional workflow ID. Defaults to a generated UUID."),
+          name: z.string().describe("Workflow display name"),
+          description: z.string().optional().describe("Workflow description"),
+          version: z
+            .string()
+            .optional()
+            .describe("Workflow version (default: 1.0.0)"),
+          apiVersion: z
+            .string()
+            .optional()
+            .describe("Workflow API version (default: 6.0.0)"),
+          inputs: z
+            .array(
+              z.object({
+                name: z.string().describe("Workflow input parameter name"),
+                type: z.string().describe("vRO parameter type"),
+                description: z.string().optional(),
+              }),
+            )
+            .optional(),
+          outputs: z
+            .array(
+              z.object({
+                name: z.string().describe("Workflow output parameter name"),
+                type: z.string().describe("vRO parameter type"),
+                description: z.string().optional(),
+              }),
+            )
+            .optional(),
+          attributes: z
+            .array(
+              z.object({
+                name: z.string().describe("Workflow attribute name"),
+                type: z.string().describe("vRO parameter type"),
+                description: z.string().optional(),
+              }),
+            )
+            .optional(),
+          tasks: z
+            .array(
+              z.object({
+                name: z
+                  .string()
+                  .optional()
+                  .describe("Internal workflow item name. Defaults to itemN."),
+                displayName: z
+                  .string()
+                  .optional()
+                  .describe("Task display name"),
+                description: z.string().optional(),
+                script: z.string().describe("Scriptable task JavaScript body"),
+                inBindings: z
+                  .array(
+                    z.object({
+                      name: z.string().describe("Script variable name"),
+                      type: z.string().describe("vRO parameter type"),
+                      source: z
+                        .string()
+                        .describe("Workflow input or attribute name"),
+                    }),
+                  )
+                  .optional(),
+                outBindings: z
+                  .array(
+                    z.object({
+                      name: z.string().describe("Script variable name"),
+                      type: z.string().describe("vRO parameter type"),
+                      target: z
+                        .string()
+                        .describe("Workflow output or attribute name"),
+                    }),
+                  )
+                  .optional(),
+              }),
+            )
+            .min(1)
+            .describe("Linear sequence of scriptable tasks"),
+        }),
+      }),
+      annotations: { readOnlyHint: false },
+    },
+    async ({ fileName, overwrite, workflow }): Promise<CallToolResult> => {
+      try {
+        const savedPath = await client.scaffoldWorkflowFile({
+          fileName,
+          overwrite: overwrite ?? false,
+          workflow,
+        });
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Workflow scaffold generated successfully at: ${savedPath}\nUse import-workflow-file to upload it into a workflow category.`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to scaffold workflow file: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
     "delete-workflow",
     {
       title: "Delete Workflow",

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,46 @@ export interface WorkflowList {
   link: Workflow[];
 }
 
+export interface WorkflowArtifactParameter {
+  name: string;
+  type: string;
+  description?: string;
+}
+
+export interface WorkflowArtifactBinding {
+  name: string;
+  type: string;
+  source?: string;
+  target?: string;
+}
+
+export interface WorkflowArtifactTask {
+  name?: string;
+  displayName?: string;
+  description?: string;
+  script: string;
+  inBindings?: WorkflowArtifactBinding[];
+  outBindings?: WorkflowArtifactBinding[];
+}
+
+export interface WorkflowArtifactSpec {
+  id?: string;
+  name: string;
+  description?: string;
+  version?: string;
+  apiVersion?: string;
+  inputs?: WorkflowArtifactParameter[];
+  outputs?: WorkflowArtifactParameter[];
+  attributes?: WorkflowArtifactParameter[];
+  tasks: WorkflowArtifactTask[];
+}
+
+export interface ScaffoldWorkflowFileParams {
+  fileName: string;
+  overwrite?: boolean;
+  workflow: WorkflowArtifactSpec;
+}
+
 export interface WorkflowExecutionState {
   value: string; // "running" | "completed" | "failed" | "canceled" | "waiting"
 }

--- a/test/workflow-artifact.test.mjs
+++ b/test/workflow-artifact.test.mjs
@@ -1,0 +1,213 @@
+import { unzipSync } from "fflate";
+import assert from "node:assert/strict";
+import {
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  buildWorkflowArtifact,
+  buildWorkflowContent,
+  buildWorkflowContentXml,
+} from "../dist/client/workflow-artifact.js";
+import { VroClient } from "../dist/vro-client.js";
+
+const config = (overrides = {}) => ({
+  host: "vcfa.example.test",
+  username: "admin",
+  organization: "org",
+  password: "secret",
+  ...overrides,
+});
+
+const workflow = {
+  id: "workflow-1",
+  name: "Provision <VM>",
+  description: "Builds & returns a VM",
+  inputs: [{ name: "projectName", type: "string", description: "Project" }],
+  outputs: [{ name: "vmCount", type: "number", description: "Count" }],
+  attributes: [{ name: "runningTotal", type: "number" }],
+  tasks: [
+    {
+      displayName: "Find project",
+      script: 'System.log("lookup ]]> safely");\nrunningTotal = 1;',
+      inBindings: [
+        { name: "projectName", type: "string", source: "projectName" },
+      ],
+      outBindings: [
+        { name: "runningTotal", type: "number", target: "runningTotal" },
+      ],
+    },
+    {
+      name: "finish",
+      displayName: "Return count",
+      script: "vmCount = runningTotal;",
+      inBindings: [
+        { name: "runningTotal", type: "number", source: "runningTotal" },
+      ],
+      outBindings: [{ name: "vmCount", type: "number", target: "vmCount" }],
+    },
+  ],
+};
+
+test("buildWorkflowContent creates UTF-16LE workflow XML with metadata and bindings", () => {
+  const content = buildWorkflowContent(workflow);
+  assert.equal(content[0], 0xff);
+  assert.equal(content[1], 0xfe);
+
+  const xml = new TextDecoder("utf-16le").decode(content);
+  assert.match(xml, /<workflow /);
+  assert.match(xml, /id="workflow-1"/);
+  assert.match(xml, /version="1\.0\.0"/);
+  assert.match(xml, /api-version="6\.0\.0"/);
+  assert.match(
+    xml,
+    /<display-name><!\[CDATA\[Provision <VM>\]\]><\/display-name>/,
+  );
+  assert.match(xml, /<param name="projectName" type="string">/);
+  assert.match(xml, /<param name="vmCount" type="number">/);
+  assert.match(xml, /<param name="runningTotal" type="number" scope="local">/);
+  assert.match(
+    xml,
+    /<workflow-item name="item1" type="task" out-name="finish">/,
+  );
+  assert.match(xml, /<workflow-item name="finish" type="task" end-mode="1">/);
+  assert.match(
+    xml,
+    /<bind name="projectName" type="string" export-name="projectName" \/>/,
+  );
+  assert.match(xml, /System\.log\("lookup \]\]\]\]><!\[CDATA\[> safely"\);/);
+});
+
+test("buildWorkflowArtifact creates a .workflow zip with required entries", () => {
+  const archive = buildWorkflowArtifact(workflow);
+  const files = unzipSync(archive);
+
+  assert.ok(files["workflow-info"]);
+  assert.ok(files["workflow-content"]);
+
+  const info = new TextDecoder().decode(files["workflow-info"]);
+  assert.match(info, /workflow-info id="workflow-1"/);
+
+  const content = files["workflow-content"];
+  assert.equal(content[0], 0xff);
+  assert.equal(content[1], 0xfe);
+  const xml = new TextDecoder("utf-16le").decode(content);
+  assert.match(xml, /<script encoded="false"><!\[CDATA\[/);
+});
+
+test("buildWorkflowArtifact reuses generated workflow ID across archive entries", () => {
+  const archive = buildWorkflowArtifact({ ...workflow, id: undefined });
+  const files = unzipSync(archive);
+  const info = new TextDecoder().decode(files["workflow-info"]);
+  const xml = new TextDecoder("utf-16le").decode(files["workflow-content"]);
+
+  const infoId = info.match(/id="([^"]+)"/)?.[1];
+  const contentId = xml.match(/ id="([^"]+)"/)?.[1];
+
+  assert.ok(infoId);
+  assert.equal(contentId, infoId);
+});
+
+test("workflow artifact builder rejects structural validation errors", () => {
+  assert.throws(
+    () =>
+      buildWorkflowContentXml({
+        name: "Invalid",
+        inputs: [{ name: "bad-name", type: "string" }],
+        outputs: [{ name: "result", type: "number" }],
+        tasks: [
+          {
+            script: "result = value;",
+            inBindings: [
+              { name: "value", type: "number", source: "missingInput" },
+            ],
+            outBindings: [{ name: "result", type: "string", target: "result" }],
+          },
+        ],
+      }),
+    /bad-name must be a valid script identifier[\s\S]*unknown source missingInput[\s\S]*type string does not match result type number/,
+  );
+});
+
+test("scaffoldWorkflowFile writes artifacts safely under workflow directory", async () => {
+  const workflowDir = await mkdtemp(join(tmpdir(), "vcfa-scaffold-workflows-"));
+
+  try {
+    const client = new VroClient(config({ workflowDir }));
+    const savedPath = await client.scaffoldWorkflowFile({
+      fileName: "generated.workflow",
+      workflow,
+    });
+
+    assert.equal(
+      savedPath,
+      join(await realpath(workflowDir), "generated.workflow"),
+    );
+    const files = unzipSync(new Uint8Array(await readFile(savedPath)));
+    assert.ok(files["workflow-content"]);
+
+    await assert.rejects(
+      () =>
+        client.scaffoldWorkflowFile({
+          fileName: "generated.workflow",
+          workflow,
+        }),
+      /already exists/,
+    );
+
+    await client.scaffoldWorkflowFile({
+      fileName: "generated.workflow",
+      overwrite: true,
+      workflow: { ...workflow, description: "replacement" },
+    });
+  } finally {
+    await rm(workflowDir, { recursive: true, force: true });
+  }
+});
+
+test("scaffoldWorkflowFile rejects unsafe target paths and symlink targets", async () => {
+  const workflowDir = await mkdtemp(join(tmpdir(), "vcfa-scaffold-workflows-"));
+  const outsideFile = join(tmpdir(), `outside-${Date.now()}.workflow`);
+  await writeFile(outsideFile, "outside");
+  await symlink(outsideFile, join(workflowDir, "linked.workflow"));
+
+  try {
+    const client = new VroClient(config({ workflowDir }));
+
+    await assert.rejects(
+      () =>
+        client.scaffoldWorkflowFile({
+          fileName: "../generated.workflow",
+          workflow,
+        }),
+      /must not contain path separators/,
+    );
+    await assert.rejects(
+      () =>
+        client.scaffoldWorkflowFile({
+          fileName: "generated.txt",
+          workflow,
+        }),
+      /must end with \.workflow/,
+    );
+    await assert.rejects(
+      () =>
+        client.scaffoldWorkflowFile({
+          fileName: "linked.workflow",
+          overwrite: true,
+          workflow,
+        }),
+      /must not be a symbolic link/,
+    );
+  } finally {
+    await rm(workflowDir, { recursive: true, force: true });
+    await rm(outsideFile, { force: true });
+  }
+});

--- a/test/workflow-tools.test.mjs
+++ b/test/workflow-tools.test.mjs
@@ -250,3 +250,67 @@ test("run-workflow-and-wait reports log fetch warnings", async () => {
     /Unable to fetch execution logs: logs unavailable/,
   );
 });
+
+test("scaffold-workflow-file returns saved path", async () => {
+  let scaffoldParams;
+  const handlers = registeredWorkflowTools({
+    scaffoldWorkflowFile: async (params) => {
+      scaffoldParams = params;
+      return "/tmp/workflows/generated.workflow";
+    },
+  });
+
+  const result = await handlers.get("scaffold-workflow-file")({
+    fileName: "generated.workflow",
+    workflow: {
+      name: "Generated Workflow",
+      inputs: [{ name: "message", type: "string" }],
+      outputs: [{ name: "result", type: "string" }],
+      tasks: [
+        {
+          script: "result = message;",
+          inBindings: [{ name: "message", type: "string", source: "message" }],
+          outBindings: [{ name: "result", type: "string", target: "result" }],
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(scaffoldParams, {
+    fileName: "generated.workflow",
+    overwrite: false,
+    workflow: {
+      name: "Generated Workflow",
+      inputs: [{ name: "message", type: "string" }],
+      outputs: [{ name: "result", type: "string" }],
+      tasks: [
+        {
+          script: "result = message;",
+          inBindings: [{ name: "message", type: "string", source: "message" }],
+          outBindings: [{ name: "result", type: "string", target: "result" }],
+        },
+      ],
+    },
+  });
+  assert.match(result.content[0].text, /generated.workflow/);
+  assert.match(result.content[0].text, /import-workflow-file/);
+});
+
+test("scaffold-workflow-file surfaces validation errors", async () => {
+  const handlers = registeredWorkflowTools({
+    scaffoldWorkflowFile: async () => {
+      throw new Error("Invalid workflow artifact spec: missing binding");
+    },
+  });
+
+  const result = await handlers.get("scaffold-workflow-file")({
+    fileName: "generated.workflow",
+    workflow: {
+      name: "Generated Workflow",
+      tasks: [{ script: "System.log('hello');" }],
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.match(result.content[0].text, /missing binding/);
+});


### PR DESCRIPTION
## Summary
- Add a local workflow artifact builder that generates importable `.workflow` ZIPs from structured metadata, inputs, outputs, tasks, and bindings
- Wire the new scaffolding flow through `VroClient`, workflow tools, and server instructions so generated artifacts stay under `VCFA_WORKFLOW_DIR`
- Update docs, TODO status, and add coverage for XML/ZIP generation, validation, and file-safety behavior

## Testing
- Added unit tests for workflow artifact generation and validation
- Added workflow tool tests for the new scaffold command
- Ran TypeScript build, full test suite, coverage, and diff whitespace checks