### PR TITLE
Add local artifact preflight validation for workflow, action, config, and package imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `get-workflow-execution`   | Check execution status and retrieve outputs                                                 |
 | `export-workflow-file`     | Export a workflow artifact to a `.workflow` file under `VCFA_WORKFLOW_DIR`                  |
 | `scaffold-workflow-file`   | Generate a local `.workflow` artifact from structured metadata and linear scriptable tasks  |
+| `preflight-workflow-file`  | Validate a local `.workflow` artifact before import                                        |
 | `import-workflow-file`     | Import a `.workflow` artifact from `VCFA_WORKFLOW_DIR` into a workflow category             |
 
 ### Actions
@@ -136,6 +137,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `get-action`         | Get action details including script content and parameters                 |
 | `create-action`      | Create a new action with script content                                    |
 | `export-action-file` | Export an action artifact to a `.action` file under `VCFA_ACTION_DIR`      |
+| `preflight-action-file` | Validate a local `.action` artifact before import                       |
 | `import-action-file` | Import a `.action` artifact from `VCFA_ACTION_DIR` into an action category |
 | `delete-action`      | Delete an action (irreversible)                                            |
 
@@ -148,6 +150,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `create-configuration`      | Create a new configuration element with attributes                                       |
 | `update-configuration`      | Update a configuration element's name, description, or attributes                        |
 | `export-configuration-file` | Export a configuration artifact to a `.vsoconf` file under `VCFA_CONFIGURATION_DIR`      |
+| `preflight-configuration-file` | Validate a local `.vsoconf` artifact before import                                  |
 | `import-configuration-file` | Import a `.vsoconf` artifact from `VCFA_CONFIGURATION_DIR` into a configuration category |
 | `delete-configuration`      | Delete a configuration element (irreversible)                                            |
 
@@ -201,6 +204,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `list-packages`  | List vRO packages on the Orchestrator instance, optionally filtered by name         |
 | `get-package`    | Get details of a specific package by its fully-qualified name                       |
 | `export-package` | Export a package as a ZIP file under `VCFA_PACKAGE_DIR`                             |
+| `preflight-package` | Validate a local `.package` or `.zip` artifact before import                    |
 | `import-package` | Import a package file from `VCFA_PACKAGE_DIR` into the Orchestrator instance        |
 | `delete-package` | Delete a package after confirmation, optionally deleting all its contained elements |
 
@@ -319,6 +323,18 @@ Assistant calls: import-workflow-file(
   confirm: true
 )
   → Uploads only after confirmation and only from VCFA_WORKFLOW_DIR
+```
+
+### Preflight local artifacts before upload
+
+```
+User: Validate the updated IPAM workflow artifact before importing it.
+
+Assistant calls: preflight-workflow-file(
+  fileName: "ipam-updated.workflow"
+)
+  → Checks the archive structure, UTF-16 workflow XML, parameters, bindings,
+    task flow, vRO type syntax, and local import safety before any upload.
 ```
 
 ### Deploy from the catalog and run day-2 actions

--- a/TODO.md
+++ b/TODO.md
@@ -13,5 +13,5 @@
 11. [x] Add support for resource elements
 12. [x] Implement import/export for actions, config elements and resource elements
 13. [x] Add workflow artifact authoring/scaffolding tools that generate valid `.workflow` files from structured metadata, inputs/outputs, scriptable task definitions, scripts, and bindings so automation developers do not have to hand-build UTF-16 workflow XML archives
-14. [ ] Add local artifact validation/preflight tools for `.workflow`, `.action`, `.vsoconf`, and package files that verify archive structure, encoding, parameter bindings, action references, supported vRO types, and import safety before uploading to VCFA
+14. [x] Add local artifact validation/preflight tools for `.workflow`, `.action`, `.vsoconf`, and package files that verify archive structure, encoding, parameter bindings, action references, supported vRO types, and import safety before uploading to VCFA
 15. [x] Improve workflow execution tooling with a `run-workflow-and-wait` development loop that validates inputs against `get-workflow`, polls until completion or timeout, and returns outputs plus useful failure details/log excerpts for rapid iteration

--- a/docs/vro-artifact-authoring.md
+++ b/docs/vro-artifact-authoring.md
@@ -47,10 +47,14 @@ The MCP tools implemented for this are:
 
 - `export-workflow-file`
 - `import-workflow-file`
+- `preflight-workflow-file`
 - `export-action-file`
 - `import-action-file`
+- `preflight-action-file`
 - `export-configuration-file`
 - `import-configuration-file`
+- `preflight-configuration-file`
+- `preflight-package`
 
 They read/write files only under their configured artifact directories:
 
@@ -162,13 +166,23 @@ Fast local checks:
 npm test
 ```
 
+Before uploading local artifacts, run the matching preflight tool:
+
+- `preflight-workflow-file` checks `.workflow` ZIP structure, `workflow-info`, UTF-16 `workflow-content`, parameters, bindings, task flow, vRO type syntax, action references, and local import path safety.
+- `preflight-action-file` checks `.action` ZIP/path safety and parses recognizable XML metadata conservatively.
+- `preflight-configuration-file` checks `.vsoconf` ZIP/path safety and parses recognizable XML metadata conservatively.
+- `preflight-package` checks `.package`/`.zip` import safety and inspects nested `.workflow`, `.action`, and `.vsoconf` artifacts when they are present.
+
+The import tools run the same preflight checks and fail locally before authentication or multipart upload when blocking errors are found.
+
 Useful live MCP sequence:
 
-1. `import-workflow-file` with `categoryId`, `fileName`, `overwrite: true`, `confirm: true`.
-2. `list-workflows` filtered by workflow name.
-3. `get-workflow` to verify inputs/outputs.
-4. `run-workflow` with inputs.
-5. `get-workflow-execution` to poll status and inspect outputs/errors.
+1. `preflight-workflow-file` with `fileName`.
+2. `import-workflow-file` with `categoryId`, `fileName`, `overwrite: true`, `confirm: true`.
+3. `list-workflows` filtered by workflow name.
+4. `get-workflow` to verify inputs/outputs.
+5. `run-workflow` with inputs.
+6. `get-workflow-execution` to poll status and inspect outputs/errors.
 
 For this repository, set `VCFA_WORKFLOW_DIR` to the directory containing generated `.workflow` files before importing.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "fast-xml-parser": "^5.7.2",
         "fflate": "^0.8.2",
         "zod": "^3.24.0"
       },
@@ -519,6 +520,18 @@
         }
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
@@ -954,6 +967,42 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -1332,6 +1381,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -1605,6 +1669,18 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "homepage": "https://github.com/mgovedarov/mcp-vcf-orchestrator#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "fast-xml-parser": "^5.7.2",
     "fflate": "^0.8.2",
     "zod": "^3.24.0"
   },

--- a/src/client/action-client.ts
+++ b/src/client/action-client.ts
@@ -2,6 +2,11 @@ import { readFile, writeFile } from "node:fs/promises";
 import { extname } from "node:path";
 import type { Action, ActionList } from "../types.js";
 import { getLinkAttrs, type AttributeLink } from "./attrs.js";
+import {
+  ensurePreflightPassed,
+  preflightActionFile,
+  type ArtifactPreflightReport,
+} from "./artifact-preflight.js";
 import type { VroHttpClient } from "./core.js";
 import {
   assertRealPathInside,
@@ -100,6 +105,10 @@ export class ActionClient {
     return this.http.actionDir;
   }
 
+  preflightActionFile(fileName: string): Promise<ArtifactPreflightReport> {
+    return preflightActionFile(this.http.actionDir, fileName);
+  }
+
   private async resolveActionPath(fileName: string): Promise<string> {
     const ext = extname(fileName).toLowerCase();
     if (ext !== ".action") {
@@ -164,6 +173,7 @@ export class ActionClient {
     categoryName: string,
     fileName: string,
   ): Promise<void> {
+    ensurePreflightPassed(await this.preflightActionFile(fileName));
     const srcPath = await this.resolveActionPath(fileName);
     await rejectSymlink(
       srcPath,

--- a/src/client/artifact-preflight.ts
+++ b/src/client/artifact-preflight.ts
@@ -1,0 +1,877 @@
+import { unzipSync } from "fflate";
+import { XMLParser, XMLValidator } from "fast-xml-parser";
+import { readFile } from "node:fs/promises";
+import { extname, posix } from "node:path";
+import {
+  assertRealPathInside,
+  rejectSymlink,
+  resolveFileInDirectory,
+} from "./files.js";
+
+const IDENTIFIER_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+const TYPE_PATTERN =
+  /^(Array\/)?([A-Za-z_$][A-Za-z0-9_.$]*|[A-Za-z][A-Za-z0-9_]*:[A-Za-z_$][A-Za-z0-9_.$]*|void)$/;
+const ACTION_REFERENCE_PATTERN =
+  /System\.getModule\(\s*["']([^"']+)["']\s*\)\.([A-Za-z_$][A-Za-z0-9_$]*)\s*\(/g;
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: "",
+  allowBooleanAttributes: true,
+  cdataPropName: "#text",
+  parseAttributeValue: false,
+  parseTagValue: false,
+  trimValues: false,
+});
+
+export type ArtifactKind =
+  | "workflow"
+  | "action"
+  | "configuration"
+  | "package";
+
+export interface ArtifactPreflightEntry {
+  name: string;
+  size: number;
+}
+
+export interface ArtifactPreflightParameter {
+  name: string;
+  type: string;
+  scope: string;
+}
+
+export interface ArtifactActionReference {
+  module: string;
+  action: string;
+  expression: string;
+}
+
+export interface ArtifactPreflightReport {
+  kind: ArtifactKind;
+  fileName: string;
+  filePath?: string;
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+  metadata: Record<string, string | number | boolean>;
+  entries: ArtifactPreflightEntry[];
+  parameters: ArtifactPreflightParameter[];
+  actionReferences: ArtifactActionReference[];
+}
+
+type XmlObject = Record<string, unknown>;
+
+interface WorkflowModel {
+  root: XmlObject;
+}
+
+export async function preflightWorkflowFile(
+  rootDir: string,
+  fileName: string,
+): Promise<ArtifactPreflightReport> {
+  return preflightLocalArchive(rootDir, fileName, {
+    kind: "workflow",
+    label: "Workflow",
+    envName: "VCFA_WORKFLOW_DIR",
+    extensions: [".workflow"],
+    validateArchive: validateWorkflowArchive,
+  });
+}
+
+export async function preflightActionFile(
+  rootDir: string,
+  fileName: string,
+): Promise<ArtifactPreflightReport> {
+  return preflightLocalArchive(rootDir, fileName, {
+    kind: "action",
+    label: "Action",
+    envName: "VCFA_ACTION_DIR",
+    extensions: [".action"],
+    validateArchive: validateGenericXmlArchive,
+  });
+}
+
+export async function preflightConfigurationFile(
+  rootDir: string,
+  fileName: string,
+): Promise<ArtifactPreflightReport> {
+  return preflightLocalArchive(rootDir, fileName, {
+    kind: "configuration",
+    label: "Configuration",
+    envName: "VCFA_CONFIGURATION_DIR",
+    extensions: [".vsoconf"],
+    validateArchive: validateGenericXmlArchive,
+  });
+}
+
+export async function preflightPackageFile(
+  rootDir: string,
+  fileName: string,
+): Promise<ArtifactPreflightReport> {
+  return preflightLocalArchive(rootDir, fileName, {
+    kind: "package",
+    label: "Package",
+    envName: "VCFA_PACKAGE_DIR",
+    extensions: [".package", ".zip"],
+    validateArchive: validatePackageArchive,
+  });
+}
+
+export function ensurePreflightPassed(report: ArtifactPreflightReport): void {
+  if (report.valid) return;
+  throw new Error(formatPreflightFailure(report));
+}
+
+export function formatPreflightFailure(
+  report: ArtifactPreflightReport,
+): string {
+  return [
+    `${title(report.kind)} artifact preflight failed for ${report.fileName}.`,
+    "",
+    ...report.errors.map((error) => `• ${error}`),
+  ].join("\n");
+}
+
+export function formatPreflightReport(report: ArtifactPreflightReport): string {
+  const lines = [
+    `${title(report.kind)} artifact preflight ${report.valid ? "passed" : "failed"} for ${report.fileName}.`,
+  ];
+  if (report.filePath) lines.push(`Path: ${report.filePath}`);
+  lines.push(`Archive entries: ${report.entries.length}`);
+
+  const metadata = Object.entries(report.metadata);
+  if (metadata.length > 0) {
+    lines.push("");
+    lines.push("Metadata:");
+    for (const [key, value] of metadata) {
+      lines.push(`  • ${key}: ${String(value)}`);
+    }
+  }
+
+  if (report.parameters.length > 0) {
+    lines.push("");
+    lines.push("Parameters:");
+    for (const parameter of report.parameters) {
+      lines.push(
+        `  • ${parameter.name} (${parameter.type}) [${parameter.scope}]`,
+      );
+    }
+  }
+
+  if (report.actionReferences.length > 0) {
+    lines.push("");
+    lines.push("Action References:");
+    for (const reference of report.actionReferences) {
+      lines.push(`  • ${reference.module}/${reference.action}`);
+    }
+  }
+
+  if (report.errors.length > 0) {
+    lines.push("");
+    lines.push("Errors:");
+    lines.push(...report.errors.map((error) => `  • ${error}`));
+  }
+
+  if (report.warnings.length > 0) {
+    lines.push("");
+    lines.push("Warnings:");
+    lines.push(...report.warnings.map((warning) => `  • ${warning}`));
+  }
+
+  return lines.join("\n");
+}
+
+async function preflightLocalArchive(
+  rootDir: string,
+  fileName: string,
+  options: {
+    kind: ArtifactKind;
+    label: string;
+    envName: string;
+    extensions: string[];
+    validateArchive: (
+      files: Record<string, Uint8Array>,
+      report: ArtifactPreflightReport,
+    ) => void;
+  },
+): Promise<ArtifactPreflightReport> {
+  const report = newReport(options.kind, fileName);
+  try {
+    const ext = extname(fileName).toLowerCase();
+    if (!options.extensions.includes(ext)) {
+      throw new Error(
+        `${options.label} file name must end with ${options.extensions.join(" or ")}`,
+      );
+    }
+
+    const filePath = await resolveFileInDirectory(
+      rootDir,
+      fileName,
+      options.label,
+      options.envName,
+    );
+    report.filePath = filePath;
+    await rejectSymlink(
+      filePath,
+      `${options.label} preflight source must not be a symbolic link`,
+    );
+    await assertRealPathInside(
+      rootDir,
+      filePath,
+      `${options.label} file path resolves outside ${options.envName}`,
+    );
+
+    const buffer = new Uint8Array(await readFile(filePath));
+    validateArchiveBuffer(buffer, report, options.validateArchive);
+  } catch (error) {
+    report.errors.push(errorMessage(error));
+  }
+
+  report.valid = report.errors.length === 0;
+  return report;
+}
+
+function validateArchiveBuffer(
+  buffer: Uint8Array,
+  report: ArtifactPreflightReport,
+  validateArchive: (
+    files: Record<string, Uint8Array>,
+    report: ArtifactPreflightReport,
+  ) => void,
+): void {
+  if (buffer.byteLength === 0) {
+    report.errors.push("Artifact file is empty");
+    return;
+  }
+
+  let files: Record<string, Uint8Array>;
+  try {
+    files = unzipSync(buffer);
+  } catch (error) {
+    report.errors.push(`Artifact is not a valid ZIP archive: ${errorMessage(error)}`);
+    return;
+  }
+
+  for (const [name, content] of Object.entries(files)) {
+    report.entries.push({ name, size: content.byteLength });
+    validateZipEntryName(name, report);
+  }
+
+  if (report.entries.length === 0) {
+    report.errors.push("Archive does not contain any entries");
+    return;
+  }
+
+  validateArchive(files, report);
+}
+
+function validateWorkflowArchive(
+  files: Record<string, Uint8Array>,
+  report: ArtifactPreflightReport,
+): void {
+  const info = files["workflow-info"];
+  const content = files["workflow-content"];
+  if (!info) report.errors.push("Missing required workflow-info entry");
+  if (!content) report.errors.push("Missing required workflow-content entry");
+  if (!info || !content) return;
+
+  const infoXml = decodeUtf8Xml(info, "workflow-info", report);
+  if (infoXml) {
+    const parsed = parseXml(infoXml, "workflow-info", report);
+    const workflowInfo = getObject(parsed, "workflow-info");
+    if (workflowInfo) {
+      copyMetadata(workflowInfo, report, ["id", "name", "version"]);
+    } else {
+      report.errors.push("workflow-info does not contain a workflow-info root");
+    }
+  }
+
+  const contentXml = decodeUtf16XmlWithBom(content, "workflow-content", report);
+  if (!contentXml) return;
+
+  const model = parseWorkflowContent(contentXml, report);
+  if (!model) return;
+
+  validateWorkflowModel(model, report);
+}
+
+function validateGenericXmlArchive(
+  files: Record<string, Uint8Array>,
+  report: ArtifactPreflightReport,
+): void {
+  let parsedXmlEntries = 0;
+  for (const [name, content] of Object.entries(files)) {
+    const xml = decodeLikelyXml(content);
+    if (!xml) continue;
+
+    const parsed = parseXml(xml, name, report);
+    if (!parsed) continue;
+
+    parsedXmlEntries += 1;
+    collectGenericMetadata(parsed, report);
+    collectGenericParameters(parsed, report);
+    collectActionReferencesFromUnknown(parsed, report);
+  }
+
+  if (parsedXmlEntries === 0) {
+    report.warnings.push(
+      "No parseable XML entries were recognized; archive structure is not documented, so only ZIP/import safety was validated",
+    );
+  }
+}
+
+function validatePackageArchive(
+  files: Record<string, Uint8Array>,
+  report: ArtifactPreflightReport,
+): void {
+  let nestedArtifacts = 0;
+  const counts = {
+    workflows: 0,
+    actions: 0,
+    configurations: 0,
+  };
+
+  for (const [name, content] of Object.entries(files)) {
+    const lowerName = name.toLowerCase();
+    const nested = newReport(nestedKind(lowerName), name);
+    if (lowerName.endsWith(".workflow")) {
+      nestedArtifacts += 1;
+      counts.workflows += 1;
+      validateArchiveBuffer(content, nested, validateWorkflowArchive);
+    } else if (lowerName.endsWith(".action")) {
+      nestedArtifacts += 1;
+      counts.actions += 1;
+      validateArchiveBuffer(content, nested, validateGenericXmlArchive);
+    } else if (lowerName.endsWith(".vsoconf")) {
+      nestedArtifacts += 1;
+      counts.configurations += 1;
+      validateArchiveBuffer(content, nested, validateGenericXmlArchive);
+    } else {
+      continue;
+    }
+
+    report.parameters.push(...nested.parameters);
+    report.actionReferences.push(...nested.actionReferences);
+    report.errors.push(
+      ...nested.errors.map((error) => `${name}: ${error}`),
+    );
+    report.warnings.push(
+      ...nested.warnings.map((warning) => `${name}: ${warning}`),
+    );
+  }
+
+  report.metadata.workflowArtifacts = counts.workflows;
+  report.metadata.actionArtifacts = counts.actions;
+  report.metadata.configurationArtifacts = counts.configurations;
+
+  if (nestedArtifacts === 0) {
+    report.warnings.push(
+      "No nested .workflow, .action, or .vsoconf entries were recognized; only package ZIP/import safety was validated",
+    );
+  }
+}
+
+function parseWorkflowContent(
+  xml: string,
+  report: ArtifactPreflightReport,
+): WorkflowModel | null {
+  const parsed = parseXml(xml, "workflow-content", report);
+  const root = getObject(parsed, "workflow");
+  if (!root) {
+    report.errors.push("workflow-content does not contain a workflow root");
+    return null;
+  }
+
+  copyMetadata(root, report, [
+    "id",
+    "version",
+    "api-version",
+    "root-name",
+    "object-name",
+  ]);
+
+  return { root };
+}
+
+function validateWorkflowModel(
+  model: WorkflowModel,
+  report: ArtifactPreflightReport,
+): void {
+  const rootName = stringValue(model.root["root-name"]);
+  const inputs = collectWorkflowParams(model.root, "input");
+  const outputs = collectWorkflowParams(model.root, "output");
+  const attributes = collectWorkflowParams(model.root, "attrib");
+  const inputOrAttributeTypes = new Map<string, string>();
+  const outputOrAttributeTypes = new Map<string, string>();
+
+  validateParameterList("input", inputs, report);
+  validateParameterList("output", outputs, report);
+  validateParameterList("attribute", attributes, report);
+  validateUniqueParameters("workflow parameter", [
+    ...inputs,
+    ...outputs,
+    ...attributes,
+  ], report);
+
+  for (const parameter of [...inputs, ...attributes]) {
+    inputOrAttributeTypes.set(parameter.name, parameter.type);
+  }
+  for (const parameter of [...outputs, ...attributes]) {
+    outputOrAttributeTypes.set(parameter.name, parameter.type);
+  }
+
+  report.parameters.push(...inputs, ...outputs, ...attributes);
+
+  const items = getWorkflowItems(model.root);
+  if (items.length === 0) {
+    report.errors.push("workflow-content does not contain any workflow-item entries");
+    return;
+  }
+
+  const itemNames = new Set<string>();
+  for (const item of items) {
+    const name = stringValue(item.name);
+    if (!name) {
+      report.errors.push("Workflow item is missing a name");
+    } else if (itemNames.has(name)) {
+      report.errors.push(`Duplicate workflow item name: ${name}`);
+    } else {
+      itemNames.add(name);
+    }
+  }
+
+  if (rootName && !itemNames.has(rootName)) {
+    report.errors.push(`Workflow root-name references unknown item ${rootName}`);
+  }
+
+  for (const item of items) {
+    validateWorkflowItemFlow(item, itemNames, report);
+    if (stringValue(item.type) === "task") {
+      const script = getScriptText(item);
+      if (!script.trim()) {
+        report.errors.push(
+          `Task ${stringValue(item.name) || "(unnamed)"} is missing script content`,
+        );
+      }
+      collectActionReferences(script, report);
+    }
+    validateBindings(
+      item,
+      "in-binding",
+      "source",
+      inputOrAttributeTypes,
+      report,
+    );
+    validateBindings(
+      item,
+      "out-binding",
+      "target",
+      outputOrAttributeTypes,
+      report,
+    );
+  }
+}
+
+function validateWorkflowItemFlow(
+  item: XmlObject,
+  itemNames: Set<string>,
+  report: ArtifactPreflightReport,
+): void {
+  const itemName = stringValue(item.name) || "(unnamed)";
+  for (const attr of ["out-name", "alt-out-name", "catch-name"]) {
+    const target = stringValue(item[attr]);
+    if (target && !itemNames.has(target)) {
+      report.errors.push(`${itemName} ${attr} references unknown item ${target}`);
+    }
+  }
+}
+
+function validateBindings(
+  item: XmlObject,
+  elementName: "in-binding" | "out-binding",
+  referenceLabel: "source" | "target",
+  availableTypes: Map<string, string>,
+  report: ArtifactPreflightReport,
+): void {
+  const itemName = stringValue(item.name) || "(unnamed)";
+  for (const binding of getBindings(item, elementName)) {
+    const bindingName = stringValue(binding.name);
+    const bindingType = stringValue(binding.type);
+    const exportName = stringValue(binding["export-name"]);
+
+    if (!bindingName) {
+      report.errors.push(`${itemName} ${elementName} bind is missing a name`);
+    } else if (!IDENTIFIER_PATTERN.test(bindingName)) {
+      report.errors.push(
+        `${itemName} ${elementName} bind ${bindingName} must be a valid script identifier`,
+      );
+    }
+
+    if (!bindingType) {
+      report.errors.push(
+        `${itemName} ${elementName} bind ${bindingName || "(unnamed)"} is missing a type`,
+      );
+    } else {
+      validateType(bindingType, `${itemName} ${elementName} bind ${bindingName}`, report);
+    }
+
+    if (!exportName) {
+      report.errors.push(
+        `${itemName} ${elementName} bind ${bindingName || "(unnamed)"} is missing an export-name`,
+      );
+      continue;
+    }
+
+    const declaredType = availableTypes.get(exportName);
+    if (!declaredType) {
+      report.errors.push(
+        `${itemName} ${elementName} bind ${bindingName || "(unnamed)"} references unknown ${referenceLabel} ${exportName}`,
+      );
+    } else if (bindingType && declaredType !== bindingType) {
+      report.errors.push(
+        `${itemName} ${elementName} bind ${bindingName || "(unnamed)"} type ${bindingType} does not match ${exportName} type ${declaredType}`,
+      );
+    }
+  }
+}
+
+function collectWorkflowParams(
+  root: XmlObject,
+  sectionName: "input" | "output" | "attrib",
+): ArtifactPreflightParameter[] {
+  const section = getObject(root, sectionName);
+  if (!section) return [];
+  return asArray(section.param)
+    .filter(isObject)
+    .map((param) => ({
+      name: stringValue(param.name),
+      type: stringValue(param.type),
+      scope: sectionName === "attrib" ? "attribute" : sectionName,
+    }));
+}
+
+function collectGenericParameters(
+  value: unknown,
+  report: ArtifactPreflightReport,
+): void {
+  walkXml(value, (node) => {
+    const name = stringValue(node.name);
+    const type = stringValue(node.type);
+    if (!name || !type) return;
+
+    const scope =
+      stringValue(node.scope) ||
+      (node["encrypt-value"] !== undefined ? "parameter" : "metadata");
+    const parameter = { name, type, scope };
+    report.parameters.push(parameter);
+    validateParameter(parameter, report);
+  });
+}
+
+function collectGenericMetadata(
+  value: unknown,
+  report: ArtifactPreflightReport,
+): void {
+  walkXml(value, (node) => {
+    for (const key of ["id", "name", "module", "fqn", "version", "output-type"]) {
+      if (report.metadata[key] === undefined) {
+        const value = stringValue(node[key]);
+        if (value) report.metadata[key] = value;
+      }
+    }
+  });
+}
+
+function collectActionReferencesFromUnknown(
+  value: unknown,
+  report: ArtifactPreflightReport,
+): void {
+  walkXml(value, (node) => {
+    const script = textValue(node.script) || textValue(node["#text"]);
+    if (script) collectActionReferences(script, report);
+  });
+}
+
+function collectActionReferences(
+  script: string,
+  report: ArtifactPreflightReport,
+): void {
+  for (const match of script.matchAll(ACTION_REFERENCE_PATTERN)) {
+    const module = match[1] ?? "";
+    const action = match[2] ?? "";
+    const expression = match[0] ?? "";
+    report.actionReferences.push({ module, action, expression });
+    report.warnings.push(
+      `Action reference ${module}/${action} was found; local preflight cannot prove it exists on the target vRO instance`,
+    );
+  }
+}
+
+function validateParameterList(
+  label: string,
+  parameters: ArtifactPreflightParameter[],
+  report: ArtifactPreflightReport,
+): void {
+  validateUniqueParameters(label, parameters, report);
+  for (const parameter of parameters) {
+    validateParameter(parameter, report);
+  }
+}
+
+function validateParameter(
+  parameter: ArtifactPreflightParameter,
+  report: ArtifactPreflightReport,
+): void {
+  if (!parameter.name) {
+    report.errors.push(`${parameter.scope} parameter is missing a name`);
+  } else if (!IDENTIFIER_PATTERN.test(parameter.name)) {
+    report.errors.push(
+      `${parameter.scope} parameter ${parameter.name} must be a valid script identifier`,
+    );
+  }
+
+  if (!parameter.type) {
+    report.errors.push(`${parameter.scope} parameter ${parameter.name || "(unnamed)"} is missing a type`);
+  } else {
+    validateType(
+      parameter.type,
+      `${parameter.scope} parameter ${parameter.name}`,
+      report,
+    );
+  }
+}
+
+function validateUniqueParameters(
+  label: string,
+  parameters: ArtifactPreflightParameter[],
+  report: ArtifactPreflightReport,
+): void {
+  const seen = new Set<string>();
+  for (const parameter of parameters) {
+    if (!parameter.name) continue;
+    if (seen.has(parameter.name)) {
+      report.errors.push(`Duplicate ${label} name: ${parameter.name}`);
+    }
+    seen.add(parameter.name);
+  }
+}
+
+function validateType(
+  type: string,
+  label: string,
+  report: ArtifactPreflightReport,
+): void {
+  if (!TYPE_PATTERN.test(type)) {
+    report.errors.push(`${label} uses unsupported or invalid vRO type ${type}`);
+  }
+}
+
+function getWorkflowItems(root: XmlObject): XmlObject[] {
+  return asArray(root["workflow-item"]).filter(isObject);
+}
+
+function getBindings(
+  item: XmlObject,
+  sectionName: "in-binding" | "out-binding",
+): XmlObject[] {
+  const section = getObject(item, sectionName);
+  if (!section) return [];
+  return asArray(section.bind).filter(isObject);
+}
+
+function getScriptText(item: XmlObject): string {
+  const script = item.script;
+  if (typeof script === "string") return script;
+  if (isObject(script)) return textValue(script["#text"]);
+  return "";
+}
+
+function decodeUtf8Xml(
+  content: Uint8Array,
+  entryName: string,
+  report: ArtifactPreflightReport,
+): string | null {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(content);
+  } catch (error) {
+    report.errors.push(`${entryName} is not valid UTF-8 XML: ${errorMessage(error)}`);
+    return null;
+  }
+}
+
+function decodeUtf16XmlWithBom(
+  content: Uint8Array,
+  entryName: string,
+  report: ArtifactPreflightReport,
+): string | null {
+  if (content.length < 2) {
+    report.errors.push(`${entryName} is empty`);
+    return null;
+  }
+  const littleEndian = content[0] === 0xff && content[1] === 0xfe;
+  const bigEndian = content[0] === 0xfe && content[1] === 0xff;
+  if (!littleEndian && !bigEndian) {
+    report.errors.push(`${entryName} must be UTF-16 XML with a BOM`);
+    return null;
+  }
+
+  const encoding = littleEndian ? "utf-16le" : "utf-16be";
+  try {
+    return new TextDecoder(encoding).decode(content);
+  } catch (error) {
+    report.errors.push(`${entryName} is not valid ${encoding} XML: ${errorMessage(error)}`);
+    return null;
+  }
+}
+
+function decodeLikelyXml(content: Uint8Array): string | null {
+  if (content.length === 0) return null;
+  const xml = content[0] === 0xff && content[1] === 0xfe
+    ? new TextDecoder("utf-16le").decode(content)
+    : content[0] === 0xfe && content[1] === 0xff
+      ? new TextDecoder("utf-16be").decode(content)
+      : new TextDecoder("utf-8").decode(content);
+  return xml.trimStart().startsWith("<") ? xml : null;
+}
+
+function parseXml(
+  xml: string,
+  entryName: string,
+  report: ArtifactPreflightReport,
+): XmlObject | null {
+  const normalizedXml = xml.replace(/^\uFEFF/, "");
+  const validation = XMLValidator.validate(normalizedXml, {
+    allowBooleanAttributes: true,
+  });
+  if (validation !== true) {
+    report.errors.push(
+      `${entryName} is not well-formed XML: ${validation.err.msg} at line ${validation.err.line}, column ${validation.err.col}`,
+    );
+    return null;
+  }
+
+  try {
+    const parsed = parser.parse(normalizedXml);
+    return isObject(parsed) ? parsed : null;
+  } catch (error) {
+    report.errors.push(`${entryName} is not parseable XML: ${errorMessage(error)}`);
+    return null;
+  }
+}
+
+function validateZipEntryName(
+  name: string,
+  report: ArtifactPreflightReport,
+): void {
+  if (!name || name.includes("\0")) {
+    report.errors.push("Archive contains an empty or invalid entry name");
+    return;
+  }
+  if (name.includes("\\")) {
+    report.errors.push(`Archive entry ${name} uses backslashes`);
+  }
+  if (name.startsWith("/") || /^[A-Za-z]:/.test(name)) {
+    report.errors.push(`Archive entry ${name} is absolute`);
+  }
+  const normalized = posix.normalize(name);
+  if (
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    normalized.includes("/../")
+  ) {
+    report.errors.push(`Archive entry ${name} escapes the archive root`);
+  }
+}
+
+function copyMetadata(
+  source: XmlObject,
+  report: ArtifactPreflightReport,
+  keys: string[],
+): void {
+  for (const key of keys) {
+    const value = stringValue(source[key]);
+    if (value) report.metadata[key] = value;
+  }
+}
+
+function walkXml(value: unknown, visitor: (node: XmlObject) => void): void {
+  if (Array.isArray(value)) {
+    for (const item of value) walkXml(item, visitor);
+    return;
+  }
+  if (!isObject(value)) return;
+  visitor(value);
+  for (const child of Object.values(value)) {
+    walkXml(child, visitor);
+  }
+}
+
+function newReport(
+  kind: ArtifactKind,
+  fileName: string,
+): ArtifactPreflightReport {
+  return {
+    kind,
+    fileName,
+    valid: false,
+    errors: [],
+    warnings: [],
+    metadata: {},
+    entries: [],
+    parameters: [],
+    actionReferences: [],
+  };
+}
+
+function nestedKind(name: string): ArtifactKind {
+  if (name.endsWith(".workflow")) return "workflow";
+  if (name.endsWith(".action")) return "action";
+  if (name.endsWith(".vsoconf")) return "configuration";
+  return "package";
+}
+
+function getObject(value: unknown, key: string): XmlObject | null {
+  if (!isObject(value)) return null;
+  const child = value[key];
+  return isObject(child) ? child : null;
+}
+
+function asArray(value: unknown): unknown[] {
+  if (value === undefined || value === null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function isObject(value: unknown): value is XmlObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
+}
+
+function textValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(textValue).join("");
+  }
+  if (isObject(value)) {
+    return textValue(value["#text"]);
+  }
+  return "";
+}
+
+function title(kind: ArtifactKind): string {
+  return kind[0]?.toUpperCase() + kind.slice(1);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/client/configuration-client.ts
+++ b/src/client/configuration-client.ts
@@ -2,6 +2,11 @@ import { readFile, writeFile } from "node:fs/promises";
 import { extname } from "node:path";
 import type { ConfigElement, ConfigElementList } from "../types.js";
 import { parseAttrs } from "./attrs.js";
+import {
+  ensurePreflightPassed,
+  preflightConfigurationFile,
+  type ArtifactPreflightReport,
+} from "./artifact-preflight.js";
 import type { VroHttpClient } from "./core.js";
 import {
   assertRealPathInside,
@@ -48,6 +53,12 @@ export class ConfigurationClient {
 
   getConfigurationDirectory(): string {
     return this.http.configurationDir;
+  }
+
+  preflightConfigurationFile(
+    fileName: string,
+  ): Promise<ArtifactPreflightReport> {
+    return preflightConfigurationFile(this.http.configurationDir, fileName);
   }
 
   private async resolveConfigurationPath(fileName: string): Promise<string> {
@@ -116,6 +127,7 @@ export class ConfigurationClient {
     categoryId: string,
     fileName: string,
   ): Promise<void> {
+    ensurePreflightPassed(await this.preflightConfigurationFile(fileName));
     const srcPath = await this.resolveConfigurationPath(fileName);
     await rejectSymlink(
       srcPath,

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -29,6 +29,7 @@ import type {
   WorkflowExecutionLogs,
   WorkflowList,
 } from "../types.js";
+import type { ArtifactPreflightReport } from "./artifact-preflight.js";
 import { ActionClient } from "./action-client.js";
 import { CatalogClient } from "./catalog-client.js";
 import { CategoryClient } from "./category-client.js";
@@ -158,6 +159,10 @@ export class VroClient {
     return this.workflows.scaffoldWorkflowFile(params);
   }
 
+  preflightWorkflowFile(fileName: string): Promise<ArtifactPreflightReport> {
+    return this.workflows.preflightWorkflowFile(fileName);
+  }
+
   listActions(filter?: string): Promise<ActionList> {
     return this.actions.listActions(filter);
   }
@@ -180,6 +185,10 @@ export class VroClient {
 
   importActionFile(categoryName: string, fileName: string): Promise<void> {
     return this.actions.importActionFile(categoryName, fileName);
+  }
+
+  preflightActionFile(fileName: string): Promise<ArtifactPreflightReport> {
+    return this.actions.preflightActionFile(fileName);
   }
 
   createAction(params: {
@@ -218,6 +227,12 @@ export class VroClient {
 
   importConfigurationFile(categoryId: string, fileName: string): Promise<void> {
     return this.configurations.importConfigurationFile(categoryId, fileName);
+  }
+
+  preflightConfigurationFile(
+    fileName: string,
+  ): Promise<ArtifactPreflightReport> {
+    return this.configurations.preflightConfigurationFile(fileName);
   }
 
   createConfiguration(
@@ -390,6 +405,10 @@ export class VroClient {
 
   importPackage(fileName: string, overwrite = true): Promise<void> {
     return this.packages.importPackage(fileName, overwrite);
+  }
+
+  preflightPackageFile(fileName: string): Promise<ArtifactPreflightReport> {
+    return this.packages.preflightPackageFile(fileName);
   }
 
   deletePackage(name: string, deleteContents = false): Promise<void> {

--- a/src/client/package-client.ts
+++ b/src/client/package-client.ts
@@ -2,6 +2,11 @@ import { readFile, writeFile } from "node:fs/promises";
 import { extname } from "node:path";
 import type { VroPackage, VroPackageList } from "../types.js";
 import { parseAttrs } from "./attrs.js";
+import {
+  ensurePreflightPassed,
+  preflightPackageFile,
+  type ArtifactPreflightReport,
+} from "./artifact-preflight.js";
 import type { VroHttpClient } from "./core.js";
 import {
   assertRealPathInside,
@@ -47,6 +52,10 @@ export class PackageClient {
 
   getPackageDirectory(): string {
     return this.http.packageDir;
+  }
+
+  preflightPackageFile(fileName: string): Promise<ArtifactPreflightReport> {
+    return preflightPackageFile(this.http.packageDir, fileName);
   }
 
   private async resolvePackagePath(fileName: string): Promise<string> {
@@ -108,6 +117,7 @@ export class PackageClient {
   }
 
   async importPackage(fileName: string, overwrite = true): Promise<void> {
+    ensurePreflightPassed(await this.preflightPackageFile(fileName));
     const srcPath = await this.resolvePackagePath(fileName);
     await rejectSymlink(
       srcPath,

--- a/src/client/workflow-client.ts
+++ b/src/client/workflow-client.ts
@@ -12,6 +12,11 @@ import type {
 import { parseAttrs } from "./attrs.js";
 import type { VroHttpClient } from "./core.js";
 import {
+  ensurePreflightPassed,
+  preflightWorkflowFile,
+  type ArtifactPreflightReport,
+} from "./artifact-preflight.js";
+import {
   assertRealPathInside,
   getExistingFile,
   rejectSymlink,
@@ -158,6 +163,10 @@ export class WorkflowClient {
     return this.http.workflowDir;
   }
 
+  preflightWorkflowFile(fileName: string): Promise<ArtifactPreflightReport> {
+    return preflightWorkflowFile(this.http.workflowDir, fileName);
+  }
+
   private async resolveWorkflowPath(fileName: string): Promise<string> {
     const ext = extname(fileName).toLowerCase();
     if (ext !== ".workflow") {
@@ -244,6 +253,7 @@ export class WorkflowClient {
     fileName: string,
     overwrite = true,
   ): Promise<void> {
+    ensurePreflightPassed(await this.preflightWorkflowFile(fileName));
     const srcPath = await this.resolveWorkflowPath(fileName);
     await rejectSymlink(
       srcPath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ async function main(): Promise<void> {
         "After starting a workflow execution with run-workflow, use get-workflow-execution to poll for completion and retrieve outputs.",
         "Use export-workflow-file to save a workflow artifact under VCFA_WORKFLOW_DIR; use import-workflow-file to upload a .workflow artifact from VCFA_WORKFLOW_DIR into a workflow category.",
         "Use scaffold-workflow-file to generate a local .workflow artifact from structured workflow metadata and linear scriptable tasks before importing it.",
+        "Use preflight-workflow-file, preflight-action-file, preflight-configuration-file, and preflight-package to validate local artifacts before importing them.",
         "Use export-action-file to save an action artifact under VCFA_ACTION_DIR; use import-action-file to upload a .action artifact from VCFA_ACTION_DIR into an action category by category name.",
         "Use export-configuration-file to save a configuration artifact under VCFA_CONFIGURATION_DIR; use import-configuration-file to upload a .vsoconf artifact from VCFA_CONFIGURATION_DIR into a configuration category.",
         "Use list-event-topics to discover available event topics before creating extensibility subscriptions.",

--- a/src/tools/action-tools.ts
+++ b/src/tools/action-tools.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
+import { formatPreflightReport } from "../client/artifact-preflight.js";
 import type { VroClient } from "../vro-client.js";
 
 export function registerActionTools(
@@ -220,6 +221,40 @@ export function registerActionTools(
             {
               type: "text",
               text: `Failed to export action file: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "preflight-action-file",
+    {
+      title: "Preflight Action File",
+      description:
+        "Validate a local .action artifact under VCFA_ACTION_DIR before importing it.",
+      inputSchema: z.object({
+        fileName: z
+          .string()
+          .describe("Action file name under VCFA_ACTION_DIR to validate"),
+      }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ fileName }): Promise<CallToolResult> => {
+      try {
+        const report = await client.preflightActionFile(fileName);
+        return {
+          content: [{ type: "text", text: formatPreflightReport(report) }],
+          isError: !report.valid,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to preflight action file: ${error instanceof Error ? error.message : String(error)}`,
             },
           ],
           isError: true,

--- a/src/tools/config-tools.ts
+++ b/src/tools/config-tools.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
+import { formatPreflightReport } from "../client/artifact-preflight.js";
 import type { VroClient } from "../vro-client.js";
 
 export function registerConfigTools(
@@ -262,6 +263,42 @@ export function registerConfigTools(
             {
               type: "text",
               text: `Failed to export configuration file: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "preflight-configuration-file",
+    {
+      title: "Preflight Configuration File",
+      description:
+        "Validate a local .vsoconf artifact under VCFA_CONFIGURATION_DIR before importing it.",
+      inputSchema: z.object({
+        fileName: z
+          .string()
+          .describe(
+            "Configuration file name under VCFA_CONFIGURATION_DIR to validate",
+          ),
+      }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ fileName }): Promise<CallToolResult> => {
+      try {
+        const report = await client.preflightConfigurationFile(fileName);
+        return {
+          content: [{ type: "text", text: formatPreflightReport(report) }],
+          isError: !report.valid,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to preflight configuration file: ${error instanceof Error ? error.message : String(error)}`,
             },
           ],
           isError: true,

--- a/src/tools/package-tools.ts
+++ b/src/tools/package-tools.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
+import { formatPreflightReport } from "../client/artifact-preflight.js";
 import type { VroClient } from "../vro-client.js";
 
 export function registerPackageTools(
@@ -139,6 +140,40 @@ export function registerPackageTools(
             {
               type: "text",
               text: `Failed to export package: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "preflight-package",
+    {
+      title: "Preflight vRO Package",
+      description:
+        "Validate a local .package or .zip artifact under VCFA_PACKAGE_DIR before importing it.",
+      inputSchema: z.object({
+        fileName: z
+          .string()
+          .describe("Package file name under VCFA_PACKAGE_DIR to validate"),
+      }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ fileName }): Promise<CallToolResult> => {
+      try {
+        const report = await client.preflightPackageFile(fileName);
+        return {
+          content: [{ type: "text", text: formatPreflightReport(report) }],
+          isError: !report.valid,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to preflight package: ${error instanceof Error ? error.message : String(error)}`,
             },
           ],
           isError: true,

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -9,6 +9,7 @@ import type {
   WorkflowExecutionLog,
   WorkflowExecutionStackItem,
 } from "../types.js";
+import { formatPreflightReport } from "../client/artifact-preflight.js";
 import type { VroClient } from "../vro-client.js";
 
 const DEFAULT_WORKFLOW_WAIT_TIMEOUT_SECONDS = 300;
@@ -852,6 +853,40 @@ export function registerWorkflowTools(
             {
               type: "text",
               text: `Failed to export workflow file: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "preflight-workflow-file",
+    {
+      title: "Preflight Workflow File",
+      description:
+        "Validate a local .workflow artifact under VCFA_WORKFLOW_DIR before importing it.",
+      inputSchema: z.object({
+        fileName: z
+          .string()
+          .describe("Workflow file name under VCFA_WORKFLOW_DIR to validate"),
+      }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ fileName }): Promise<CallToolResult> => {
+      try {
+        const report = await client.preflightWorkflowFile(fileName);
+        return {
+          content: [{ type: "text", text: formatPreflightReport(report) }],
+          isError: !report.valid,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to preflight workflow file: ${error instanceof Error ? error.message : String(error)}`,
             },
           ],
           isError: true,

--- a/test/artifact-preflight.test.mjs
+++ b/test/artifact-preflight.test.mjs
@@ -1,0 +1,266 @@
+import { zipSync } from "fflate";
+import assert from "node:assert/strict";
+import {
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  preflightPackageFile,
+  preflightWorkflowFile,
+} from "../dist/client/artifact-preflight.js";
+import { buildWorkflowArtifact } from "../dist/client/workflow-artifact.js";
+import { VroClient } from "../dist/vro-client.js";
+
+const config = (overrides = {}) => ({
+  host: "vcfa.example.test",
+  username: "admin",
+  organization: "org",
+  password: "secret",
+  ...overrides,
+});
+
+const workflow = {
+  id: "workflow-1",
+  name: "Generated Workflow",
+  inputs: [{ name: "message", type: "string" }],
+  outputs: [{ name: "result", type: "string" }],
+  tasks: [
+    {
+      script: 'result = System.getModule("com.example.actions").echo(message);',
+      inBindings: [{ name: "message", type: "string", source: "message" }],
+      outBindings: [{ name: "result", type: "string", target: "result" }],
+    },
+  ],
+};
+
+test("preflightWorkflowFile accepts generated workflow artifacts and reports action references", async () => {
+  const workflowDir = await mkdtemp(join(tmpdir(), "vcfa-preflight-"));
+  await writeFile(
+    join(workflowDir, "generated.workflow"),
+    buildWorkflowArtifact(workflow),
+  );
+
+  try {
+    const report = await preflightWorkflowFile(
+      workflowDir,
+      "generated.workflow",
+    );
+
+    assert.equal(report.valid, true);
+    assert.equal(report.errors.length, 0);
+    assert.match(report.metadata.name, /Generated Workflow/);
+    assert.deepEqual(report.parameters, [
+      { name: "message", type: "string", scope: "input" },
+      { name: "result", type: "string", scope: "output" },
+    ]);
+    assert.deepEqual(report.actionReferences, [
+      {
+        module: "com.example.actions",
+        action: "echo",
+        expression: 'System.getModule("com.example.actions").echo(',
+      },
+    ]);
+    assert.match(report.warnings[0], /cannot prove it exists/);
+  } finally {
+    await rm(workflowDir, { recursive: true, force: true });
+  }
+});
+
+test("preflightWorkflowFile reports malformed ZIPs, missing entries, and bad encoding", async () => {
+  const workflowDir = await mkdtemp(join(tmpdir(), "vcfa-preflight-"));
+  await writeFile(join(workflowDir, "bad.workflow"), "not a zip");
+  await writeFile(
+    join(workflowDir, "missing.workflow"),
+    zipSync({
+      "workflow-info": new TextEncoder().encode(
+        '<workflow-info id="workflow-1" name="Missing" />',
+      ),
+    }),
+  );
+  await writeFile(
+    join(workflowDir, "utf8.workflow"),
+    zipSync({
+      "workflow-info": new TextEncoder().encode(
+        '<workflow-info id="workflow-1" name="UTF8" />',
+      ),
+      "workflow-content": new TextEncoder().encode("<workflow />"),
+    }),
+  );
+  const malformedXml = [
+    '<?xml version="1.0" encoding="UTF-16"?>',
+    '<workflow root-name="item1">',
+    "  <input />",
+    "  <output />",
+    "  <attrib />",
+    '  <workflow-item name="item1" type="task" end-mode="1">',
+    "    <in-binding />",
+    "    <out-binding />",
+    "    <script>System.log('bad');</scriptx>",
+    "  </workflow-item>",
+    "</workflow>",
+  ].join("\n");
+  await writeFile(
+    join(workflowDir, "malformed.workflow"),
+    zipSync({
+      "workflow-info": new TextEncoder().encode(
+        '<workflow-info id="workflow-1" name="Malformed" />',
+      ),
+      "workflow-content": utf16LeWithBom(malformedXml),
+    }),
+  );
+
+  try {
+    const bad = await preflightWorkflowFile(workflowDir, "bad.workflow");
+    assert.equal(bad.valid, false);
+    assert.match(bad.errors.join("\n"), /valid ZIP archive/);
+
+    const missing = await preflightWorkflowFile(
+      workflowDir,
+      "missing.workflow",
+    );
+    assert.equal(missing.valid, false);
+    assert.match(missing.errors.join("\n"), /Missing required workflow-content/);
+
+    const utf8 = await preflightWorkflowFile(workflowDir, "utf8.workflow");
+    assert.equal(utf8.valid, false);
+    assert.match(utf8.errors.join("\n"), /UTF-16 XML with a BOM/);
+
+    const malformed = await preflightWorkflowFile(
+      workflowDir,
+      "malformed.workflow",
+    );
+    assert.equal(malformed.valid, false);
+    assert.match(malformed.errors.join("\n"), /not well-formed XML/);
+    assert.match(malformed.errors.join("\n"), /scriptx/);
+  } finally {
+    await rm(workflowDir, { recursive: true, force: true });
+  }
+});
+
+test("preflightWorkflowFile reports binding and parameter validation errors", async () => {
+  const workflowDir = await mkdtemp(join(tmpdir(), "vcfa-preflight-"));
+  const invalidXml = [
+    '<?xml version="1.0" encoding="UTF-16"?>',
+    '<workflow id="workflow-1" root-name="missingRoot">',
+    "  <input>",
+    '    <param name="message" type="string" />',
+    '    <param name="message" type="string" />',
+    "  </input>",
+    "  <output>",
+    '    <param name="result" type="number" />',
+    "  </output>",
+    '  <workflow-item name="item1" type="task">',
+    '    <in-binding><bind name="bad-name" type="string" export-name="unknown" /></in-binding>',
+    '    <out-binding><bind name="result" type="string" export-name="result" /></out-binding>',
+    "    <script></script>",
+    "  </workflow-item>",
+    "</workflow>",
+  ].join("\n");
+  await writeFile(
+    join(workflowDir, "invalid.workflow"),
+    zipSync({
+      "workflow-info": new TextEncoder().encode(
+        '<workflow-info id="workflow-1" name="Invalid" />',
+      ),
+      "workflow-content": utf16LeWithBom(invalidXml),
+    }),
+  );
+
+  try {
+    const report = await preflightWorkflowFile(workflowDir, "invalid.workflow");
+    const errors = report.errors.join("\n");
+    assert.equal(report.valid, false);
+    assert.match(errors, /Duplicate input name: message/);
+    assert.match(errors, /root-name references unknown item missingRoot/);
+    assert.match(errors, /bad-name must be a valid script identifier/);
+    assert.match(errors, /references unknown source unknown/);
+    assert.match(errors, /type string does not match result type number/);
+    assert.match(errors, /missing script content/);
+  } finally {
+    await rm(workflowDir, { recursive: true, force: true });
+  }
+});
+
+test("preflightWorkflowFile rejects unsafe file and archive paths", async () => {
+  const workflowDir = await mkdtemp(join(tmpdir(), "vcfa-preflight-"));
+  const outsideFile = join(tmpdir(), `outside-${Date.now()}.workflow`);
+  await writeFile(outsideFile, buildWorkflowArtifact(workflow));
+  await symlink(outsideFile, join(workflowDir, "linked.workflow"));
+  await writeFile(
+    join(workflowDir, "unsafe.workflow"),
+    zipSync({
+      "../workflow-content": utf16LeWithBom("<workflow />"),
+      "workflow-info": new TextEncoder().encode("<workflow-info />"),
+    }),
+  );
+
+  try {
+    const traversal = await preflightWorkflowFile(workflowDir, "../x.workflow");
+    assert.equal(traversal.valid, false);
+    assert.match(traversal.errors.join("\n"), /path separators/);
+
+    const linked = await preflightWorkflowFile(workflowDir, "linked.workflow");
+    assert.equal(linked.valid, false);
+    assert.match(linked.errors.join("\n"), /symbolic link/);
+
+    const unsafe = await preflightWorkflowFile(workflowDir, "unsafe.workflow");
+    assert.equal(unsafe.valid, false);
+    assert.match(unsafe.errors.join("\n"), /escapes the archive root/);
+  } finally {
+    await rm(workflowDir, { recursive: true, force: true });
+    await rm(outsideFile, { force: true });
+  }
+});
+
+test("preflightPackageFile summarizes nested recognizable artifacts", async () => {
+  const packageDir = await mkdtemp(join(tmpdir(), "vcfa-preflight-packages-"));
+  await writeFile(
+    join(packageDir, "bundle.package"),
+    zipSync({
+      "workflows/generated.workflow": buildWorkflowArtifact(workflow),
+      "manifest.xml": new TextEncoder().encode("<package />"),
+    }),
+  );
+
+  try {
+    const report = await preflightPackageFile(packageDir, "bundle.package");
+    assert.equal(report.valid, true);
+    assert.equal(report.metadata.workflowArtifacts, 1);
+    assert.equal(report.metadata.actionArtifacts, 0);
+    assert.equal(report.metadata.configurationArtifacts, 0);
+    assert.equal(report.parameters.length, 2);
+  } finally {
+    await rm(packageDir, { recursive: true, force: true });
+  }
+});
+
+test("malformed imports fail preflight before authentication or upload", async () => {
+  const workflowDir = await mkdtemp(join(tmpdir(), "vcfa-preflight-import-"));
+  await writeFile(join(workflowDir, "bad.workflow"), "not a zip");
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    return new Response("", { status: 500 });
+  };
+
+  try {
+    const client = new VroClient(config({ workflowDir }));
+    await assert.rejects(
+      () => client.importWorkflowFile("category-1", "bad.workflow"),
+      /preflight failed[\s\S]*valid ZIP archive/,
+    );
+    assert.equal(calls.length, 0);
+  } finally {
+    await rm(workflowDir, { recursive: true, force: true });
+  }
+});
+
+function utf16LeWithBom(value) {
+  return new Uint8Array([0xff, 0xfe, ...Buffer.from(value, "utf16le")]);
+}

--- a/test/artifact-tools.test.mjs
+++ b/test/artifact-tools.test.mjs
@@ -15,6 +15,19 @@ function registeredTools(register, client) {
   return handlers;
 }
 
+function registeredToolsWithConfigs(register, client) {
+  const handlers = new Map();
+  const configs = new Map();
+  const server = {
+    registerTool(name, config, handler) {
+      configs.set(name, config);
+      handlers.set(name, handler);
+    },
+  };
+  register(server, client);
+  return { handlers, configs };
+}
+
 test("action tools format detail responses and pass create payloads", async () => {
   let createParams;
   const handlers = registeredTools(registerActionTools, {
@@ -124,6 +137,58 @@ test("configuration tools format attributes and guard imports and deletes", asyn
     confirm: true,
   });
   assert.equal(deletedId, "config-1");
+});
+
+test("action and configuration preflight tools format reports and are read-only", async () => {
+  const action = registeredToolsWithConfigs(registerActionTools, {
+    preflightActionFile: async (fileName) => ({
+      kind: "action",
+      fileName,
+      valid: true,
+      errors: [],
+      warnings: ["No parseable XML entries were recognized"],
+      metadata: { name: "getVmIp" },
+      entries: [{ name: "action.xml", size: 100 }],
+      parameters: [],
+      actionReferences: [],
+    }),
+  });
+  assert.equal(
+    action.configs.get("preflight-action-file").annotations.readOnlyHint,
+    true,
+  );
+  const actionResult = await action.handlers.get("preflight-action-file")({
+    fileName: "getVmIp.action",
+  });
+  assert.equal(actionResult.isError, false);
+  assert.match(actionResult.content[0].text, /preflight passed/);
+  assert.match(actionResult.content[0].text, /getVmIp/);
+
+  const config = registeredToolsWithConfigs(registerConfigTools, {
+    preflightConfigurationFile: async (fileName) => ({
+      kind: "configuration",
+      fileName,
+      valid: false,
+      errors: ["Artifact is not a valid ZIP archive"],
+      warnings: [],
+      metadata: {},
+      entries: [],
+      parameters: [],
+      actionReferences: [],
+    }),
+  });
+  assert.equal(
+    config.configs.get("preflight-configuration-file").annotations
+      .readOnlyHint,
+    true,
+  );
+  const configResult = await config.handlers.get(
+    "preflight-configuration-file",
+  )({
+    fileName: "settings.vsoconf",
+  });
+  assert.equal(configResult.isError, true);
+  assert.match(configResult.content[0].text, /valid ZIP archive/);
 });
 
 test("resource tools format lists and guard updates and deletes", async () => {

--- a/test/package-tools.test.mjs
+++ b/test/package-tools.test.mjs
@@ -48,3 +48,36 @@ test("delete-package deletes only after confirmation", async () => {
   assert.deepEqual(deleted, { name: "com.example", deleteContents: true });
   assert.match(result.content[0].text, /including contents/);
 });
+
+test("preflight-package formats reports and is read-only", async () => {
+  const handlers = new Map();
+  const configs = new Map();
+  const server = {
+    registerTool(name, config, handler) {
+      configs.set(name, config);
+      handlers.set(name, handler);
+    },
+  };
+  registerPackageTools(server, {
+    preflightPackageFile: async (fileName) => ({
+      kind: "package",
+      fileName,
+      valid: true,
+      errors: [],
+      warnings: ["No nested artifacts were recognized"],
+      metadata: { workflowArtifacts: 0 },
+      entries: [{ name: "manifest.xml", size: 12 }],
+      parameters: [],
+      actionReferences: [],
+    }),
+  });
+
+  assert.equal(configs.get("preflight-package").annotations.readOnlyHint, true);
+
+  const result = await handlers.get("preflight-package")({
+    fileName: "bundle.package",
+  });
+  assert.equal(result.isError, false);
+  assert.match(result.content[0].text, /preflight passed/);
+  assert.match(result.content[0].text, /workflowArtifacts: 0/);
+});

--- a/test/vro-client.test.mjs
+++ b/test/vro-client.test.mjs
@@ -1,8 +1,10 @@
+import { zipSync } from "fflate";
 import assert from "node:assert/strict";
 import { mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { buildWorkflowArtifact } from "../dist/client/workflow-artifact.js";
 import { VroClient } from "../dist/vro-client.js";
 
 const config = (overrides = {}) => ({
@@ -17,6 +19,25 @@ function authResponse() {
   return new Response("", {
     status: 200,
     headers: { "x-vmware-vcloud-access-token": "token" },
+  });
+}
+
+function xmlArchive(rootName) {
+  return zipSync({
+    "artifact.xml": new TextEncoder().encode(`<${rootName} name="payload" />`),
+  });
+}
+
+function minimalWorkflowArtifact() {
+  return buildWorkflowArtifact({
+    name: "Payload",
+    outputs: [{ name: "result", type: "string" }],
+    tasks: [
+      {
+        script: 'result = "ok";',
+        outBindings: [{ name: "result", type: "string", target: "result" }],
+      },
+    ],
   });
 }
 
@@ -444,7 +465,7 @@ test("package import rejects symbolic links", async () => {
 
 test("package import sends multipart file and overwrite query", async () => {
   const packageDir = await mkdtemp(join(tmpdir(), "vcfa-packages-"));
-  await writeFile(join(packageDir, "payload.package"), "package");
+  await writeFile(join(packageDir, "payload.package"), xmlArchive("package"));
   const calls = [];
   globalThis.fetch = async (url, init) => {
     calls.push({ url: String(url), init });
@@ -564,7 +585,10 @@ test("workflow import rejects symbolic links", async () => {
 
 test("workflow import sends multipart file with category and overwrite query", async () => {
   const workflowDir = await mkdtemp(join(tmpdir(), "vcfa-workflows-"));
-  await writeFile(join(workflowDir, "payload.workflow"), "workflow");
+  await writeFile(
+    join(workflowDir, "payload.workflow"),
+    minimalWorkflowArtifact(),
+  );
   const calls = [];
   globalThis.fetch = async (url, init) => {
     calls.push({ url: String(url), init });
@@ -680,7 +704,7 @@ test("action import rejects symbolic links", async () => {
 
 test("action import sends multipart file and category name", async () => {
   const actionDir = await mkdtemp(join(tmpdir(), "vcfa-actions-"));
-  await writeFile(join(actionDir, "payload.action"), "action");
+  await writeFile(join(actionDir, "payload.action"), xmlArchive("action"));
   const calls = [];
   globalThis.fetch = async (url, init) => {
     calls.push({ url: String(url), init });
@@ -855,7 +879,10 @@ test("configuration import sends multipart file and category id", async () => {
   const configurationDir = await mkdtemp(
     join(tmpdir(), "vcfa-configurations-"),
   );
-  await writeFile(join(configurationDir, "payload.vsoconf"), "configuration");
+  await writeFile(
+    join(configurationDir, "payload.vsoconf"),
+    xmlArchive("configuration"),
+  );
   const calls = [];
   globalThis.fetch = async (url, init) => {
     calls.push({ url: String(url), init });

--- a/test/workflow-tools.test.mjs
+++ b/test/workflow-tools.test.mjs
@@ -314,3 +314,39 @@ test("scaffold-workflow-file surfaces validation errors", async () => {
   assert.equal(result.isError, true);
   assert.match(result.content[0].text, /missing binding/);
 });
+
+test("preflight-workflow-file formats reports and is read-only", async () => {
+  const handlers = new Map();
+  const configs = new Map();
+  const server = {
+    registerTool(name, config, handler) {
+      configs.set(name, config);
+      handlers.set(name, handler);
+    },
+  };
+  registerWorkflowTools(server, {
+    preflightWorkflowFile: async (fileName) => ({
+      kind: "workflow",
+      fileName,
+      valid: false,
+      errors: ["Missing required workflow-content entry"],
+      warnings: [],
+      metadata: { id: "workflow-1" },
+      entries: [{ name: "workflow-info", size: 42 }],
+      parameters: [],
+      actionReferences: [],
+    }),
+  });
+
+  assert.equal(
+    configs.get("preflight-workflow-file").annotations.readOnlyHint,
+    true,
+  );
+
+  const result = await handlers.get("preflight-workflow-file")({
+    fileName: "bad.workflow",
+  });
+  assert.equal(result.isError, true);
+  assert.match(result.content[0].text, /preflight failed/);
+  assert.match(result.content[0].text, /Missing required workflow-content/);
+});


### PR DESCRIPTION
## Summary
- Adds shared preflight checks for local `.workflow`, `.action`, `.vsoconf`, and `.package`/`.zip` artifacts before import
- Surfaces preflight results through new MCP tools and blocks imports when validation fails
- Updates docs and examples to guide users toward validating artifacts before upload

## Testing
- Added unit coverage for preflight parsing, malformed archives/XML, path safety, and nested package inspection
- Added tool-level tests for the new read-only preflight MCP commands
- Ran the full test suite locally; all tests passed