### PR TITLE
[codex] Add VitePress documentation site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,53 @@
+name: Deploy documentation to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build documentation
+        run: npm run docs:build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 dist/
+docs/.vitepress/cache/
+docs/.vitepress/dist/
 .env

--- a/README.md
+++ b/README.md
@@ -3,19 +3,23 @@
 [![npm version](https://img.shields.io/npm/v/@mgovedarov/mcp-vcf-orchestrator)](https://www.npmjs.com/package/@mgovedarov/mcp-vcf-orchestrator)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-An [MCP](https://modelcontextprotocol.io/) server that exposes VCF Automation Orchestrator (vRO), Service Broker, and Cloud Assembly REST API operations as tools. Enables AI assistants to list, create, delete, and run workflows, actions, configuration elements, resource elements, extensibility subscriptions, catalog items, deployments, blueprint templates, and plugins via natural language.
+An [MCP](https://modelcontextprotocol.io/) server that exposes VCF Automation Orchestrator (vRO), Service Broker, and Cloud Assembly REST API operations as tools. It helps AI assistants list, inspect, run, create, export, preflight, diff, import, and delete VCFA/vRO automation assets through discovery-first workflows.
 
 Supports **VCF 9 Automation** and **Aria Automation 8.x**.
 
-## Prerequisites
+## Documentation
 
-- **Node.js** 18.0 or higher
-- **VCF Automation** 9.x (or Aria Automation 8.x) instance with REST API access
-- Credentials (username, organization, password) for the VCF Cloud API
+Full documentation is available in the GitHub Pages site:
 
-## Installation
+- Published site: <https://mgovedarov.github.io/mcp-vcf-orchestrator/>
+- Local docs entry point: [docs/index.md](docs/index.md)
+- vRO artifact authoring notes: [docs/vro-artifact-authoring.md](docs/vro-artifact-authoring.md)
 
-### From npm (recommended)
+The docs include installation, configuration, MCP client setup, tool references, resources/prompts, how-tos, artifact lifecycle guidance, safety notes, troubleshooting, and contributor guidance.
+
+## Quick Start
+
+Run directly from npm:
 
 ```bash
 npx @mgovedarov/mcp-vcf-orchestrator
@@ -28,7 +32,7 @@ npm install -g @mgovedarov/mcp-vcf-orchestrator
 mcp-vcf-orchestrator
 ```
 
-### From source
+Run from source:
 
 ```bash
 git clone https://github.com/mgovedarov/mcp-vcf-orchestrator.git
@@ -39,515 +43,64 @@ npm run build
 
 ## Configuration
 
-Set the following environment variables (see `.env.example`):
-
-| Variable                 | Required | Description                                                                                  |
-| ------------------------ | -------- | -------------------------------------------------------------------------------------------- |
-| `VCFA_HOST`              | Yes      | VCFA hostname (e.g. `vcfa.example.com`)                                                      |
-| `VCFA_USERNAME`          | Yes      | Username without organization (e.g. `admin`)                                                 |
-| `VCFA_ORGANIZATION`      | Yes      | Organization/tenant (e.g. `System` or `vsphere.local`)                                       |
-| `VCFA_PASSWORD`          | Yes      | Password                                                                                     |
-| `VCFA_IGNORE_TLS`        | No       | Set to `true` to skip TLS certificate verification (lab environments)                        |
-| `VCFA_ARTIFACT_DIR`      | No       | Root directory for local artifact import/export files (defaults to a temp directory)         |
-
-Artifact files are organized under `VCFA_ARTIFACT_DIR` as `packages`, `resources`, `workflows`, `actions`, and `configurations`. Advanced users can still override individual locations with `VCFA_PACKAGE_DIR`, `VCFA_RESOURCE_DIR`, `VCFA_WORKFLOW_DIR`, `VCFA_ACTION_DIR`, or `VCFA_CONFIGURATION_DIR`.
-
-The server authenticates by POSTing to `https://{VCFA_HOST}/cloudapi/1.0.0/sessions` with Basic Auth as `{VCFA_USERNAME}@{VCFA_ORGANIZATION}:{VCFA_PASSWORD}` and uses the returned bearer token for all VCFA API calls.
-
-## Usage
-
-### Run directly
-
-```bash
-VCFA_HOST=vcfa.example.com VCFA_USERNAME=admin VCFA_ORGANIZATION=vsphere.local VCFA_PASSWORD=secret npx @mgovedarov/mcp-vcf-orchestrator
-```
-
-### VS Code (GitHub Copilot)
-
-Add to your VS Code `settings.json`:
-
-```json
-{
-  "mcp": {
-    "servers": {
-      "vcfa": {
-        "command": "npx",
-        "args": ["-y", "@mgovedarov/mcp-vcf-orchestrator"],
-        "env": {
-          "VCFA_HOST": "vcfa.example.com",
-          "VCFA_USERNAME": "administrator",
-          "VCFA_ORGANIZATION": "vsphere.local",
-          "VCFA_PASSWORD": "your-password",
-          "VCFA_IGNORE_TLS": "false"
-        }
-      }
-    }
-  }
-}
-```
-
-### Claude Desktop
-
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "vcfa": {
-      "command": "npx",
-      "args": ["-y", "@mgovedarov/mcp-vcf-orchestrator"],
-      "env": {
-        "VCFA_HOST": "vcfa.example.com",
-        "VCFA_USERNAME": "administrator",
-        "VCFA_ORGANIZATION": "vsphere.local",
-        "VCFA_PASSWORD": "your-password",
-        "VCFA_IGNORE_TLS": "false"
-      }
-    }
-  }
-}
-```
-
-## Tools Reference
-
-### Artifact Promotion
-
-| Tool                         | Description                                                                                                            |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `prepare-artifact-promotion` | Run preflight, optionally export a live backup, summarize risks/changes, and recommend the exact confirmed import call |
-
-### Workflows
-
-| Tool                       | Description                                                                                 |
-| -------------------------- | ------------------------------------------------------------------------------------------- |
-| `list-workflows`           | List workflows, optionally filtered by name                                                 |
-| `get-workflow`             | Get workflow details including input/output parameters                                      |
-| `create-workflow`          | Create a new empty workflow in a category                                                   |
-| `delete-workflow`          | Delete a workflow (irreversible)                                                            |
-| `run-workflow`             | Execute a workflow with optional input parameters                                           |
-| `run-workflow-and-wait`    | Validate inputs, execute a workflow, wait for completion, and return outputs or diagnostics |
-| `list-workflow-executions` | List past and current executions for a workflow, with optional status filter                |
-| `get-workflow-execution`   | Check execution status and retrieve outputs                                                 |
-| `export-workflow-file`     | Export a workflow artifact to a `.workflow` file under the configured workflow artifact directory |
-| `scaffold-workflow-file`   | Generate a local `.workflow` artifact from structured metadata and linear scriptable tasks  |
-| `preflight-workflow-file`  | Validate a local `.workflow` artifact before import                                        |
-| `diff-workflow-file`       | Compare two local `.workflow` artifacts, or a live workflow export against a local artifact |
-| `import-workflow-file`     | Import a `.workflow` artifact from the configured workflow artifact directory into a workflow category |
-
-### Actions
-
-| Tool                 | Description                                                                |
-| -------------------- | -------------------------------------------------------------------------- |
-| `list-actions`       | List actions (scriptable tasks), optionally filtered by name               |
-| `get-action`         | Get action details including script content and parameters                 |
-| `create-action`      | Create a new action with script content                                    |
-| `export-action-file` | Export an action artifact to a `.action` file under the configured action artifact directory |
-| `preflight-action-file` | Validate a local `.action` artifact before import                       |
-| `diff-action-file`  | Compare two local `.action` artifacts, or a live action export against a local artifact |
-| `import-action-file` | Import a `.action` artifact from the configured action artifact directory into an action category |
-| `delete-action`      | Delete an action (irreversible)                                            |
-
-### Configuration Elements
-
-| Tool                        | Description                                                                              |
-| --------------------------- | ---------------------------------------------------------------------------------------- |
-| `list-configurations`       | List configuration elements, optionally filtered by name                                 |
-| `get-configuration`         | Get configuration element details and attributes                                         |
-| `create-configuration`      | Create a new configuration element with attributes                                       |
-| `update-configuration`      | Update a configuration element's name, description, or attributes                        |
-| `export-configuration-file` | Export a configuration artifact to a `.vsoconf` file under the configured configuration artifact directory |
-| `preflight-configuration-file` | Validate a local `.vsoconf` artifact before import                                  |
-| `import-configuration-file` | Import a `.vsoconf` artifact from the configured configuration artifact directory into a configuration category |
-| `delete-configuration`      | Delete a configuration element (irreversible)                                            |
-
-### Resource Elements
-
-| Tool                      | Description                                                                                 |
-| ------------------------- | ------------------------------------------------------------------------------------------- |
-| `list-resource-elements`  | List resource elements, optionally filtered by name                                         |
-| `export-resource-element` | Export a resource element by ID to a file under the configured resource artifact directory  |
-| `import-resource-element` | Import a resource element file from the configured resource artifact directory into a resource category |
-| `update-resource-element` | Replace an existing resource element's binary content from a file under the configured resource artifact directory |
-| `delete-resource-element` | Delete a resource element, optionally forcing deletion when it is referenced                |
-
-### Categories
-
-| Tool              | Description                                                                                                               |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `list-categories` | List categories by type (`WorkflowCategory`, `ActionCategory`, `ConfigurationElementCategory`, `ResourceElementCategory`) |
-
-### Catalog Items
-
-| Tool                 | Description                                                              |
-| -------------------- | ------------------------------------------------------------------------ |
-| `list-catalog-items` | List available Service Broker catalog items, optionally searched by name |
-| `get-catalog-item`   | Get catalog item details including type, source, and project assignments |
-
-### Deployments
-
-| Tool                      | Description                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------ |
-| `list-deployments`        | List deployments, optionally filtered by name/keyword or project ID            |
-| `get-deployment`          | Get deployment details including status, project, and catalog item info        |
-| `create-deployment`       | Deploy a catalog item by providing its ID, a deployment name, and a project ID |
-| `delete-deployment`       | Delete a deployment (irreversible)                                             |
-| `list-deployment-actions` | List deployment-level day-2 actions available for a deployment                 |
-| `run-deployment-action`   | Submit a deployment-level day-2 action request with optional inputs and reason |
-
-### Blueprint Templates
-
-| Tool              | Description                                                                     |
-| ----------------- | ------------------------------------------------------------------------------- |
-| `list-templates`  | List blueprint templates, optionally filtered by name/keyword or project ID     |
-| `get-template`    | Get template details including status, project, validity, and full YAML content |
-| `create-template` | Create a new blueprint template with optional YAML content                      |
-| `delete-template` | Delete a blueprint template (irreversible)                                      |
-
-### vRO Packages
-
-| Tool             | Description                                                                         |
-| ---------------- | ----------------------------------------------------------------------------------- |
-| `list-packages`  | List vRO packages on the Orchestrator instance, optionally filtered by name         |
-| `get-package`    | Get details of a specific package by its fully-qualified name                       |
-| `export-package` | Export a package as a ZIP file under the configured package artifact directory       |
-| `preflight-package` | Validate a local `.package` or `.zip` artifact before import                    |
-| `import-package` | Import a package file from the configured package artifact directory into the Orchestrator instance |
-| `delete-package` | Delete a package after confirmation, optionally deleting all its contained elements |
-
-### vRO Plugins
-
-| Tool           | Description                                                                      |
-| -------------- | -------------------------------------------------------------------------------- |
-| `list-plugins` | List installed plugins on the Orchestrator instance, optionally filtered by name |
-
-### Extensibility Subscriptions
-
-| Tool                  | Description                                                                      |
-| --------------------- | -------------------------------------------------------------------------------- |
-| `list-event-topics`   | List available event topics from the Event Broker                                |
-| `list-subscriptions`  | List extensibility subscriptions, optionally filtered by project ID              |
-| `get-subscription`    | Get subscription details including constraints, blocking, and priority           |
-| `create-subscription` | Create a new subscription linking an event topic to a vRO workflow or ABX action |
-| `update-subscription` | Update a subscription (enable/disable, re-target, change priority)               |
-| `delete-subscription` | Delete a subscription                                                            |
-
-## MCP Resources
-
-| Resource URI                     | Description                                     |
-| -------------------------------- | ----------------------------------------------- |
-| `vcfa://docs/readme`             | README content for tool usage and configuration |
-| `vcfa://docs/artifact-authoring` | vRO artifact authoring and import/export guide  |
-| `vcfa://schemas/workflow-scaffold` | Structured contract and validation notes for `scaffold-workflow-file` |
-| `vcfa://patterns/workflows/basic-scriptable-task` | Discovery, scaffold, binding, and validation guidance for a linear scriptable-task workflow |
-| `vcfa://patterns/workflows/action-wrapper` | Guidance for wrapping a verified vRO action in a workflow |
-| `vcfa://patterns/templates/conventions` | Blueprint template metadata/content conventions and discovery-first authoring rules |
-| `vcfa://patterns/templates/small-vm` | Guidance for drafting a minimal small VM blueprint template from discovered conventions |
-| `vcfa://patterns/templates/catalog-ready` | Guidance for catalog-facing templates and deployment workflow alignment |
-| `vcfa://workflows/{id}`          | Workflow metadata as JSON                       |
-| `vcfa://actions/{id}`            | Action metadata and script details as JSON      |
-| `vcfa://deployments/{id}`        | Deployment details as JSON                      |
-| `vcfa://packages/{name}`         | vRO package metadata as JSON                    |
-
-## MCP Prompts
-
-| Prompt                         | Description                                                   |
-| ------------------------------ | ------------------------------------------------------------- |
-| `vcfa-author-workflow`         | Guide workflow authoring, scaffolding, preflight, and import  |
-| `vcfa-review-artifact-import`  | Review local artifacts before import                          |
-| `vcfa-troubleshoot-deployment` | Inspect a deployment and guide safe remediation               |
-| `vcfa-discover-capabilities`   | Discover reusable plugins, categories, actions, and workflows |
-| `vcfa-build-workflow-from-action` | Discover an existing action and scaffold a verified workflow wrapper |
-| `vcfa-refactor-workflow`       | Inspect, export, preflight, and safely plan workflow refactors |
-| `vcfa-create-template`         | Discover existing templates and create new blueprint templates safely |
-| `vcfa-review-template`         | Review blueprint template metadata, content, and catalog readiness |
-| `vcfa-integrate-workflow-template-subscription` | Plan workflow, template, catalog, deployment, and subscription integration |
-| `vcfa-discovery-first-implementation-plan` | Produce a phased implementation plan that starts with verified read-only discovery |
-
-Workflow and template implementation prompts include a discovery guardrail: when required environment details are missing, the assistant should stop and report the gap instead of inventing IDs, parameter names, return types, or blueprint schema details.
-
-## Examples
-
-These examples show developer-oriented prompts you can use with an AI assistant connected to this MCP server. The interesting bit is not just one tool call; it is the assistant chaining discovery, validation, execution, diagnostics, local artifact work, and guarded changes.
-
-### Debug a workflow run without memorizing its schema
-
-```
-User: Find the workflow we use to resize a deployment, show me the inputs,
-      then run it for deployment dep-123 with size large and wait for the result.
-
-Assistant calls: list-workflows(filter: "resize")
-  → Finds candidate workflows and IDs
-Assistant calls: get-workflow(id: "...")
-  → Reads required input names and vRO types
-Assistant calls: run-workflow-and-wait(
-  id: "...",
-  inputs: [
-    {name: "deploymentId", value: "dep-123"},
-    {name: "size", value: "large"}
-  ],
-  timeoutSeconds: 600,
-  logLimit: 30
-)
-  → Validates inputs before running, polls until completion, and returns outputs.
-    If the workflow fails, the response includes current item, stack, log excerpts,
-    and warnings when diagnostics cannot be fetched.
-```
-
-### Scaffold, import, and test a workflow artifact
-
-```
-User: Create a simple workflow artifact called Echo Message. It should take
-      message as a string and return result as a string. Save it locally,
-      import it into the Dev workflows category, and run it once.
-
-Assistant calls: scaffold-workflow-file(
-  fileName: "echo-message.workflow",
-  workflow: {
-    name: "Echo Message",
-    inputs: [{name: "message", type: "string", description: "Text to echo"}],
-    outputs: [{name: "result", type: "string", description: "Echo result"}],
-    tasks: [{
-      displayName: "Echo",
-      script: "result = message;",
-      inBindings: [{name: "message", type: "string", source: "message"}],
-      outBindings: [{name: "result", type: "string", target: "result"}]
-    }]
-  }
-)
-  → Writes echo-message.workflow under the configured workflow artifact directory as an importable ZIP
-    with UTF-16 workflow-content
-
-Assistant calls: list-categories(type: "WorkflowCategory", filter: "Dev")
-  → Finds the target workflow category ID
-Assistant calls: import-workflow-file(
-  categoryId: "<dev-workflow-category-id>",
-  fileName: "echo-message.workflow",
-  overwrite: true,
-  confirm: true
-)
-  → Imports the local artifact
-Assistant calls: list-workflows(filter: "Echo Message")
-Assistant calls: run-workflow-and-wait(
-  id: "<workflow-id>",
-  inputs: [{name: "message", value: "hello"}]
-)
-  → Returns result: "hello"
-```
-
-### Export, review, and promote vRO artifacts safely
-
-```
-User: Export the Netbox package and the IPAM workflow before I change them.
-      Then import the updated workflow artifact from my local workflow directory.
-
-Assistant calls: list-packages(filter: "netbox")
-Assistant calls: export-package(
-  name: "com.example.netbox",
-  fileName: "com.example.netbox.package",
-  overwrite: true
-)
-  → Saves the package under the configured package artifact directory
-
-Assistant calls: list-workflows(filter: "IPAM")
-Assistant calls: export-workflow-file(
-  id: "<workflow-id>",
-  fileName: "ipam-before-change.workflow",
-  overwrite: true
-)
-  → Saves the current workflow under the configured workflow artifact directory
-
-Assistant calls: import-workflow-file(
-  categoryId: "<workflow-category-id>",
-  fileName: "ipam-updated.workflow",
-  overwrite: true,
-  confirm: true
-)
-  → Uploads only after confirmation and only from the configured workflow artifact directory
-```
-
-### Preflight local artifacts before upload
-
-```
-User: Validate the updated IPAM workflow artifact before importing it.
-
-Assistant calls: preflight-workflow-file(
-  fileName: "ipam-updated.workflow"
-)
-  → Checks the archive structure, UTF-16 workflow XML, parameters, bindings,
-    task flow, vRO type syntax, and local import safety before any upload.
-```
-
-### Deploy from the catalog and run day-2 actions
-
-```
-User: Find the Ubuntu catalog item, deploy a medium build agent in project
-      project-dev-123, then show me the actions available after it is created.
-
-Assistant calls: list-catalog-items(search: "Ubuntu")
-  → Lists matching Service Broker catalog items
-Assistant calls: get-catalog-item(id: "...")
-  → Shows item metadata, source, projects, and useful context
-Assistant calls: create-deployment(
-  catalogItemId: "...",
-  deploymentName: "build-agent-01",
-  projectId: "project-dev-123",
-  reason: "Temporary CI build agent",
-  inputs: {size: "medium", diskGb: 80}
-)
-  → Deployment request submitted
-Assistant calls: list-deployments(search: "build-agent-01", projectId: "project-dev-123")
-  → Confirms current deployment state
-Assistant calls: list-deployment-actions(deploymentId: "<deployment-id>")
-  → Shows day-2 actions and input hints
-Assistant calls: run-deployment-action(
-  deploymentId: "<deployment-id>",
-  actionId: "<power-or-reboot-action-id>",
-  reason: "Developer requested reboot after bootstrap",
-  confirm: true
-)
-  → Submits the action only after confirmation
-```
-
-### Create a reusable vRO action
-
-```
-User: Create a utility action that normalizes deployment names for our
-      provisioning workflows.
-
-Assistant calls: create-action(
-  moduleName: "com.example.naming",
-  name: "normalizeDeploymentName",
-  script: "return name.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-');",
-  inputParameters: [{name: "name", type: "string", description: "Raw deployment name"}],
-  returnType: "string"
-)
-  → Creates the action in the target module
-
-User: Show me what was created.
-
-Assistant calls: list-actions(filter: "normalizeDeploymentName")
-Assistant calls: get-action(id: "<action-id>")
-  → Returns the script, inputs, module, and return type for review
-```
-
-### Review and create blueprint templates
-
-```
-User: Show me the current Ubuntu template YAML, then create a starter template
-      for a small web tier in project project-dev-123.
-
-Assistant calls: list-templates(search: "Ubuntu")
-  → Finds matching Cloud Assembly blueprint templates
-Assistant calls: get-template(id: "<ubuntu-template-id>")
-  → Returns status, project metadata, validity, and YAML content
-Assistant calls: create-template(
-  name: "Web Tier Starter",
-  projectId: "project-dev-123",
-  description: "Starter web tier blueprint for development",
-  content: "formatVersion: 1\ninputs: {}\nresources: {}"
-)
-  → Creates a draft blueprint template that can be refined in Cloud Assembly
-```
-
-### Wire a vRO workflow to an event topic
-
-```
-User: Run the workflow "Post-Provision Hardening" whenever compute provisioning
-      completes. Make it blocking if the event topic supports blocking.
-
-Assistant calls: list-event-topics()
-  → Finds the provisioning topic and whether it is blockable
-Assistant calls: list-workflows(filter: "Post-Provision Hardening")
-  → Finds the vRO workflow ID
-Assistant calls: create-subscription(
-  name: "Post-Provision Hardening",
-  eventTopicId: "<provisioning-topic-id>",
-  runnableType: "extensibility.vro",
-  runnableId: "<workflow-id>",
-  blocking: true,
-  priority: 10,
-  description: "Run hardening workflow after VM provisioning"
-)
-  → Creates an enabled subscription
-
-User: Disable that hook while I test a new version.
-
-Assistant calls: list-subscriptions()
-Assistant calls: update-subscription(id: "<subscription-id>", disabled: true)
-  → Disables the subscription without deleting it
-```
-
-### Manage runtime configuration and resource files
-
-```
-User: Create a Netbox configuration element and upload a logo resource used by
-      the provisioning workflows.
-
-Assistant calls: list-categories(type: "ConfigurationElementCategory", filter: "Integrations")
-  → Returns category ID
-Assistant calls: create-configuration(
-  categoryId: "<category-id>",
-  name: "Netbox Settings",
-  description: "Netbox API connection parameters",
-  attributes: [
-    {name: "netboxUrl", type: "string", value: "https://netbox.example.com"},
-    {name: "apiToken", type: "string", value: "your-token-here"}
-  ]
-)
-  → Creates a typed configuration element
-
-Assistant calls: list-categories(type: "ResourceElementCategory", filter: "Assets")
-Assistant calls: import-resource-element(
-  categoryId: "<resource-category-id>",
-  fileName: "portal-logo.png",
-  confirm: true
-)
-  → Imports a local file from the configured resource artifact directory
-
-User: Rotate the Netbox token and replace the logo without changing workflow code.
-
-Assistant calls: list-configurations(filter: "Netbox Settings")
-Assistant calls: update-configuration(
-  id: "<config-id>",
-  attributes: [
-    {name: "netboxUrl", type: "string", value: "https://netbox.example.com"},
-    {name: "apiToken", type: "string", value: "new-token"}
-  ]
-)
-Assistant calls: update-resource-element(
-  id: "<resource-id>",
-  fileName: "portal-logo-v2.png",
-  confirm: true
-)
-  → Updates shared runtime data safely from local artifact directories
-```
-
-### Inspect platform capabilities before writing code
-
-```
-User: Before I write a workflow that talks to NSX and vCenter, show me the
-      installed plugins and any actions that already do VM lookup.
-
-Assistant calls: list-plugins()
-Assistant calls: list-plugins(filter: "nsx")
-Assistant calls: list-actions(filter: "getAllMachines")
-Assistant calls: get-action(id: "<candidate-action-id>")
-  → Shows installed plugin coverage and reusable library action code before
-    generating or importing new workflow artifacts
-```
+Required environment variables:
+
+| Variable | Description |
+| --- | --- |
+| `VCFA_HOST` | VCF Automation hostname, for example `vcfa.example.com`. |
+| `VCFA_USERNAME` | Username without organization, for example `admin`. |
+| `VCFA_ORGANIZATION` | Organization or tenant, for example `System` or `vsphere.local`. |
+| `VCFA_PASSWORD` | Password for the VCF Cloud API session. |
+
+Useful optional variables:
+
+| Variable | Description |
+| --- | --- |
+| `VCFA_IGNORE_TLS` | Set to `true` to skip TLS certificate verification in lab environments. |
+| `VCFA_ARTIFACT_DIR` | Root directory for local artifact files. |
+| `VCFA_PACKAGE_DIR` | Override package artifact directory. |
+| `VCFA_RESOURCE_DIR` | Override resource artifact directory. |
+| `VCFA_WORKFLOW_DIR` | Override workflow artifact directory. |
+| `VCFA_ACTION_DIR` | Override action artifact directory. |
+| `VCFA_CONFIGURATION_DIR` | Override configuration artifact directory. |
+
+## Tool Coverage
+
+The server includes tools for:
+
+- Workflows, workflow executions, workflow artifact scaffold/preflight/diff/import/export
+- Actions and action artifact import/export/preflight/diff
+- Configuration elements and resource elements
+- vRO packages and plugins
+- Categories
+- Service Broker catalog items and deployments
+- Deployment day-2 actions
+- Cloud Assembly blueprint templates
+- Event topics and extensibility subscriptions
+- Artifact promotion planning
+- MCP resources and prompts for discovery-first implementation work
+
+See the [tool reference](docs/reference/tools.md) for the full list.
 
 ## Development
 
 ```bash
-# Type-check without emitting
-npx tsc --noEmit
-
-# Run in dev mode (no build step)
-VCFA_HOST=... VCFA_USERNAME=... VCFA_ORGANIZATION=... VCFA_PASSWORD=... npm start
-
-# Build for production
+# Type-check and build
 npm run build
 
-# Test with MCP Inspector
-npx @modelcontextprotocol/inspector node dist/index.js
+# Run tests
+npm test
+
+# Run in dev mode
+VCFA_HOST=... VCFA_USERNAME=... VCFA_ORGANIZATION=... VCFA_PASSWORD=... npm start
+
+# Build documentation
+npm run docs:build
+
+# Preview documentation locally
+npm run docs:dev
 ```
+
+## Safety
+
+Use read-only discovery tools before live writes. Import, delete, deployment action, and overwrite operations require explicit confirmation. Local artifact tools only read or write under configured artifact directories and reject unsafe paths.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,0 +1,73 @@
+import { defineConfig } from "vitepress";
+
+export default defineConfig({
+  title: "VCF Orchestrator MCP",
+  description:
+    "MCP server documentation for VCF Automation Orchestrator and Aria Automation operations.",
+  base: "/mcp-vcf-orchestrator/",
+  cleanUrls: true,
+  themeConfig: {
+    nav: [
+      { text: "Guide", link: "/guide/overview" },
+      { text: "Tools", link: "/reference/tools" },
+      { text: "How-Tos", link: "/how-tos/workflows" },
+    ],
+    sidebar: [
+      {
+        text: "Getting Started",
+        items: [
+          { text: "Overview", link: "/guide/overview" },
+          { text: "Installation", link: "/guide/installation" },
+          { text: "Configuration", link: "/guide/configuration" },
+          { text: "MCP Client Setup", link: "/guide/mcp-clients" },
+        ],
+      },
+      {
+        text: "Tool Reference",
+        items: [
+          { text: "Tools", link: "/reference/tools" },
+          { text: "Resources And Prompts", link: "/reference/resources-prompts" },
+        ],
+      },
+      {
+        text: "How-Tos",
+        items: [
+          { text: "Workflows", link: "/how-tos/workflows" },
+          { text: "Artifacts", link: "/how-tos/artifacts" },
+          { text: "Catalog And Deployments", link: "/how-tos/catalog-deployments" },
+          { text: "Templates And Subscriptions", link: "/how-tos/templates-subscriptions" },
+          { text: "Configuration And Resources", link: "/how-tos/configuration-resources" },
+        ],
+      },
+      {
+        text: "Artifact Lifecycle",
+        items: [
+          { text: "Lifecycle", link: "/artifacts/lifecycle" },
+          { text: "Workflow Authoring", link: "/artifacts/workflow-authoring" },
+        ],
+      },
+      {
+        text: "Operations",
+        items: [
+          { text: "Safety", link: "/operations/safety" },
+          { text: "Troubleshooting", link: "/operations/troubleshooting" },
+          { text: "Contributing", link: "/operations/contributing" },
+        ],
+      },
+    ],
+    socialLinks: [
+      {
+        icon: "github",
+        link: "https://github.com/mgovedarov/mcp-vcf-orchestrator",
+      },
+    ],
+    search: {
+      provider: "local",
+    },
+    editLink: {
+      pattern:
+        "https://github.com/mgovedarov/mcp-vcf-orchestrator/edit/main/docs/:path",
+      text: "Edit this page on GitHub",
+    },
+  },
+});

--- a/docs/artifacts/lifecycle.md
+++ b/docs/artifacts/lifecycle.md
@@ -1,0 +1,80 @@
+# Artifact Lifecycle
+
+The artifact lifecycle is designed to keep live changes deliberate and reviewable.
+
+## 1. Discover
+
+Use read-only tools to identify the live asset and target category:
+
+- `list-workflows`, `get-workflow`
+- `list-actions`, `get-action`
+- `list-configurations`, `get-configuration`
+- `list-packages`, `get-package`
+- `list-categories`
+
+## 2. Export
+
+Export live artifacts before modifying or replacing them:
+
+- `export-workflow-file`
+- `export-action-file`
+- `export-configuration-file`
+- `export-resource-element`
+- `export-package`
+
+Export targets must be plain file names under the configured artifact directory. Existing targets require `overwrite: true`.
+
+## 3. Create Or Update Locally
+
+Use `scaffold-workflow-file` to generate `.workflow` artifacts from structured metadata and linear scriptable tasks.
+
+For other artifact types, place local files in the matching configured directory:
+
+- workflows: `.workflow`
+- actions: `.action`
+- configurations: `.vsoconf`
+- packages: `.package` or `.zip`
+- resources: any supported binary/text resource file
+
+## 4. Preflight
+
+Run preflight before any import:
+
+- `preflight-workflow-file`
+- `preflight-action-file`
+- `preflight-configuration-file`
+- `preflight-package`
+
+Preflight catches local path safety issues, malformed archives, encoding problems, recognizable metadata, and workflow/action-specific concerns before live upload.
+
+## 5. Diff
+
+Use diffs when replacing workflow or action artifacts:
+
+- `diff-workflow-file`
+- `diff-action-file`
+
+Diffs can compare two local artifacts or a live export against a local artifact.
+
+## 6. Promote
+
+Use `prepare-artifact-promotion` for a reviewable summary before import. It can combine preflight, optional backup export, diff summaries, target validation, and an exact recommended import call.
+
+## 7. Import With Confirmation
+
+Imports and destructive operations require explicit confirmation. Recommended final checks:
+
+- The target category or package is correct.
+- The artifact file name is correct.
+- Preflight has no blocking errors.
+- Diffs match the intended change.
+- Backup export succeeded when required.
+
+## 8. Verify
+
+After import, verify with read-only or execution tools:
+
+- `list-workflows`, `get-workflow`, `run-workflow-and-wait`
+- `list-actions`, `get-action`
+- `list-configurations`, `get-configuration`
+- `list-packages`, `get-package`

--- a/docs/artifacts/workflow-authoring.md
+++ b/docs/artifacts/workflow-authoring.md
@@ -1,0 +1,59 @@
+# Workflow Authoring
+
+This page summarizes the repository's practical vRO workflow artifact knowledge. For the full authoring note, see [`vro-artifact-authoring.md`](../vro-artifact-authoring.md).
+
+## Workflow Artifact Format
+
+A `.workflow` file is a ZIP archive containing at least:
+
+- `workflow-info`
+- `workflow-content`
+
+`workflow-content` is XML encoded as UTF-16 with a BOM. The XML root is a vRO workflow document with metadata such as `id`, `version`, and `api-version`.
+
+Workflow inputs live under `<input>`, outputs under `<output>`, and scriptable task logic lives in `<workflow-item type="task">` nodes.
+
+## Scriptable Task Bindings
+
+Task variables must be connected to workflow parameters:
+
+```xml
+<in-binding>
+  <bind name="projectName" type="string" export-name="projectName"/>
+</in-binding>
+<out-binding>
+  <bind name="vms" type="Array/Properties" export-name="vms"/>
+</out-binding>
+```
+
+The scaffold tool validates binding references and type matches.
+
+## Scaffolded Workflow Pattern
+
+Use `scaffold-workflow-file` with:
+
+- workflow metadata: name, description, version, API version
+- inputs, outputs, and attributes
+- one or more scriptable tasks
+- explicit in/out bindings per task
+
+Then run `preflight-workflow-file` before import.
+
+## Robust Script Helpers
+
+Portable workflow scripts often need small helpers for vRO object shapes:
+
+- `toText(value)` for null-safe string conversion.
+- `normalize(value)` for trimmed, case-insensitive matching.
+- `getField(object, fieldName)` for direct property and getter access.
+- `asArray(value)` for arrays and common paged response shapes.
+
+Keep generated scripts readable because runtime errors often reference workflow item line numbers.
+
+## Common Pitfalls
+
+- `create-workflow` creates only an empty workflow shell; use `import-workflow-file` for real workflow content.
+- `.workflow` content must preserve UTF-16 encoding with BOM.
+- Multipart imports break if `Content-Type` is set manually without the boundary.
+- Workflow execution is asynchronous; poll with `get-workflow-execution` or use `run-workflow-and-wait`.
+- Action imports use category/module name, while workflow and configuration imports use category IDs.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,0 +1,51 @@
+# Configuration
+
+The server reads all runtime configuration from environment variables.
+
+## Required Variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `VCFA_HOST` | Yes | VCF Automation hostname, for example `vcfa.example.com`. |
+| `VCFA_USERNAME` | Yes | Username without organization, for example `admin`. |
+| `VCFA_ORGANIZATION` | Yes | Organization or tenant, for example `System` or `vsphere.local`. |
+| `VCFA_PASSWORD` | Yes | Password for the VCF Cloud API session. |
+
+The server authenticates by sending Basic Auth as `{VCFA_USERNAME}@{VCFA_ORGANIZATION}:{VCFA_PASSWORD}` to:
+
+```text
+https://{VCFA_HOST}/cloudapi/1.0.0/sessions
+```
+
+It uses the returned bearer token for later VCF Automation, Service Broker, Cloud Assembly, and vRO API calls.
+
+## Optional Variables
+
+| Variable | Description |
+| --- | --- |
+| `VCFA_IGNORE_TLS` | Set to `true` to disable TLS certificate verification for lab environments. |
+| `VCFA_ARTIFACT_DIR` | Root directory for local artifact import/export files. Defaults to a temp directory. |
+| `VCFA_PACKAGE_DIR` | Override the package artifact directory. |
+| `VCFA_RESOURCE_DIR` | Override the resource element artifact directory. |
+| `VCFA_WORKFLOW_DIR` | Override the workflow artifact directory. |
+| `VCFA_ACTION_DIR` | Override the action artifact directory. |
+| `VCFA_CONFIGURATION_DIR` | Override the configuration artifact directory. |
+
+## Artifact Directories
+
+When `VCFA_ARTIFACT_DIR` is set, artifacts are organized into typed subdirectories:
+
+```text
+VCFA_ARTIFACT_DIR/
+  actions/
+  configurations/
+  packages/
+  resources/
+  workflows/
+```
+
+Use the specific directory overrides only when you need different storage locations per artifact type.
+
+## TLS Warning
+
+`VCFA_IGNORE_TLS=true` sets `NODE_TLS_REJECT_UNAUTHORIZED=0` for the process. Use it only for lab or test environments where the risk is understood.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,0 +1,56 @@
+# Installation
+
+## Prerequisites
+
+- Node.js 18.0 or higher.
+- A VCF Automation 9.x or Aria Automation 8.x instance with REST API access.
+- Credentials for the VCF Cloud API.
+
+## Run From npm
+
+Use the package directly:
+
+```bash
+npx @mgovedarov/mcp-vcf-orchestrator
+```
+
+Or install it globally:
+
+```bash
+npm install -g @mgovedarov/mcp-vcf-orchestrator
+mcp-vcf-orchestrator
+```
+
+## Run From Source
+
+```bash
+git clone https://github.com/mgovedarov/mcp-vcf-orchestrator.git
+cd mcp-vcf-orchestrator
+npm install
+npm run build
+```
+
+For local development:
+
+```bash
+VCFA_HOST=vcfa.example.com \
+VCFA_USERNAME=admin \
+VCFA_ORGANIZATION=vsphere.local \
+VCFA_PASSWORD=secret \
+npm start
+```
+
+## Local Docs
+
+Preview this documentation site locally:
+
+```bash
+npm run docs:dev
+```
+
+Build and preview the production output:
+
+```bash
+npm run docs:build
+npm run docs:preview
+```

--- a/docs/guide/mcp-clients.md
+++ b/docs/guide/mcp-clients.md
@@ -1,0 +1,56 @@
+# MCP Client Setup
+
+## VS Code
+
+Add the server to your VS Code `settings.json`:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "vcfa": {
+        "command": "npx",
+        "args": ["-y", "@mgovedarov/mcp-vcf-orchestrator"],
+        "env": {
+          "VCFA_HOST": "vcfa.example.com",
+          "VCFA_USERNAME": "administrator",
+          "VCFA_ORGANIZATION": "vsphere.local",
+          "VCFA_PASSWORD": "your-password",
+          "VCFA_IGNORE_TLS": "false"
+        }
+      }
+    }
+  }
+}
+```
+
+## Claude Desktop
+
+Add the server to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "vcfa": {
+      "command": "npx",
+      "args": ["-y", "@mgovedarov/mcp-vcf-orchestrator"],
+      "env": {
+        "VCFA_HOST": "vcfa.example.com",
+        "VCFA_USERNAME": "administrator",
+        "VCFA_ORGANIZATION": "vsphere.local",
+        "VCFA_PASSWORD": "your-password",
+        "VCFA_IGNORE_TLS": "false"
+      }
+    }
+  }
+}
+```
+
+## MCP Inspector
+
+Build the project first, then inspect the server:
+
+```bash
+npm run build
+npx @modelcontextprotocol/inspector node dist/index.js
+```

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -1,0 +1,32 @@
+# Overview
+
+`@mgovedarov/mcp-vcf-orchestrator` is an MCP server for VCF Automation Orchestrator, Service Broker, and Cloud Assembly operations. It exposes tools that let an AI assistant inspect and manage workflows, actions, configuration elements, resource elements, packages, templates, catalog items, deployments, subscriptions, categories, and plugins.
+
+The server supports VCF 9 Automation and Aria Automation 8.x environments with REST API access.
+
+## What It Helps With
+
+- Discover existing automation assets before implementing new workflows or templates.
+- Run workflows with validated inputs and useful execution diagnostics.
+- Export, scaffold, preflight, diff, and import vRO workflow/action/configuration/package artifacts.
+- Browse catalog items, create deployments, and discover day-2 actions.
+- Manage extensibility subscriptions that connect event topics to workflows or ABX actions.
+- Collect practical context through MCP resources and prompts so agents avoid inventing environment-specific details.
+
+## Operating Model
+
+The safest workflow is discovery first:
+
+1. Use read-only list/get tools to find the current asset, category, project, or schema.
+2. Generate or edit local artifacts under configured artifact directories.
+3. Run preflight and diff tools before importing.
+4. Require explicit confirmation for destructive or live write operations.
+5. Verify changes with list/get/run tools after the operation completes.
+
+## Documentation Map
+
+- [Installation](./installation.md) covers npm and source setup.
+- [Configuration](./configuration.md) documents environment variables and artifact directories.
+- [Tool Reference](../reference/tools.md) groups all MCP tools by domain.
+- [How-Tos](../how-tos/workflows.md) show end-to-end assistant workflows.
+- [Artifact Lifecycle](../artifacts/lifecycle.md) explains export, preflight, diff, promotion, and import.

--- a/docs/how-tos/artifacts.md
+++ b/docs/how-tos/artifacts.md
@@ -1,0 +1,42 @@
+# Artifact How-Tos
+
+## Export Before Changing
+
+Before replacing or importing artifacts, export the current live asset.
+
+```text
+User: Export the Netbox package and the IPAM workflow before I change them.
+```
+
+Recommended sequence:
+
+1. `list-packages(filter: "netbox")`
+2. `export-package(name: "com.example.netbox", fileName: "com.example.netbox.package", overwrite: true)`
+3. `list-workflows(filter: "IPAM")`
+4. `export-workflow-file(id: "<workflow-id>", fileName: "ipam-before-change.workflow", overwrite: true)`
+
+## Preflight Before Upload
+
+Preflight checks run locally before authentication or upload.
+
+```text
+User: Validate the updated IPAM workflow artifact before importing it.
+```
+
+Recommended call:
+
+```text
+preflight-workflow-file(fileName: "ipam-updated.workflow")
+```
+
+The workflow preflight validates archive structure, UTF-16 workflow XML, parameters, bindings, task flow, vRO type syntax, action references, and file path safety.
+
+## Promote With A Backup And Diff
+
+Use `prepare-artifact-promotion` when replacing live artifacts. It can run preflight, export a live backup, summarize workflow/action diffs, and recommend the exact import call. It never imports by itself.
+
+Recommended sequence:
+
+1. `prepare-artifact-promotion(...)`
+2. Review preflight errors, warnings, metadata, backup status, and diff summary.
+3. Run the recommended import call only after the user confirms the target and overwrite intent.

--- a/docs/how-tos/catalog-deployments.md
+++ b/docs/how-tos/catalog-deployments.md
@@ -1,0 +1,30 @@
+# Catalog And Deployment How-Tos
+
+## Deploy From A Catalog Item
+
+Use catalog discovery before submitting a deployment request.
+
+```text
+User: Find the Ubuntu catalog item and deploy a medium build agent.
+```
+
+Recommended sequence:
+
+1. `list-catalog-items(search: "Ubuntu")`
+2. `get-catalog-item(id: "...")`
+3. `create-deployment(catalogItemId: "...", deploymentName: "...", projectId: "...", inputs: {...})`
+4. `list-deployments(search: "...", projectId: "...")`
+
+## Discover And Run Day-2 Actions
+
+After a deployment exists, inspect available actions before submitting one:
+
+1. `list-deployment-actions(deploymentId: "<deployment-id>")`
+2. Review action IDs, names, and input hints.
+3. `run-deployment-action(..., confirm: true)`
+
+Day-2 action availability is deployment-specific. Do not guess action IDs or inputs from another deployment.
+
+## Delete Deployments
+
+`delete-deployment` is destructive. Use `get-deployment` first to confirm the ID, name, project, and status, then require explicit user confirmation before deletion.

--- a/docs/how-tos/configuration-resources.md
+++ b/docs/how-tos/configuration-resources.md
@@ -1,0 +1,33 @@
+# Configuration And Resource How-Tos
+
+## Create Runtime Configuration
+
+Use configuration elements for runtime data that workflows should read without hard-coding.
+
+Recommended sequence:
+
+1. `list-categories(type: "ConfigurationElementCategory", filter: "Integrations")`
+2. `create-configuration(...)`
+3. `list-configurations(filter: "...")`
+4. `get-configuration(id: "...")`
+
+Avoid dumping sensitive values in docs, issue comments, or generated context. Prefer redaction when summarizing configuration attributes.
+
+## Import Resource Files
+
+Resource element imports read local files from the configured resource artifact directory.
+
+Recommended sequence:
+
+1. Put the file under `VCFA_RESOURCE_DIR` or `VCFA_ARTIFACT_DIR/resources`.
+2. `list-categories(type: "ResourceElementCategory", filter: "Assets")`
+3. `import-resource-element(categoryId: "...", fileName: "portal-logo.png", confirm: true)`
+4. `list-resource-elements(filter: "portal-logo")`
+
+## Update Shared Runtime Data
+
+To rotate a value or replace a shared binary resource:
+
+1. `list-configurations(filter: "...")` or `list-resource-elements(filter: "...")`
+2. `update-configuration(...)` or `update-resource-element(..., confirm: true)`
+3. Re-read the object to verify the change.

--- a/docs/how-tos/templates-subscriptions.md
+++ b/docs/how-tos/templates-subscriptions.md
@@ -1,0 +1,40 @@
+# Templates And Subscriptions How-Tos
+
+## Review And Create Blueprint Templates
+
+Start from existing Cloud Assembly templates when possible.
+
+```text
+User: Show me the current Ubuntu template YAML, then create a starter template.
+```
+
+Recommended sequence:
+
+1. `list-templates(search: "Ubuntu")`
+2. `get-template(id: "<ubuntu-template-id>")`
+3. Draft YAML using discovered resource types, inputs, and project conventions.
+4. `create-template(name: "...", projectId: "...", content: "...")`
+5. `get-template(id: "<new-template-id>")`
+
+Do not invent provider-specific YAML properties. If no reliable example or user-provided schema exists, report the missing facts.
+
+## Wire A Workflow To An Event Topic
+
+Use subscriptions to connect Event Broker topics to vRO workflows or ABX actions.
+
+```text
+User: Run the workflow "Post-Provision Hardening" whenever compute provisioning completes.
+```
+
+Recommended sequence:
+
+1. `list-event-topics()`
+2. `list-workflows(filter: "Post-Provision Hardening")`
+3. `create-subscription(...)`
+4. `list-subscriptions()` or `get-subscription(id: "...")`
+
+If blocking behavior matters, verify the event topic supports it before setting `blocking: true`.
+
+## Disable Instead Of Delete
+
+For temporary testing, prefer `update-subscription(id: "...", disabled: true)` over `delete-subscription`. Delete only when the hook is no longer needed.

--- a/docs/how-tos/workflows.md
+++ b/docs/how-tos/workflows.md
@@ -1,0 +1,58 @@
+# Workflow How-Tos
+
+## Run A Workflow With Validated Inputs
+
+Use this flow when you know the desired behavior but not the workflow schema.
+
+```text
+User: Find the workflow we use to resize a deployment, show me the inputs,
+then run it for deployment dep-123 with size large and wait for the result.
+```
+
+Recommended tool sequence:
+
+1. `list-workflows(filter: "resize")`
+2. `get-workflow(id: "...")`
+3. `run-workflow-and-wait(...)`
+
+`run-workflow-and-wait` validates inputs before running and polls until completion. If the workflow fails, the response includes current item details, stack information, log excerpts, and warnings when diagnostics cannot be fetched.
+
+## Scaffold, Import, And Test A Workflow
+
+Use `scaffold-workflow-file` for real importable `.workflow` artifacts instead of hand-building ZIP/XML content.
+
+```text
+User: Create a simple workflow artifact called Echo Message. It should take
+message as a string and return result as a string.
+```
+
+Recommended tool sequence:
+
+1. `scaffold-workflow-file` with workflow inputs, outputs, tasks, and bindings.
+2. `preflight-workflow-file(fileName: "echo-message.workflow")`.
+3. `list-categories(type: "WorkflowCategory", filter: "Dev")`.
+4. `import-workflow-file(..., confirm: true)`.
+5. `list-workflows(filter: "Echo Message")`.
+6. `run-workflow-and-wait(...)`.
+
+Example scaffold task:
+
+```json
+{
+  "displayName": "Echo",
+  "script": "result = message;",
+  "inBindings": [{ "name": "message", "type": "string", "source": "message" }],
+  "outBindings": [{ "name": "result", "type": "string", "target": "result" }]
+}
+```
+
+## Inspect Platform Capabilities Before Writing Code
+
+Before creating new workflow code, discover existing plugins and reusable actions:
+
+1. `list-plugins()`
+2. `list-plugins(filter: "nsx")`
+3. `list-actions(filter: "getAllMachines")`
+4. `get-action(id: "<candidate-action-id>")`
+
+If discovery does not find the required action, category, parameter, or plugin, stop and report the missing detail instead of inventing a schema.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,23 @@
+---
+layout: home
+
+hero:
+  name: VCF Orchestrator MCP
+  text: Operate VCF Automation and vRO through MCP
+  tagline: Tools, prompts, resources, and artifact workflows for AI-assisted automation work.
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /guide/overview
+    - theme: alt
+      text: Tool Reference
+      link: /reference/tools
+
+features:
+  - title: Discovery-first operations
+    details: Inspect workflows, actions, categories, templates, catalog items, deployments, subscriptions, and plugins before changing anything.
+  - title: Safer artifact lifecycle
+    details: Export, scaffold, preflight, diff, promote, and import vRO artifacts from controlled local directories.
+  - title: Practical how-tos
+    details: Follow concrete examples for workflow runs, package promotion, catalog deployments, day-2 actions, and extensibility hooks.
+---

--- a/docs/operations/contributing.md
+++ b/docs/operations/contributing.md
@@ -1,0 +1,37 @@
+# Contributing
+
+## Development Commands
+
+```bash
+npm install
+npm run build
+npm test
+npm run docs:build
+```
+
+## Adding Tools
+
+When adding a new MCP tool:
+
+1. Add the tool in the relevant `src/tools/*` module.
+2. Use existing client modules before introducing new API logic.
+3. Mark read-only and destructive annotations accurately.
+4. Add tests for success, error, confirmation, and formatting behavior.
+5. Update the tool reference and relevant how-to docs.
+
+## Adding Resources Or Prompts
+
+Resources and prompts are registered in the resource and prompt modules. Keep content concrete and discovery-first. When an agent needs environment-specific facts, prompts should direct it to discovery tools instead of relying on memory.
+
+## Artifact Work
+
+When authoring or importing vRO artifacts, read the workflow authoring guide and run preflight before import. Prefer real importable artifacts over illustrative pseudocode.
+
+## Documentation
+
+Docs live under `docs/` and are built with VitePress.
+
+- Add pages to the sidebar in `docs/.vitepress/config.ts`.
+- Keep examples aligned with current tool names and schemas.
+- Distinguish read-only discovery from live write or destructive operations.
+- Run `npm run docs:build` before opening a docs PR.

--- a/docs/operations/safety.md
+++ b/docs/operations/safety.md
@@ -1,0 +1,47 @@
+# Safety
+
+The server includes read-only discovery tools and write-capable tools. Treat every live write operation as an environment change.
+
+## Confirmation Required
+
+These operations should be performed only after explicit user confirmation:
+
+- importing workflows, actions, configurations, packages, or resource elements
+- deleting workflows, actions, configurations, resource elements, packages, templates, deployments, or subscriptions
+- running deployment day-2 actions
+- overwriting local artifact export targets
+
+## Artifact Path Safety
+
+Artifact file tools require plain file names under configured artifact directories. They reject:
+
+- absolute paths
+- path separators
+- traversal such as `../`
+- unsafe symlink import sources
+- unsafe symlink export targets
+- existing export targets unless `overwrite: true`
+
+## Secrets
+
+Configuration values and workflow/action scripts may contain sensitive information. When summarizing output:
+
+- avoid printing passwords, API tokens, and private keys
+- redact sensitive configuration attribute values
+- prefer names, types, IDs, and descriptions over raw values
+
+## Destructive Operations
+
+Before deletion, confirm:
+
+- object type
+- object ID
+- display name
+- project/category/package context
+- expected impact
+
+For subscriptions, disabling is often safer than deleting during testing.
+
+## Discovery Guardrail
+
+Do not invent environment-specific values. If discovery does not return a required category, action, workflow, project, template, parameter, return type, or schema detail, stop and report the missing fact.

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -1,0 +1,51 @@
+# Troubleshooting
+
+## Missing Environment Variables
+
+If the server exits with a missing variable error, set all required values:
+
+```bash
+VCFA_HOST=...
+VCFA_USERNAME=...
+VCFA_ORGANIZATION=...
+VCFA_PASSWORD=...
+```
+
+## TLS Errors In Lab Environments
+
+For lab systems with self-signed certificates, set:
+
+```bash
+VCFA_IGNORE_TLS=true
+```
+
+Use this only when you accept the TLS risk.
+
+## Workflow Run Failures
+
+Prefer `run-workflow-and-wait` during development. It validates input names and types against `get-workflow`, waits for completion, and returns failure context when available.
+
+If a workflow was started asynchronously, use:
+
+1. `list-workflow-executions`
+2. `get-workflow-execution`
+3. execution logs when available
+
+## Artifact Import Failures
+
+Run the matching preflight tool first. Common issues include:
+
+- malformed ZIP archive
+- missing `workflow-info` or `workflow-content`
+- wrong workflow-content encoding
+- bad parameter or binding references
+- unsafe file name or path
+- package contents that include malformed nested artifacts
+
+## Catalog Or Template Ambiguity
+
+Catalog items, templates, and deployments can be project-scoped. If a search returns no match or several plausible matches, inspect with `get-catalog-item`, `get-template`, or `get-deployment` before creating or updating anything.
+
+## GitHub Pages
+
+After merging the docs workflow, set repository Pages source to **GitHub Actions** in GitHub repository settings. The workflow publishes the VitePress build output from `docs/.vitepress/dist`.

--- a/docs/reference/resources-prompts.md
+++ b/docs/reference/resources-prompts.md
@@ -1,0 +1,39 @@
+# Resources And Prompts
+
+The server exposes MCP resources for documentation, artifact patterns, and live object lookup. It also provides prompts that guide agents through discovery-first workflows.
+
+## Resources
+
+| Resource URI | Purpose |
+| --- | --- |
+| `vcfa://docs/readme` | README content for tool usage and configuration. |
+| `vcfa://docs/artifact-authoring` | vRO artifact authoring and import/export guide. |
+| `vcfa://schemas/workflow-scaffold` | Structured contract and validation notes for `scaffold-workflow-file`. |
+| `vcfa://patterns/workflows/basic-scriptable-task` | Guidance for linear scriptable-task workflows. |
+| `vcfa://patterns/workflows/action-wrapper` | Guidance for wrapping a verified vRO action in a workflow. |
+| `vcfa://patterns/templates/conventions` | Blueprint template metadata/content conventions and authoring rules. |
+| `vcfa://patterns/templates/small-vm` | Guidance for minimal small VM blueprint templates. |
+| `vcfa://patterns/templates/catalog-ready` | Guidance for catalog-facing templates and deployment workflow alignment. |
+| `vcfa://workflows/{id}` | Workflow metadata as JSON. |
+| `vcfa://actions/{id}` | Action metadata and script details as JSON. |
+| `vcfa://deployments/{id}` | Deployment details as JSON. |
+| `vcfa://packages/{name}` | vRO package metadata as JSON. |
+
+## Prompts
+
+| Prompt | Purpose |
+| --- | --- |
+| `vcfa-author-workflow` | Guide workflow authoring, scaffolding, preflight, and import. |
+| `vcfa-review-artifact-import` | Review local artifacts before import. |
+| `vcfa-troubleshoot-deployment` | Inspect a deployment and guide safe remediation. |
+| `vcfa-discover-capabilities` | Discover reusable plugins, categories, actions, workflows, catalog items, and templates. |
+| `vcfa-build-workflow-from-action` | Discover an existing action and scaffold a verified workflow wrapper. |
+| `vcfa-refactor-workflow` | Inspect, export, preflight, and safely plan workflow refactors. |
+| `vcfa-create-template` | Discover templates and create blueprint templates safely. |
+| `vcfa-review-template` | Review template metadata, content, and catalog readiness. |
+| `vcfa-integrate-workflow-template-subscription` | Plan workflow, template, catalog, deployment, and subscription integration. |
+| `vcfa-discovery-first-implementation-plan` | Produce a phased plan that starts with verified read-only discovery. |
+
+## Discovery Guardrail
+
+Workflow and template implementation prompts tell agents to stop when required environment details are missing. Agents should report missing workflows, actions, categories, projects, parameters, return types, IDs, or blueprint schema details instead of inventing plausible values.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -1,0 +1,124 @@
+# Tool Reference
+
+Tools are grouped by operating domain. Read-only tools are safe for discovery; write and delete tools can modify live VCFA/vRO state or local artifact files.
+
+## Artifact Promotion
+
+| Tool | Purpose |
+| --- | --- |
+| `prepare-artifact-promotion` | Run preflight, optionally export a live backup, summarize risks/changes, and recommend the exact confirmed import call. |
+
+## Workflows
+
+| Tool | Purpose |
+| --- | --- |
+| `list-workflows` | List workflows, optionally filtered by name. |
+| `get-workflow` | Get workflow details including input/output parameters. |
+| `create-workflow` | Create a new empty workflow in a category. |
+| `delete-workflow` | Delete a workflow. Irreversible. |
+| `run-workflow` | Execute a workflow with optional inputs. |
+| `run-workflow-and-wait` | Validate inputs, execute a workflow, wait for completion, and return outputs or diagnostics. |
+| `list-workflow-executions` | List past and current executions for a workflow. |
+| `get-workflow-execution` | Check execution status and retrieve outputs. |
+| `export-workflow-file` | Export a workflow artifact to a `.workflow` file. |
+| `scaffold-workflow-file` | Generate a local `.workflow` artifact from structured metadata and scriptable tasks. |
+| `preflight-workflow-file` | Validate a local `.workflow` artifact before import. |
+| `diff-workflow-file` | Compare local workflow artifacts, or a live workflow export against a local artifact. |
+| `import-workflow-file` | Import a `.workflow` artifact into a workflow category. |
+
+## Actions
+
+| Tool | Purpose |
+| --- | --- |
+| `list-actions` | List scriptable actions, optionally filtered by name. |
+| `get-action` | Get action details including script content and parameters. |
+| `create-action` | Create a new action with script content. |
+| `export-action-file` | Export an action artifact to a `.action` file. |
+| `preflight-action-file` | Validate a local `.action` artifact before import. |
+| `diff-action-file` | Compare local action artifacts, or a live action export against a local artifact. |
+| `import-action-file` | Import a `.action` artifact into an action category. |
+| `delete-action` | Delete an action. Irreversible. |
+
+## Configuration Elements
+
+| Tool | Purpose |
+| --- | --- |
+| `list-configurations` | List configuration elements, optionally filtered by name. |
+| `get-configuration` | Get configuration element details and attributes. |
+| `create-configuration` | Create a configuration element with attributes. |
+| `update-configuration` | Update a configuration element name, description, or attributes. |
+| `export-configuration-file` | Export a configuration artifact to a `.vsoconf` file. |
+| `preflight-configuration-file` | Validate a local `.vsoconf` artifact before import. |
+| `import-configuration-file` | Import a `.vsoconf` artifact into a configuration category. |
+| `delete-configuration` | Delete a configuration element. Irreversible. |
+
+## Resource Elements
+
+| Tool | Purpose |
+| --- | --- |
+| `list-resource-elements` | List resource elements, optionally filtered by name. |
+| `export-resource-element` | Export a resource element by ID to a local file. |
+| `import-resource-element` | Import a local resource file into a resource category. |
+| `update-resource-element` | Replace an existing resource element's binary content from a local file. |
+| `delete-resource-element` | Delete a resource element, optionally forcing deletion when referenced. |
+
+## Categories
+
+| Tool | Purpose |
+| --- | --- |
+| `list-categories` | List categories by type: `WorkflowCategory`, `ActionCategory`, `ConfigurationElementCategory`, or `ResourceElementCategory`. |
+
+## Catalog Items
+
+| Tool | Purpose |
+| --- | --- |
+| `list-catalog-items` | List available Service Broker catalog items, optionally searched by name. |
+| `get-catalog-item` | Get catalog item details including type, source, and project assignments. |
+
+## Deployments
+
+| Tool | Purpose |
+| --- | --- |
+| `list-deployments` | List deployments, optionally filtered by name/keyword or project ID. |
+| `get-deployment` | Get deployment details including status, project, and catalog item info. |
+| `create-deployment` | Deploy a catalog item by ID, deployment name, and project ID. |
+| `delete-deployment` | Delete a deployment. Irreversible. |
+| `list-deployment-actions` | List deployment-level day-2 actions available for a deployment. |
+| `run-deployment-action` | Submit a deployment-level day-2 action request. |
+
+## Blueprint Templates
+
+| Tool | Purpose |
+| --- | --- |
+| `list-templates` | List blueprint templates, optionally filtered by name/keyword or project ID. |
+| `get-template` | Get template details including status, project, validity, and YAML content. |
+| `create-template` | Create a blueprint template with optional YAML content. |
+| `delete-template` | Delete a blueprint template. Irreversible. |
+
+## Packages
+
+| Tool | Purpose |
+| --- | --- |
+| `list-packages` | List vRO packages, optionally filtered by name. |
+| `get-package` | Get details of a package by fully qualified package name. |
+| `export-package` | Export a package as a ZIP file. |
+| `preflight-package` | Validate a `.package` or `.zip` artifact before import. |
+| `import-package` | Import a package file into Orchestrator. |
+| `delete-package` | Delete a package after confirmation, optionally deleting contained elements. |
+
+## Plugins
+
+| Tool | Purpose |
+| --- | --- |
+| `list-plugins` | List installed vRO plugins, optionally filtered by name. |
+
+## Extensibility Subscriptions
+
+| Tool | Purpose |
+| --- | --- |
+| `list-event-topics` | List available Event Broker topics. |
+| `list-subscriptions` | List extensibility subscriptions, optionally filtered by project ID. |
+| `get-subscription` | Get subscription details including constraints, blocking, and priority. |
+| `create-subscription` | Create a subscription linking an event topic to a vRO workflow or ABX action. |
+| `update-subscription` | Update a subscription. |
+| `delete-subscription` | Delete a subscription. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,10 +20,370 @@
       "devDependencies": {
         "@types/node": "^22.19.17",
         "tsx": "^4.19.0",
-        "typescript": "^5.7.0"
+        "typescript": "^5.7.0",
+        "vitepress": "^1.6.4"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.18.0.tgz",
+      "integrity": "sha512-8siuLG+FIns1AjZ/g2SDVwHz9S+ObacDQISEJvS8XsNei1zl3FXqfqQrBpmrG7ACWCyesXHbicMJtvRbg00FEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.52.0.tgz",
+      "integrity": "sha512-wtwPgyPmO7b7sQPVgoK29c1VpfS08DnnJCmxX/oU1pV2DlMRJCzQcLN7JSloYpodyKHwM8+9wOzlAM0co3TDmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.52.0.tgz",
+      "integrity": "sha512-9KY36bRl4AH7RjqSeDDOKnjsz4IxQFBEOB8/fWmEbdQe+Isbs5jGzVJu9NEPQ1Tgwxlf8Uf07Swj3jZyMNUZ2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.52.0.tgz",
+      "integrity": "sha512-3a/qM3dzJqqfTx7Yrw7uGQ98I3Q0rDfb4Vkv0wEzko96l7YQMxfBVz/VbLq2N+c59GweYv6Vhp8mPeqnWJSITw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.52.0.tgz",
+      "integrity": "sha512-Rki7ACbMcvbQW0BuM84x9dkGHY47ABmv4jU6tYssat2k02p3mIUms2YOLUAMeknhmnFsj6lb6ZzOXdMWMyc1sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.52.0.tgz",
+      "integrity": "sha512-96s4Uzc3kk+/f4jJXIVVGWP5XlngOGNQ1x6hW9AT59pOixHlOs5tqJg+ZUS/GQ6h/iYP0ceQcmxDQeLyCLTaDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.52.0.tgz",
+      "integrity": "sha512-lqeycNpSPe5Qa0OUWpejVvYQjQWV5nQuLT0a4aq7XzRAvCxprV/6Lf841EygdD2nrFnuS58ok7Au1uOtXzpnkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.52.0.tgz",
+      "integrity": "sha512-ly1wETVGRo30cx61O7fetESN+ElL9c9K+bD/AVgnT1ar4c6v+/Yqjrhdtu6Fm4D0s4NZP081Isf6tunH1wUXHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.52.0.tgz",
+      "integrity": "sha512-U4EeTvgmluRjj39ykZSAd5X+a6LD5m7/mcOWDmB7hqm1R6QY0yT8jLxpNVEjYhzgEN5hcDGW6X67EWQY8KiYGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.52.0.tgz",
+      "integrity": "sha512-FCPnDcILfpTE94u7BVlV4DmnSV5wE3+j25EEF+3dYPrVzkVCSoAHs318oWDGxnxsAgiL4HpL12Jc4XHmw9shpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.52.0.tgz",
+      "integrity": "sha512-br3DO7n4N8CXwTRbZS0MnB4WQ9YHfNjCwkCEzVR/wek/qNTDQKDb0nROmkFaNZ8ucUqUVKZi074dbwMwRDlK8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.52.0.tgz",
+      "integrity": "sha512-b0T/Ca2c9KyEslKsVrGZvbe1UrrKKSdfXhBZ2pbpKahFUzJfziRZ0urbOm7V65O0tO/jwU+Lo/+bIiiyhzGt8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.52.0.tgz",
+      "integrity": "sha512-ozBT8J/mtD4H4IAojw8QPirlcL2gHrI1BGuZ4/ZXXO/rTE1yQ4VIPJj4mTTbwo4FbkS1MoJsD/DsrqLzhnc4/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.52.0.tgz",
+      "integrity": "sha512-gyyWcLD22tnabmoit4iukCXuoRc5HYJuUjPSEa8a0D/f/NlRafpWi52AlAaa4Uu/rsl7saHsJFTNjTptWbu2+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -480,6 +840,30 @@
         "hono": "^4"
       }
     },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.80",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.80.tgz",
+      "integrity": "sha512-iglncJJ6X/dVuzFDU32MrHwwo4RBwivGf108dgyYg+HKS78ifx0h7sTenpDZMVT+UhdS6CSgZcvY/SvRXlIEUg==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -532,6 +916,495 @@
       ],
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
@@ -540,6 +1413,292 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
+      "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/shared": "3.5.33",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
+      "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.33",
+        "@vue/shared": "3.5.33"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
+      "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/compiler-core": "3.5.33",
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/compiler-ssr": "3.5.33",
+        "@vue/shared": "3.5.33",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.10",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
+      "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/shared": "3.5.33"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
+      "integrity": "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.33"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
+      "integrity": "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.33",
+        "@vue/shared": "3.5.33"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
+      "integrity": "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.33",
+        "@vue/runtime-core": "3.5.33",
+        "@vue/shared": "3.5.33",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
+      "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.33",
+        "@vue/shared": "3.5.33"
+      },
+      "peerDependencies": {
+        "vue": "3.5.33"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
+      "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/accepts": {
@@ -586,6 +1745,42 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.52.0.tgz",
+      "integrity": "sha512-0ZzY9mjqV7gop/AH8pIBiAS8giXP7WcSiUfoFYIzYAK9QC5c37E4SIVtJVBMwlURc0/uNt2o4RcNRvdHa4CJ5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/abtesting": "1.18.0",
+        "@algolia/client-abtesting": "5.52.0",
+        "@algolia/client-analytics": "5.52.0",
+        "@algolia/client-common": "5.52.0",
+        "@algolia/client-insights": "5.52.0",
+        "@algolia/client-personalization": "5.52.0",
+        "@algolia/client-query-suggestions": "5.52.0",
+        "@algolia/client-search": "5.52.0",
+        "@algolia/ingestion": "1.52.0",
+        "@algolia/monitoring": "1.52.0",
+        "@algolia/recommend": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/body-parser": {
@@ -650,6 +1845,50 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
@@ -690,6 +1929,22 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -721,6 +1976,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -747,6 +2009,30 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -767,6 +2053,13 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -774,6 +2067,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -852,6 +2158,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/etag": {
@@ -1030,6 +2343,16 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1158,6 +2481,44 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hono": {
       "version": "4.12.14",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
@@ -1165,6 +2526,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/http-errors": {
@@ -1233,6 +2612,19 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1260,6 +2652,23 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1267,6 +2676,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/media-typer": {
@@ -1289,6 +2720,100 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
@@ -1315,11 +2840,44 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -1372,6 +2930,18 @@
         "wrappy": "1"
       }
     },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1415,6 +2985,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -1422,6 +3006,57 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/proxy-addr": {
@@ -1476,6 +3111,33 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -1493,6 +3155,58 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/router": {
@@ -1516,6 +3230,14 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -1587,6 +3309,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/side-channel": {
@@ -1661,6 +3400,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1668,6 +3438,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strnum": {
@@ -1682,6 +3467,26 @@
       ],
       "license": "MIT"
     },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1689,6 +3494,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/tsx": {
@@ -1746,6 +3562,79 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1762,6 +3651,590 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
+      "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/compiler-sfc": "3.5.33",
+        "@vue/runtime-dom": "3.5.33",
+        "@vue/server-renderer": "3.5.33",
+        "@vue/shared": "3.5.33"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/which": {
@@ -1801,6 +4274,17 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "build": "tsc",
+    "docs:dev": "vitepress dev docs",
+    "docs:build": "vitepress build docs",
+    "docs:preview": "vitepress preview docs",
     "test": "npm run build && node --test test/*.test.mjs",
     "test:coverage": "npm run build && node --test --experimental-test-coverage test/*.test.mjs",
     "prepublishOnly": "npm run build",
@@ -45,7 +48,8 @@
   "devDependencies": {
     "@types/node": "^22.19.17",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitepress": "^1.6.4"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Summary

Addresses VCFO-003 by adding a VitePress documentation site and GitHub Pages deployment workflow.

## Changes

- Add VitePress docs under `docs/` with guide pages, tool reference, resources/prompts reference, how-tos, artifact lifecycle, workflow authoring, safety, troubleshooting, and contributor guidance.
- Add `docs:dev`, `docs:build`, and `docs:preview` scripts plus the `vitepress` dev dependency.
- Add a GitHub Pages workflow that builds `docs/.vitepress/dist` and deploys it with Pages actions.
- Replace the root README with a concise landing page linking to the full docs site and local docs entry point.
- Ignore generated VitePress cache and dist output.

## Validation

- `npm run docs:build`
- `npm test` passed: 111 tests green.

## Notes

After merge, repository Pages should be configured with **Build and deployment → Source: GitHub Actions**.