### PR TITLE
feat: add context snapshot tool for reusable VCFA/vRO context collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Useful optional variables:
 | `VCFA_WORKFLOW_DIR` | Override workflow artifact directory. |
 | `VCFA_ACTION_DIR` | Override action artifact directory. |
 | `VCFA_CONFIGURATION_DIR` | Override configuration artifact directory. |
+| `VCFA_CONTEXT_DIR` | Override persisted context snapshot directory. |
 
 ## Tool Coverage
 
@@ -78,6 +79,7 @@ The server includes tools for:
 - Cloud Assembly blueprint templates
 - Event topics and extensibility subscriptions
 - Artifact promotion planning
+- Persisted Markdown/JSON context snapshots for future agents
 - MCP resources and prompts for discovery-first implementation work
 
 See the [tool reference](docs/reference/tools.md) for the full list.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -30,6 +30,7 @@ It uses the returned bearer token for later VCF Automation, Service Broker, Clou
 | `VCFA_WORKFLOW_DIR` | Override the workflow artifact directory. |
 | `VCFA_ACTION_DIR` | Override the action artifact directory. |
 | `VCFA_CONFIGURATION_DIR` | Override the configuration artifact directory. |
+| `VCFA_CONTEXT_DIR` | Override the persisted context snapshot directory. |
 
 ## Artifact Directories
 
@@ -39,6 +40,7 @@ When `VCFA_ARTIFACT_DIR` is set, artifacts are organized into typed subdirectori
 VCFA_ARTIFACT_DIR/
   actions/
   configurations/
+  context/
   packages/
   resources/
   workflows/

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -23,6 +23,18 @@ The safest workflow is discovery first:
 4. Require explicit confirmation for destructive or live write operations.
 5. Verify changes with list/get/run tools after the operation completes.
 
+## Starting A New VCFA Project
+
+When starting in a new VCFA or vRO environment, use the server to map current state before drafting new automation:
+
+1. Configure `VCFA_HOST`, `VCFA_USERNAME`, `VCFA_ORGANIZATION`, and `VCFA_PASSWORD`. Set `VCFA_ARTIFACT_DIR` when local exports and generated artifacts should live in a project directory.
+2. Verify access with read-only discovery: `list-plugins`, `list-categories`, `list-workflows`, `list-actions`, `list-templates`, `list-catalog-items`, `list-event-topics`, and `list-subscriptions`.
+3. Inspect reusable candidates with `get-workflow`, `get-action`, `get-template`, or `get-catalog-item` before designing a replacement.
+4. Read the relevant MCP resources, especially `vcfa://docs/artifact-authoring`, `vcfa://schemas/workflow-scaffold`, and the matching `vcfa://patterns/*` resource.
+5. Export existing assets before changing them. Then scaffold or edit local artifacts, run preflight and diff tools, and import only after explicit confirmation.
+
+Use the built-in MCP prompts when the assistant should follow a known workflow rather than free-form instructions. For example, use `vcfa-discover-capabilities` to inventory an unfamiliar environment conversationally, `vcfa-collect-context-snapshot` to persist reusable Markdown/JSON inventory with `collect-context-snapshot`, `vcfa-discovery-first-implementation-plan` to plan a change, `vcfa-build-workflow-from-action` to wrap a verified action, and `vcfa-review-artifact-import` before importing a local artifact. See [Resources And Prompts](../reference/resources-prompts.md) for prompt arguments and examples.
+
 ## Documentation Map
 
 - [Installation](./installation.md) covers npm and source setup.

--- a/docs/reference/resources-prompts.md
+++ b/docs/reference/resources-prompts.md
@@ -27,6 +27,7 @@ The server exposes MCP resources for documentation, artifact patterns, and live 
 | `vcfa-review-artifact-import` | Review local artifacts before import. |
 | `vcfa-troubleshoot-deployment` | Inspect a deployment and guide safe remediation. |
 | `vcfa-discover-capabilities` | Discover reusable plugins, categories, actions, workflows, catalog items, and templates. |
+| `vcfa-collect-context-snapshot` | Persist reusable Markdown/JSON VCFA/vRO context for future agents. |
 | `vcfa-build-workflow-from-action` | Discover an existing action and scaffold a verified workflow wrapper. |
 | `vcfa-refactor-workflow` | Inspect, export, preflight, and safely plan workflow refactors. |
 | `vcfa-create-template` | Discover templates and create blueprint templates safely. |
@@ -34,6 +35,77 @@ The server exposes MCP resources for documentation, artifact patterns, and live 
 | `vcfa-integrate-workflow-template-subscription` | Plan workflow, template, catalog, deployment, and subscription integration. |
 | `vcfa-discovery-first-implementation-plan` | Produce a phased plan that starts with verified read-only discovery. |
 
+Use prompts when you want the client assistant to follow one of the server's discovery-first playbooks. Prompts are most useful at the start of a task, before tool calls or artifact edits, because they tell the assistant which read-only discovery calls, resources, preflight checks, confirmation points, and verification steps belong in the workflow.
+
+Use `vcfa-discover-capabilities` for exploratory conversational discovery. Use `vcfa-collect-context-snapshot` when that discovery should be persisted as reusable Markdown and JSON inventory for future agents.
+
+## Prompt Examples
+
+Initial environment discovery:
+
+```text
+Use prompt vcfa-discover-capabilities with:
+goal: "Map reusable VM provisioning workflows, actions, templates, catalog items, and subscriptions."
+```
+
+Persist reusable context:
+
+```text
+Use prompt vcfa-collect-context-snapshot with:
+goal: "Persist reusable VM provisioning context before implementation work."
+includeOptionalDomains: true
+```
+
+Discovery-first implementation planning:
+
+```text
+Use prompt vcfa-discovery-first-implementation-plan with:
+goal: "Create a workflow that lists VMs by project name."
+artifactKinds: "workflows and actions"
+```
+
+Author a new workflow:
+
+```text
+Use prompt vcfa-author-workflow with:
+goal: "Build a workflow that accepts a project name and returns matching VM names."
+categoryHint: "VCFA"
+```
+
+Wrap an existing action:
+
+```text
+Use prompt vcfa-build-workflow-from-action with:
+actionHint: "getAllMachines"
+workflowGoal: "Expose machine inventory lookup as a workflow."
+categoryHint: "VCFA"
+```
+
+Review before import:
+
+```text
+Use prompt vcfa-review-artifact-import with:
+artifactKind: "workflow"
+fileName: "list-vms-by-project.workflow"
+```
+
+Template work:
+
+```text
+Use prompt vcfa-create-template with:
+templateGoal: "Small Ubuntu VM blueprint aligned with existing catalog conventions."
+projectHint: "Development"
+```
+
+Subscription or integration planning:
+
+```text
+Use prompt vcfa-integrate-workflow-template-subscription with:
+integrationGoal: "Run a tagging workflow after deployment creation."
+workflowHint: "Tag VM"
+templateHint: "Ubuntu"
+```
+
 ## Discovery Guardrail
 
-Workflow and template implementation prompts tell agents to stop when required environment details are missing. Agents should report missing workflows, actions, categories, projects, parameters, return types, IDs, or blueprint schema details instead of inventing plausible values.
+Workflow and template implementation prompts tell agents to stop when required environment details are missing. Agents should report missing workflows, actions, categories, projects, parameters, return types, IDs, or blueprint schema details instead of inventing plausible values. When action discovery is required, `list-actions` must produce an exact candidate and `get-action` must verify the contract; no match, partial data, or ambiguous action data means the agent should stop and ask for the missing details instead of inventing parameter names or return types.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -2,6 +2,12 @@
 
 Tools are grouped by operating domain. Read-only tools are safe for discovery; write and delete tools can modify live VCFA/vRO state or local artifact files.
 
+## Context Snapshots
+
+| Tool | Purpose |
+| --- | --- |
+| `collect-context-snapshot` | Collect reusable VCFA/vRO context and persist deterministic Markdown and JSON snapshots without dumping secrets, scripts, template YAML, or binary content. |
+
 ## Artifact Promotion
 
 | Tool | Purpose |

--- a/src/client/context-snapshot.ts
+++ b/src/client/context-snapshot.ts
@@ -1,0 +1,670 @@
+import { createHash } from "node:crypto";
+import { writeFile } from "node:fs/promises";
+import { basename, isAbsolute } from "node:path";
+import type {
+  Action,
+  CatalogItem,
+  Category,
+  ConfigAttribute,
+  ConfigElement,
+  EventTopic,
+  ResourceElement,
+  Subscription,
+  Template,
+  VroPackage,
+  VroParameter,
+  VroPlugin,
+  Workflow,
+} from "../types.js";
+import { getExistingFile, resolveFileInDirectory } from "./files.js";
+
+const CORE_DOMAINS = [
+  "workflows",
+  "actions",
+  "configurations",
+  "resources",
+  "categories",
+] as const;
+
+const OPTIONAL_DOMAINS = [
+  "templates",
+  "catalogItems",
+  "eventTopics",
+  "subscriptions",
+  "packages",
+  "plugins",
+] as const;
+
+const CATEGORY_TYPES = [
+  "WorkflowCategory",
+  "ActionCategory",
+  "ConfigurationElementCategory",
+  "ResourceElementCategory",
+] as const;
+
+export type ContextSnapshotDomain =
+  | (typeof CORE_DOMAINS)[number]
+  | (typeof OPTIONAL_DOMAINS)[number];
+
+export interface CollectContextSnapshotParams {
+  fileBaseName?: string;
+  overwrite?: boolean;
+  domains?: ContextSnapshotDomain[];
+  includeOptionalDomains?: boolean;
+  maxItemsPerDomain?: number;
+}
+
+export interface CollectContextSnapshotResult {
+  jsonPath: string;
+  markdownPath: string;
+  counts: Record<string, number>;
+  skipped: Record<string, number>;
+  warnings: string[];
+}
+
+export interface ContextSnapshotClient {
+  getContextDirectory(): string;
+  listWorkflows(filter?: string): Promise<{ link: Workflow[]; total?: number }>;
+  getWorkflow(id: string): Promise<Workflow>;
+  listActions(filter?: string): Promise<{ link: Action[]; total?: number }>;
+  getAction(id: string): Promise<Action>;
+  listConfigurations(filter?: string): Promise<{
+    link: ConfigElement[];
+    total?: number;
+  }>;
+  getConfiguration(id: string): Promise<ConfigElement>;
+  listResources(filter?: string): Promise<{
+    link: ResourceElement[];
+    total?: number;
+  }>;
+  listCategories(
+    categoryType: string,
+    filter?: string,
+  ): Promise<{ link: Category[]; total?: number }>;
+  listTemplates(search?: string, projectId?: string): Promise<{
+    content: Template[];
+    totalElements?: number;
+  }>;
+  getTemplate(id: string): Promise<Template>;
+  listCatalogItems(search?: string): Promise<{
+    content: CatalogItem[];
+    totalElements?: number;
+  }>;
+  getCatalogItem(id: string): Promise<CatalogItem>;
+  listEventTopics(): Promise<{ content: EventTopic[]; totalElements?: number }>;
+  listSubscriptions(projectId?: string): Promise<{
+    content: Subscription[];
+    totalElements?: number;
+  }>;
+  listPackages(filter?: string): Promise<{ link: VroPackage[]; total?: number }>;
+  getPackage(name: string): Promise<VroPackage>;
+  listPlugins(filter?: string): Promise<{ link: VroPlugin[]; total?: number }>;
+}
+
+interface DomainStats {
+  count: number;
+  skipped: number;
+}
+
+type SnapshotSection = unknown[] | Record<string, unknown[]>;
+
+interface ContextSnapshot {
+  schemaVersion: 1;
+  domains: ContextSnapshotDomain[];
+  limits: { maxItemsPerDomain: number };
+  warnings: string[];
+  counts: Record<string, number>;
+  skipped: Record<string, number>;
+  data: Record<string, SnapshotSection>;
+}
+
+export async function collectContextSnapshot(
+  client: ContextSnapshotClient,
+  params: CollectContextSnapshotParams = {},
+): Promise<CollectContextSnapshotResult> {
+  const fileBaseName = params.fileBaseName ?? "vcfa-context";
+  validateFileBaseName(fileBaseName);
+  const maxItemsPerDomain = normalizeLimit(params.maxItemsPerDomain);
+  const domains = resolveDomains(params.domains, params.includeOptionalDomains);
+  const warnings: string[] = [];
+  const counts: Record<string, number> = {};
+  const skipped: Record<string, number> = {};
+  const data: Record<string, SnapshotSection> = {};
+
+  const snapshot: ContextSnapshot = {
+    schemaVersion: 1,
+    domains,
+    limits: { maxItemsPerDomain },
+    warnings,
+    counts,
+    skipped,
+    data,
+  };
+
+  for (const domain of domains) {
+    const result = await collectDomain(client, domain, maxItemsPerDomain, warnings);
+    data[domain] = result.data;
+    counts[domain] = result.stats.count;
+    skipped[domain] = result.stats.skipped;
+  }
+
+  const jsonPath = await resolveSnapshotPath(client, `${fileBaseName}.json`);
+  const markdownPath = await resolveSnapshotPath(client, `${fileBaseName}.md`);
+  await ensureWritable(jsonPath, `${fileBaseName}.json`, params.overwrite);
+  await ensureWritable(markdownPath, `${fileBaseName}.md`, params.overwrite);
+
+  await writeFile(jsonPath, `${JSON.stringify(snapshot, null, 2)}\n`, {
+    flag: params.overwrite ? "w" : "wx",
+  });
+  await writeFile(markdownPath, renderMarkdown(snapshot), {
+    flag: params.overwrite ? "w" : "wx",
+  });
+
+  return { jsonPath, markdownPath, counts, skipped, warnings };
+}
+
+async function collectDomain(
+  client: ContextSnapshotClient,
+  domain: ContextSnapshotDomain,
+  maxItems: number,
+  warnings: string[],
+): Promise<{ data: SnapshotSection; stats: DomainStats }> {
+  switch (domain) {
+    case "workflows":
+      return collectListWithDetails(
+        "workflows",
+        () => client.listWorkflows(),
+        (item) => item.id,
+        (id) => client.getWorkflow(id),
+        summarizeWorkflow,
+        maxItems,
+        warnings,
+      );
+    case "actions":
+      return collectListWithDetails(
+        "actions",
+        () => client.listActions(),
+        (item) => item.id || item.fqn,
+        (id) => client.getAction(id),
+        summarizeAction,
+        maxItems,
+        warnings,
+      );
+    case "configurations":
+      return collectListWithDetails(
+        "configurations",
+        () => client.listConfigurations(),
+        (item) => item.id,
+        (id) => client.getConfiguration(id),
+        summarizeConfiguration,
+        maxItems,
+        warnings,
+      );
+    case "resources": {
+      const list = await client.listResources();
+      const items = sortByNameAndId(list.link ?? []).slice(0, maxItems);
+      return {
+        data: items.map(summarizeResource),
+        stats: boundedStats(list.link ?? [], maxItems),
+      };
+    }
+    case "categories":
+      return collectCategories(client, maxItems, warnings);
+    case "templates":
+      return collectListWithDetails(
+        "templates",
+        () => client.listTemplates(),
+        (item) => item.id,
+        (id) => client.getTemplate(id),
+        summarizeTemplate,
+        maxItems,
+        warnings,
+        "content",
+      );
+    case "catalogItems":
+      return collectListWithDetails(
+        "catalogItems",
+        () => client.listCatalogItems(),
+        (item) => item.id,
+        (id) => client.getCatalogItem(id),
+        summarizeCatalogItem,
+        maxItems,
+        warnings,
+        "content",
+      );
+    case "eventTopics": {
+      const list = await client.listEventTopics();
+      const items = sortByNameAndId(list.content ?? []).slice(0, maxItems);
+      return {
+        data: items.map(summarizeEventTopic),
+        stats: boundedStats(list.content ?? [], maxItems),
+      };
+    }
+    case "subscriptions": {
+      const list = await client.listSubscriptions();
+      const items = sortByNameAndId(list.content ?? []).slice(0, maxItems);
+      return {
+        data: items.map(summarizeSubscription),
+        stats: boundedStats(list.content ?? [], maxItems),
+      };
+    }
+    case "packages":
+      return collectListWithDetails(
+        "packages",
+        () => client.listPackages(),
+        (item) => item.name,
+        (name) => client.getPackage(name),
+        summarizePackage,
+        maxItems,
+        warnings,
+      );
+    case "plugins": {
+      const list = await client.listPlugins();
+      const items = sortByNameAndId(list.link ?? []).slice(0, maxItems);
+      return {
+        data: items.map(summarizePlugin),
+        stats: boundedStats(list.link ?? [], maxItems),
+      };
+    }
+  }
+}
+
+async function collectListWithDetails<TListItem, TDetail>(
+  domain: string,
+  listFn: () => Promise<{ link?: TListItem[]; content?: TListItem[] }>,
+  idFn: (item: TListItem) => string | undefined,
+  detailFn: (id: string) => Promise<TDetail>,
+  summarize: (item: TDetail | TListItem) => unknown,
+  maxItems: number,
+  warnings: string[],
+  listField: "link" | "content" = "link",
+): Promise<{ data: unknown[]; stats: DomainStats }> {
+  const list = await listFn();
+  const rawItems = (list[listField] ?? []) as TListItem[];
+  const items = sortByNameAndId(rawItems).slice(0, maxItems);
+  const data: unknown[] = [];
+  for (const item of items) {
+    const id = idFn(item);
+    if (!id) {
+      warnings.push(`${domain}: skipped item without an ID or name`);
+      data.push(summarize(item));
+      continue;
+    }
+    try {
+      data.push(summarize(await detailFn(id)));
+    } catch (error) {
+      warnings.push(
+        `${domain}: detail lookup failed for ${id}: ${formatError(error)}`,
+      );
+      data.push(summarize(item));
+    }
+  }
+  return { data, stats: boundedStats(rawItems, maxItems) };
+}
+
+async function collectCategories(
+  client: ContextSnapshotClient,
+  maxItems: number,
+  warnings: string[],
+): Promise<{ data: Record<string, unknown[]>; stats: DomainStats }> {
+  const data: Record<string, unknown[]> = {};
+  let count = 0;
+  let skipped = 0;
+  for (const categoryType of CATEGORY_TYPES) {
+    try {
+      const list = await client.listCategories(categoryType);
+      const raw = list.link ?? [];
+      data[categoryType] = sortByNameAndId(raw)
+        .slice(0, maxItems)
+        .map(summarizeCategory);
+      count += Math.min(raw.length, maxItems);
+      skipped += Math.max(0, raw.length - maxItems);
+    } catch (error) {
+      warnings.push(
+        `categories: lookup failed for ${categoryType}: ${formatError(error)}`,
+      );
+      data[categoryType] = [];
+    }
+  }
+  return { data, stats: { count, skipped } };
+}
+
+function summarizeWorkflow(workflow: Workflow) {
+  return dropUndefined({
+    id: workflow.id,
+    name: workflow.name,
+    description: workflow.description,
+    version: workflow.version,
+    categoryId: workflow.categoryId,
+    categoryName: workflow.categoryName,
+    inputs: summarizeParameters(
+      workflow.inputParameters ?? workflow["input-parameters"],
+    ),
+    outputs: summarizeParameters(
+      workflow.outputParameters ?? workflow["output-parameters"],
+    ),
+  });
+}
+
+function summarizeAction(action: Action) {
+  return dropUndefined({
+    id: action.id,
+    fqn: action.fqn,
+    module: action.module,
+    name: action.name,
+    description: action.description,
+    version: action.version,
+    inputs: summarizeParameters(action["input-parameters"]),
+    returnType: action["output-type"],
+    script: contentMetadata(action.script),
+  });
+}
+
+function summarizeConfiguration(config: ConfigElement) {
+  return dropUndefined({
+    id: config.id,
+    name: config.name,
+    description: config.description,
+    version: config.version,
+    categoryId: config.categoryId,
+    attributes: (config.attributes ?? []).map(summarizeAttribute),
+  });
+}
+
+function summarizeResource(resource: ResourceElement) {
+  return dropUndefined({
+    id: resource.id,
+    name: resource.name,
+    description: resource.description,
+    version: resource.version,
+    categoryId: resource.categoryId,
+    categoryName: resource.categoryName,
+    mimeType: resource.mimeType,
+  });
+}
+
+function summarizeCategory(category: Category) {
+  return dropUndefined({
+    id: category.id,
+    name: category.name,
+    description: category.description,
+    type: category.type,
+    path: category.path,
+  });
+}
+
+function summarizeTemplate(template: Template) {
+  return dropUndefined({
+    id: template.id,
+    name: template.name,
+    description: template.description,
+    status: template.status,
+    projectId: template.projectId,
+    projectName: template.projectName,
+    requestScopeOrg: template.requestScopeOrg,
+    valid: template.valid,
+    content: contentMetadata(template.content),
+  });
+}
+
+function summarizeCatalogItem(item: CatalogItem) {
+  return dropUndefined({
+    id: item.id,
+    name: item.name,
+    description: item.description,
+    type: item.type,
+    sourceType: item.sourceType,
+    sourceName: item.sourceName,
+    sourceId: item.sourceId,
+    projectIds: item.projectIds,
+    requestScopeOrg: item.requestScopeOrg,
+  });
+}
+
+function summarizeEventTopic(topic: EventTopic) {
+  return dropUndefined({
+    id: topic.id,
+    name: topic.name,
+    description: topic.description,
+    blockable: topic.blockable,
+    schema: topic.schema
+      ? { included: false, sha256: hash(JSON.stringify(topic.schema)), length: JSON.stringify(topic.schema).length }
+      : undefined,
+  });
+}
+
+function summarizeSubscription(subscription: Subscription) {
+  return dropUndefined({
+    id: subscription.id,
+    name: subscription.name,
+    description: subscription.description,
+    type: subscription.type,
+    disabled: subscription.disabled,
+    eventTopicId: subscription.eventTopicId,
+    runnableType: subscription.runnableType,
+    runnableId: subscription.runnableId,
+    blocking: subscription.blocking,
+    priority: subscription.priority,
+    timeout: subscription.timeout,
+    projectId: subscription.projectId,
+  });
+}
+
+function summarizePackage(pkg: VroPackage) {
+  return dropUndefined({
+    name: pkg.name,
+    description: pkg.description,
+    version: pkg.version,
+  });
+}
+
+function summarizePlugin(plugin: VroPlugin) {
+  return dropUndefined({
+    name: plugin.name,
+    displayName: plugin.displayName,
+    description: plugin.description,
+    version: plugin.version,
+    type: plugin.type,
+  });
+}
+
+function summarizeAttribute(attribute: ConfigAttribute) {
+  return dropUndefined({
+    name: attribute.name,
+    type: attribute.type,
+    description: attribute.description,
+    value: attribute.value ? { included: false, redacted: true } : undefined,
+  });
+}
+
+function summarizeParameters(parameters?: VroParameter[]) {
+  return (parameters ?? []).map((parameter) =>
+    dropUndefined({
+      name: parameter.name,
+      type: parameter.type,
+      description: parameter.description,
+    }),
+  );
+}
+
+function contentMetadata(content?: string) {
+  if (content === undefined) return undefined;
+  return {
+    included: false,
+    sha256: hash(content),
+    length: content.length,
+  };
+}
+
+function renderMarkdown(snapshot: ContextSnapshot): string {
+  const lines = [
+    "# VCFA Context Snapshot",
+    "",
+    `Schema version: ${snapshot.schemaVersion}`,
+    `Domains: ${snapshot.domains.join(", ")}`,
+    `Max items per domain: ${snapshot.limits.maxItemsPerDomain}`,
+    "",
+  ];
+
+  if (snapshot.warnings.length > 0) {
+    lines.push("## Warnings", "");
+    lines.push(...snapshot.warnings.map((warning) => `- ${warning}`), "");
+  }
+
+  lines.push("## Summary", "");
+  for (const domain of snapshot.domains) {
+    lines.push(
+      `- ${domain}: ${snapshot.counts[domain] ?? 0} collected, ${snapshot.skipped[domain] ?? 0} skipped`,
+    );
+  }
+
+  for (const domain of snapshot.domains) {
+    lines.push("", `## ${title(domain)}`, "");
+    const section = snapshot.data[domain];
+    if (Array.isArray(section)) {
+      renderItemList(lines, section);
+    } else {
+      for (const [group, items] of Object.entries(section ?? {})) {
+        lines.push(`### ${group}`, "");
+        renderItemList(lines, items);
+        lines.push("");
+      }
+    }
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+function renderItemList(lines: string[], items: unknown[]): void {
+  if (items.length === 0) {
+    lines.push("_None._");
+    return;
+  }
+  for (const item of items) {
+    const record = item as Record<string, unknown>;
+    const label = String(record.name ?? record.fqn ?? record.id ?? "unnamed");
+    const id = record.id ? ` (${record.id})` : "";
+    lines.push(`- ${label}${id}`);
+    const details = Object.entries(record)
+      .filter(([key]) => !["id", "name"].includes(key))
+      .filter(([, value]) => value !== undefined && !isEmptyArray(value));
+    for (const [key, value] of details) {
+      lines.push(`  - ${key}: ${formatMarkdownValue(value)}`);
+    }
+  }
+}
+
+function formatMarkdownValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return `\`${JSON.stringify(value)}\``;
+}
+
+function validateFileBaseName(fileBaseName: string): void {
+  if (!fileBaseName.trim()) {
+    throw new Error("Context snapshot fileBaseName must not be empty");
+  }
+  if (
+    isAbsolute(fileBaseName) ||
+    fileBaseName !== basename(fileBaseName) ||
+    fileBaseName.includes("/") ||
+    fileBaseName.includes("\\")
+  ) {
+    throw new Error(
+      "Context snapshot fileBaseName must be a plain file name without path separators",
+    );
+  }
+  if (fileBaseName.endsWith(".json") || fileBaseName.endsWith(".md")) {
+    throw new Error("Context snapshot fileBaseName must not include an extension");
+  }
+}
+
+async function resolveSnapshotPath(
+  client: ContextSnapshotClient,
+  fileName: string,
+): Promise<string> {
+  return resolveFileInDirectory(
+    client.getContextDirectory(),
+    fileName,
+    "Context snapshot",
+    "the configured context directory",
+  );
+}
+
+async function ensureWritable(
+  path: string,
+  fileName: string,
+  overwrite?: boolean,
+): Promise<void> {
+  const existing = await getExistingFile(path);
+  if (existing?.isSymbolicLink()) {
+    throw new Error("Context snapshot export target must not be a symbolic link");
+  }
+  if (existing && !overwrite) {
+    throw new Error(
+      `Context snapshot file already exists: ${fileName}. Set overwrite to true to replace it.`,
+    );
+  }
+}
+
+function resolveDomains(
+  requested?: ContextSnapshotDomain[],
+  includeOptionalDomains?: boolean,
+): ContextSnapshotDomain[] {
+  const domains = requested?.length ? requested : [...CORE_DOMAINS];
+  const resolved = new Set<ContextSnapshotDomain>(domains);
+  if (includeOptionalDomains) {
+    for (const domain of OPTIONAL_DOMAINS) resolved.add(domain);
+  }
+  return [...resolved].sort();
+}
+
+function normalizeLimit(limit?: number): number {
+  if (limit === undefined) return 100;
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new Error("maxItemsPerDomain must be a positive integer");
+  }
+  return limit;
+}
+
+function boundedStats(items: unknown[], maxItems: number): DomainStats {
+  return {
+    count: Math.min(items.length, maxItems),
+    skipped: Math.max(0, items.length - maxItems),
+  };
+}
+
+function sortByNameAndId<T>(items: T[]): T[] {
+  return [...items].sort((a, b) => {
+    const left = sortKey(a);
+    const right = sortKey(b);
+    return left.localeCompare(right);
+  });
+}
+
+function sortKey(value: unknown): string {
+  const record = value as Record<string, unknown>;
+  return String(record.name ?? record.fqn ?? record.id ?? "").toLowerCase();
+}
+
+function dropUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, item]) => item !== undefined),
+  ) as T;
+}
+
+function hash(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function title(value: string): string {
+  return value.replace(/([A-Z])/g, " $1").replace(/^./, (char) => char.toUpperCase());
+}
+
+function isEmptyArray(value: unknown): boolean {
+  return Array.isArray(value) && value.length === 0;
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -17,6 +17,7 @@ export class VroHttpClient {
   readonly workflowDir: string;
   readonly actionDir: string;
   readonly configurationDir: string;
+  readonly contextDir: string;
 
   private sessionUrl: string;
   private loginHeader: string;
@@ -48,6 +49,7 @@ export class VroHttpClient {
     this.configurationDir = resolve(
       config.configurationDir ?? join(artifactDir, "configurations"),
     );
+    this.contextDir = resolve(config.contextDir ?? join(artifactDir, "context"));
     this.loginHeader =
       "Basic " +
       Buffer.from(

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -40,6 +40,11 @@ import { ActionClient } from "./action-client.js";
 import { CatalogClient } from "./catalog-client.js";
 import { CategoryClient } from "./category-client.js";
 import { ConfigurationClient } from "./configuration-client.js";
+import {
+  collectContextSnapshot,
+  type CollectContextSnapshotParams,
+  type CollectContextSnapshotResult,
+} from "./context-snapshot.js";
 import { VroHttpClient } from "./core.js";
 import { DeploymentClient } from "./deployment-client.js";
 import { PackageClient } from "./package-client.js";
@@ -56,6 +61,7 @@ import { WorkflowClient } from "./workflow-client.js";
  * `VroClient` from `vro-client.js` and calling `client.method(...)`.
  */
 export class VroClient {
+  private http: VroHttpClient;
   private workflows: WorkflowClient;
   private actions: ActionClient;
   private configurations: ConfigurationClient;
@@ -70,6 +76,7 @@ export class VroClient {
 
   constructor(config: VroClientConfig) {
     const http = new VroHttpClient(config);
+    this.http = http;
     this.workflows = new WorkflowClient(http);
     this.actions = new ActionClient(http);
     this.configurations = new ConfigurationClient(http);
@@ -389,6 +396,16 @@ export class VroClient {
 
   getConfigurationDirectory(): string {
     return this.configurations.getConfigurationDirectory();
+  }
+
+  getContextDirectory(): string {
+    return this.http.contextDir;
+  }
+
+  collectContextSnapshot(
+    params: CollectContextSnapshotParams,
+  ): Promise<CollectContextSnapshotResult> {
+    return collectContextSnapshot(this, params);
   }
 
   exportConfigurationFile(

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { registerActionTools } from "./tools/action-tools.js";
 import { registerCatalogTools } from "./tools/catalog-tools.js";
 import { registerCategoryTools } from "./tools/category-tools.js";
 import { registerConfigTools } from "./tools/config-tools.js";
+import { registerContextTools } from "./tools/context-tools.js";
 import { registerDeploymentTools } from "./tools/deployment-tools.js";
 import { registerPackageTools } from "./tools/package-tools.js";
 import { registerPluginTools } from "./tools/plugin-tools.js";
@@ -40,6 +41,7 @@ async function main(): Promise<void> {
   const workflowDir = process.env["VCFA_WORKFLOW_DIR"];
   const actionDir = process.env["VCFA_ACTION_DIR"];
   const configurationDir = process.env["VCFA_CONFIGURATION_DIR"];
+  const contextDir = process.env["VCFA_CONTEXT_DIR"];
 
   if (ignoreTls) {
     process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = "0";
@@ -61,6 +63,7 @@ async function main(): Promise<void> {
     workflowDir,
     actionDir,
     configurationDir,
+    contextDir,
   });
 
   // Create MCP server
@@ -77,6 +80,7 @@ async function main(): Promise<void> {
         "Use scaffold-workflow-file to generate a local .workflow artifact from structured workflow metadata and linear scriptable tasks before importing it.",
         "Use preflight-workflow-file, preflight-action-file, preflight-configuration-file, and preflight-package to validate local artifacts before importing them.",
         "Use prepare-artifact-promotion before artifact imports when you need preflight, optional live backup export, workflow/action diff summaries, and the exact confirmed import call; it never imports.",
+        "Use collect-context-snapshot to persist reusable Markdown and JSON summaries of workflows, actions, configurations, resources, categories, and optional VCFA domains for future agents.",
         "Use export-action-file to save an action artifact under the configured action artifact directory; use import-action-file to upload a .action artifact from that directory into an action category by category name.",
         "Use export-configuration-file to save a configuration artifact under the configured configuration artifact directory; use import-configuration-file to upload a .vsoconf artifact from that directory into a configuration category.",
         "Use list-event-topics to discover available event topics before creating extensibility subscriptions.",
@@ -102,6 +106,7 @@ async function main(): Promise<void> {
   registerTemplateTools(server, client);
   registerPackageTools(server, client);
   registerPromotionTools(server, client);
+  registerContextTools(server, client);
   registerResourceTools(server, client);
   registerPluginTools(server, client);
   registerVcfaResources(server, client);

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -17,6 +17,7 @@ function promptResult(description: string, text: string): GetPromptResult {
 function discoveryGuardrails(): string[] {
   return [
     "Discovery guardrail: if a required workflow, action, template, category, project, parameter, or return type is not found, stop and report the missing fact. Do not invent IDs, parameter names, types, schemas, or provider-specific YAML.",
+    "When action discovery is required, list-actions must produce an exact candidate and get-action must verify its contract. If list-actions returns no match or only partial/ambiguous action data, stop and ask for the missing action details instead of inventing parameter names or return types.",
     "Prefer reading vcfa://docs/artifact-authoring and the relevant vcfa://patterns/* or vcfa://schemas/* resource before drafting artifacts.",
   ];
 }
@@ -127,6 +128,42 @@ export function registerVcfaPrompts(server: McpServer): void {
           ...discoveryGuardrails(),
           "Summarize what already exists, what can be reused, and what gaps remain.",
           "Prefer concrete next tool calls and avoid creating or importing artifacts during discovery.",
+        ].join("\n"),
+      ),
+  );
+
+  server.registerPrompt(
+    "vcfa-collect-context-snapshot",
+    {
+      title: "Collect Context Snapshot",
+      description:
+        "Collect and persist reusable VCFA/vRO context for future agents.",
+      argsSchema: {
+        goal: z
+          .string()
+          .optional()
+          .describe("Optional project or implementation goal for the snapshot"),
+        includeOptionalDomains: z
+          .boolean()
+          .optional()
+          .describe(
+            "Whether to include templates, catalog items, event topics, subscriptions, packages, and plugins",
+          ),
+      },
+    },
+    ({ goal, includeOptionalDomains }) =>
+      promptResult(
+        "Collect reusable VCFA/vRO context.",
+        [
+          goal ? `Goal: ${goal}` : "Goal: create reusable VCFA/vRO context.",
+          `Include optional domains: ${includeOptionalDomains === true ? "yes" : "no"}`,
+          "",
+          "Use collect-context-snapshot before major workflow, action, template, or subscription work in an unfamiliar environment.",
+          "Use vcfa-discover-capabilities for exploratory conversational discovery; use collect-context-snapshot when the inventory should be persisted for future agents.",
+          "Persist both Markdown and JSON so humans and agents can reuse the same snapshot before rediscovering assets.",
+          ...discoveryGuardrails(),
+          "Do not ask the user to provide workflow, action, parameter, category, project, or template details that can be discovered by the snapshot tool.",
+          "After the snapshot is written, summarize the saved paths, collected counts, skipped counts, and any warnings.",
         ].join("\n"),
       ),
   );

--- a/src/tools/context-tools.ts
+++ b/src/tools/context-tools.ts
@@ -1,0 +1,99 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import type { VroClient } from "../vro-client.js";
+
+const contextDomainSchema = z.enum([
+  "workflows",
+  "actions",
+  "configurations",
+  "resources",
+  "categories",
+  "templates",
+  "catalogItems",
+  "eventTopics",
+  "subscriptions",
+  "packages",
+  "plugins",
+]);
+
+export function registerContextTools(
+  server: McpServer,
+  client: VroClient,
+): void {
+  server.registerTool(
+    "collect-context-snapshot",
+    {
+      title: "Collect Context Snapshot",
+      description:
+        "Collect reusable VCF Automation/vRO environment context and persist deterministic Markdown and JSON snapshots for future agents. Secrets, scripts, template YAML, and binary content are omitted by default.",
+      inputSchema: z.object({
+        fileBaseName: z
+          .string()
+          .optional()
+          .describe(
+            "Base file name for the generated .json and .md files under the configured context directory. Defaults to vcfa-context.",
+          ),
+        overwrite: z
+          .boolean()
+          .optional()
+          .describe("Overwrite existing snapshot files. Defaults to false."),
+        domains: z
+          .array(contextDomainSchema)
+          .optional()
+          .describe(
+            "Domains to collect. Defaults to workflows, actions, configurations, resources, and categories.",
+          ),
+        includeOptionalDomains: z
+          .boolean()
+          .optional()
+          .describe(
+            "Also collect templates, catalog items, event topics, subscriptions, packages, and plugins.",
+          ),
+        maxItemsPerDomain: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Maximum items to collect per domain. Defaults to 100."),
+      }),
+      annotations: { readOnlyHint: true },
+    },
+    async (params): Promise<CallToolResult> => {
+      try {
+        const result = await client.collectContextSnapshot(params);
+        const warnings =
+          result.warnings.length > 0
+            ? `\nWarnings:\n${result.warnings.map((warning) => `  • ${warning}`).join("\n")}`
+            : "";
+        return {
+          content: [
+            {
+              type: "text",
+              text: [
+                "Context snapshot collected.",
+                `JSON: ${result.jsonPath}`,
+                `Markdown: ${result.markdownPath}`,
+                `Counts: ${JSON.stringify(result.counts)}`,
+                `Skipped: ${JSON.stringify(result.skipped)}`,
+                warnings,
+              ]
+                .filter(Boolean)
+                .join("\n"),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to collect context snapshot: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -505,4 +505,5 @@ export interface VroClientConfig {
   workflowDir?: string;
   actionDir?: string;
   configurationDir?: string;
+  contextDir?: string;
 }

--- a/test/context-snapshot.test.mjs
+++ b/test/context-snapshot.test.mjs
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { collectContextSnapshot } from "../dist/client/context-snapshot.js";
+import { registerContextTools } from "../dist/tools/context-tools.js";
+
+function baseClient(contextDir) {
+  return {
+    getContextDirectory: () => contextDir,
+    listWorkflows: async () => ({
+      link: [
+        { id: "workflow-2", name: "Z Workflow" },
+        { id: "workflow-1", name: "A Workflow" },
+      ],
+    }),
+    getWorkflow: async (id) => ({
+      id,
+      name: id === "workflow-1" ? "A Workflow" : "Z Workflow",
+      description: "Workflow description",
+      version: "1.0.0",
+      categoryName: "VCFA",
+      inputParameters: [{ name: "projectName", type: "string" }],
+      outputParameters: [{ name: "vmNames", type: "Array/string" }],
+    }),
+    listActions: async () => ({
+      link: [
+        {
+          id: "action-1",
+          name: "getVmIp",
+          module: "com.example",
+          fqn: "com.example.getVmIp",
+        },
+      ],
+    }),
+    getAction: async (id) => ({
+      id,
+      name: "getVmIp",
+      module: "com.example",
+      fqn: "com.example.getVmIp",
+      "input-parameters": [{ name: "vm", type: "VC:VirtualMachine" }],
+      "output-type": "string",
+      script: "return vm.ipAddress;",
+    }),
+    listConfigurations: async () => ({
+      link: [{ id: "config-1", name: "Settings" }],
+    }),
+    getConfiguration: async (id) => ({
+      id,
+      name: "Settings",
+      attributes: [
+        {
+          name: "apiToken",
+          type: "SecureString",
+          value: { string: { value: "secret-token" } },
+          description: "Token",
+        },
+      ],
+    }),
+    listResources: async () => ({
+      link: [{ id: "resource-1", name: "logo", mimeType: "image/png" }],
+    }),
+    listCategories: async (categoryType) => ({
+      link: [
+        {
+          id: `${categoryType}-1`,
+          name: categoryType,
+          type: categoryType,
+          path: `/${categoryType}`,
+        },
+      ],
+    }),
+    listTemplates: async () => ({ content: [{ id: "template-1", name: "Ubuntu" }] }),
+    getTemplate: async (id) => ({
+      id,
+      name: "Ubuntu",
+      content: "formatVersion: 1\nresources: {}",
+      projectId: "project-1",
+    }),
+    listCatalogItems: async () => ({
+      content: [{ id: "catalog-1", name: "Small VM" }],
+    }),
+    getCatalogItem: async (id) => ({ id, name: "Small VM", sourceName: "Ubuntu" }),
+    listEventTopics: async () => ({
+      content: [{ id: "topic-1", name: "Deployment requested", schema: { secret: "shape" } }],
+    }),
+    listSubscriptions: async () => ({
+      content: [{ id: "sub-1", name: "Tag VM", runnableId: "workflow-1" }],
+    }),
+    listPackages: async () => ({ link: [{ name: "com.example.package" }] }),
+    getPackage: async (name) => ({ name, version: "1.0.0" }),
+    listPlugins: async () => ({ link: [{ name: "vra", version: "1.0.0" }] }),
+  };
+}
+
+test("collectContextSnapshot writes deterministic JSON and Markdown with redaction", async () => {
+  const contextDir = await mkdtemp(join(tmpdir(), "vcfa-context-"));
+  try {
+    const result = await collectContextSnapshot(baseClient(contextDir), {
+      fileBaseName: "snapshot",
+      overwrite: true,
+    });
+
+    assert.equal(result.counts.workflows, 2);
+    assert.equal(result.skipped.workflows, 0);
+    const json = JSON.parse(await readFile(result.jsonPath, "utf8"));
+    const markdown = await readFile(result.markdownPath, "utf8");
+
+    assert.deepEqual(json.domains, [
+      "actions",
+      "categories",
+      "configurations",
+      "resources",
+      "workflows",
+    ]);
+    assert.equal(json.data.workflows[0].name, "A Workflow");
+    assert.equal(json.data.actions[0].script.included, false);
+    assert.equal(json.data.actions[0].script.length, "return vm.ipAddress;".length);
+    assert.match(json.data.actions[0].script.sha256, /^[0-9a-f]{64}$/);
+    assert.equal(json.data.configurations[0].attributes[0].value.redacted, true);
+    assert.doesNotMatch(JSON.stringify(json), /secret-token/);
+    assert.match(markdown, /# VCFA Context Snapshot/);
+    assert.match(markdown, /A Workflow/);
+  } finally {
+    await rm(contextDir, { recursive: true, force: true });
+  }
+});
+
+test("collectContextSnapshot bounds domains and records skipped counts", async () => {
+  const contextDir = await mkdtemp(join(tmpdir(), "vcfa-context-"));
+  try {
+    const result = await collectContextSnapshot(baseClient(contextDir), {
+      fileBaseName: "limited",
+      domains: ["workflows"],
+      maxItemsPerDomain: 1,
+    });
+    const json = JSON.parse(await readFile(result.jsonPath, "utf8"));
+    assert.equal(result.counts.workflows, 1);
+    assert.equal(result.skipped.workflows, 1);
+    assert.equal(json.data.workflows.length, 1);
+    assert.equal(json.data.workflows[0].name, "A Workflow");
+  } finally {
+    await rm(contextDir, { recursive: true, force: true });
+  }
+});
+
+test("collectContextSnapshot includes optional domains when requested", async () => {
+  const contextDir = await mkdtemp(join(tmpdir(), "vcfa-context-"));
+  try {
+    const result = await collectContextSnapshot(baseClient(contextDir), {
+      fileBaseName: "optional",
+      domains: ["workflows"],
+      includeOptionalDomains: true,
+    });
+    const json = JSON.parse(await readFile(result.jsonPath, "utf8"));
+    assert.equal(result.counts.templates, 1);
+    assert.equal(json.data.templates[0].content.included, false);
+    assert.match(json.data.templates[0].content.sha256, /^[0-9a-f]{64}$/);
+    assert.equal(result.counts.catalogItems, 1);
+    assert.equal(result.counts.plugins, 1);
+  } finally {
+    await rm(contextDir, { recursive: true, force: true });
+  }
+});
+
+test("collectContextSnapshot rejects unsafe names and existing files", async () => {
+  const contextDir = await mkdtemp(join(tmpdir(), "vcfa-context-"));
+  try {
+    await assert.rejects(
+      collectContextSnapshot(baseClient(contextDir), {
+        fileBaseName: "../bad",
+      }),
+      /path separators|absolute|escapes/,
+    );
+    await assert.rejects(
+      collectContextSnapshot(baseClient(contextDir), {
+        fileBaseName: "snapshot.json",
+      }),
+      /must not include an extension/,
+    );
+
+    await writeFile(join(contextDir, "exists.json"), "{}");
+    await writeFile(join(contextDir, "exists.md"), "# existing");
+    await assert.rejects(
+      collectContextSnapshot(baseClient(contextDir), {
+        fileBaseName: "exists",
+      }),
+      /already exists/,
+    );
+  } finally {
+    await rm(contextDir, { recursive: true, force: true });
+  }
+});
+
+test("collect-context-snapshot tool delegates and reports saved paths", async () => {
+  let received;
+  const handlers = new Map();
+  const configs = new Map();
+  const server = {
+    registerTool(name, config, handler) {
+      configs.set(name, config);
+      handlers.set(name, handler);
+    },
+  };
+  registerContextTools(server, {
+    collectContextSnapshot: async (params) => {
+      received = params;
+      return {
+        jsonPath: "/tmp/context/vcfa-context.json",
+        markdownPath: "/tmp/context/vcfa-context.md",
+        counts: { workflows: 1 },
+        skipped: { workflows: 0 },
+        warnings: [],
+      };
+    },
+  });
+
+  assert.equal(configs.get("collect-context-snapshot").annotations.readOnlyHint, true);
+  const result = await handlers.get("collect-context-snapshot")({
+    domains: ["workflows"],
+  });
+  assert.deepEqual(received, { domains: ["workflows"] });
+  assert.match(result.content[0].text, /vcfa-context\.json/);
+});

--- a/test/resources-prompts.test.mjs
+++ b/test/resources-prompts.test.mjs
@@ -143,6 +143,17 @@ test("prompts return workflow instructions with provided arguments", async () =>
   assert.match(discover.messages[0].content.text, /NSX automation coverage/);
   assert.match(discover.messages[0].content.text, /installed plugins/);
   assert.match(discover.messages[0].content.text, /Do not invent IDs/);
+
+  const snapshot = await prompts
+    .get("vcfa-collect-context-snapshot")
+    .handler({
+      goal: "Prepare project context",
+      includeOptionalDomains: true,
+    });
+  assert.match(snapshot.messages[0].content.text, /Prepare project context/);
+  assert.match(snapshot.messages[0].content.text, /collect-context-snapshot/);
+  assert.match(snapshot.messages[0].content.text, /vcfa-discover-capabilities/);
+  assert.match(snapshot.messages[0].content.text, /Include optional domains: yes/);
 });
 
 test("implementation prompts include discovery-first guardrails", async () => {
@@ -158,6 +169,8 @@ test("implementation prompts include discovery-first guardrails", async () => {
   assert.match(fromAction.messages[0].content.text, /get-action/);
   assert.match(fromAction.messages[0].content.text, /action-wrapper/);
   assert.match(fromAction.messages[0].content.text, /Do not invent IDs/);
+  assert.match(fromAction.messages[0].content.text, /partial\/ambiguous action data/);
+  assert.match(fromAction.messages[0].content.text, /instead of inventing parameter names or return types/);
 
   const refactor = await prompts.get("vcfa-refactor-workflow").handler({
     workflowHint: "List VMs",
@@ -198,4 +211,5 @@ test("implementation prompts include discovery-first guardrails", async () => {
     });
   assert.match(plan.messages[0].content.text, /read-only discovery/);
   assert.match(plan.messages[0].content.text, /preflight\/diff/);
+  assert.match(plan.messages[0].content.text, /get-action must verify its contract/);
 });

--- a/test/vro-client.test.mjs
+++ b/test/vro-client.test.mjs
@@ -34,6 +34,7 @@ test("artifact directories default to temp subdirectories", () => {
     client.getConfigurationDirectory(),
     join(root, "configurations"),
   );
+  assert.equal(client.getContextDirectory(), join(root, "context"));
 });
 
 test("artifactDir config derives artifact type subdirectories", async () => {
@@ -50,6 +51,7 @@ test("artifactDir config derives artifact type subdirectories", async () => {
       client.getConfigurationDirectory(),
       join(artifactDir, "configurations"),
     );
+    assert.equal(client.getContextDirectory(), join(artifactDir, "context"));
   } finally {
     await rm(artifactDir, { recursive: true, force: true });
   }
@@ -58,11 +60,13 @@ test("artifactDir config derives artifact type subdirectories", async () => {
 test("specific artifact directories override artifactDir", async () => {
   const artifactDir = await mkdtemp(join(tmpdir(), "vcfa-artifacts-"));
   const workflowDir = await mkdtemp(join(tmpdir(), "vcfa-workflows-"));
+  const contextDir = await mkdtemp(join(tmpdir(), "vcfa-context-"));
 
   try {
-    const client = new VroClient(config({ artifactDir, workflowDir }));
+    const client = new VroClient(config({ artifactDir, workflowDir, contextDir }));
 
     assert.equal(client.getWorkflowDirectory(), workflowDir);
+    assert.equal(client.getContextDirectory(), contextDir);
     assert.equal(client.getPackageDirectory(), join(artifactDir, "packages"));
     assert.equal(client.getResourceDirectory(), join(artifactDir, "resources"));
     assert.equal(client.getActionDirectory(), join(artifactDir, "actions"));
@@ -73,6 +77,7 @@ test("specific artifact directories override artifactDir", async () => {
   } finally {
     await rm(artifactDir, { recursive: true, force: true });
     await rm(workflowDir, { recursive: true, force: true });
+    await rm(contextDir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
- Introduced `collect-context-snapshot` tool to gather and persist VCFA/vRO context in Markdown and JSON formats, excluding sensitive data.
- Enhanced `VroHttpClient` to manage context directory.
- Updated `VroClient` to provide context directory access and context snapshot collection functionality.
- Implemented context snapshot logic in `context-snapshot.ts`, including domain collection and data summarization.
- Registered context tools in `context-tools.ts` for server integration.
- Added tests for context snapshot functionality, ensuring proper data collection and file handling.
- Updated documentation to reflect new tool and usage instructions.