### PR TITLE
[codex] Add project validation gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,5 +8,16 @@ VCFA_PASSWORD=your-password-here
 VCFA_IGNORE_TLS=false
 
 # Optional: override the local root directory for artifact import/export files
-# Defaults to the artifacts/ folder in the repository root
+# Defaults to the artifacts/ folder in the MCP server process working directory
 # VCFA_ARTIFACT_DIR=/custom/path/to/artifacts
+
+# Optional: override individual artifact directories
+# VCFA_WORKFLOW_DIR=/custom/path/to/artifacts/workflows
+# VCFA_ACTION_DIR=/custom/path/to/artifacts/actions
+# VCFA_CONFIGURATION_DIR=/custom/path/to/artifacts/configurations
+# VCFA_RESOURCE_DIR=/custom/path/to/artifacts/resources
+# VCFA_PACKAGE_DIR=/custom/path/to/artifacts/packages
+
+# Optional: override persisted context snapshot output
+# If unset, snapshots prefer the MCP client's current workspace root at artifacts/context/
+# VCFA_CONTEXT_DIR=/custom/path/to/artifacts/context

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Run tests
         run: npm test
 
-  docs:
-    name: Build documentation
+  validate:
+    name: Validate docs, coverage, and package
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -48,5 +48,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build documentation
-        run: npm run docs:build
+      - name: Run full validation gate
+        run: npm run validate

--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -6,8 +6,10 @@ on:
       - ".github/workflows/package-check.yml"
       - "README.md"
       - "docs/**"
+      - "examples/**"
       - "package-lock.json"
       - "package.json"
+      - "scripts/**"
       - "src/**"
       - "tsconfig.json"
   push:
@@ -16,8 +18,10 @@ on:
       - ".github/workflows/package-check.yml"
       - "README.md"
       - "docs/**"
+      - "examples/**"
       - "package-lock.json"
       - "package.json"
+      - "scripts/**"
       - "src/**"
       - "tsconfig.json"
 
@@ -44,5 +48,5 @@ jobs:
       - name: Build package output
         run: npm run build
 
-      - name: Dry-run package publish
-        run: npm pack --dry-run
+      - name: Validate package contents
+        run: npm run validate:package

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ trigger: "vcfa-orchestrator"
 
 # VCF Orchestrator Agent
 
-This custom agent is designed to assist with managing VCF Automation Orchestrator workflows, workflow executions, actions, configurations, resource elements, subscriptions, catalog items, deployments, templates, packages, and plugins via natural language commands. It loads the MCP server tools automatically and exposes commands like \`list-workflows\`, \`create-workflow\`, \`run-workflow\`, \`run-workflow-and-wait\`, \`list-workflow-executions\`, \`list-deployments\`, and related artifact import/export commands.
+This custom agent assists with VCF Automation Orchestrator workflows, workflow executions, actions, configurations, resource elements, subscriptions, catalog items, deployments, templates, packages, plugins, artifact promotion, context snapshots, MCP resources, and prompts. It should favor discovery-first workflows and map natural language requests to the MCP tools exposed by this server.
 
 ## When to Use
 
@@ -16,22 +16,32 @@ This custom agent is designed to assist with managing VCF Automation Orchestrato
 - When you need to inspect workflow execution history, status, and outputs
 - When you need to manage deployments and blueprint templates
 - When you need to export or import real vRO workflow, action, configuration, package, or resource artifacts
+- When you need to collect reusable environment context before implementation work
+- When you need to preflight, diff, back up, or promote local artifacts safely
 - When authoring or importing real vRO workflow/action artifacts, first read `docs/vro-artifact-authoring.md`
 
 ## Commands
 
-- Workflows: \`list-workflows\`, \`get-workflow\`, \`create-workflow\`, \`run-workflow\`, \`run-workflow-and-wait\`, \`list-workflow-executions\`, \`get-workflow-execution\`, \`export-workflow-file\`, \`import-workflow-file\`, \`delete-workflow\`
-- Actions: \`list-actions\`, \`get-action\`, \`create-action\`, \`export-action-file\`, \`import-action-file\`, \`delete-action\`
-- Configuration elements: \`list-configurations\`, \`get-configuration\`, \`create-configuration\`, \`update-configuration\`, \`export-configuration-file\`, \`import-configuration-file\`, \`delete-configuration\`
-- Resource elements: \`list-resource-elements\`, \`export-resource-element\`, \`import-resource-element\`, \`update-resource-element\`, \`delete-resource-element\`
-- Categories: \`list-categories\`
-- Subscriptions: \`list-event-topics\`, \`list-subscriptions\`, \`get-subscription\`, \`create-subscription\`, \`update-subscription\`, \`delete-subscription\`
-- Catalog items: \`list-catalog-items\`, \`get-catalog-item\`
-- Deployments: \`list-deployments\`, \`get-deployment\`, \`create-deployment\`, \`list-deployment-actions\`, \`run-deployment-action\`, \`delete-deployment\`
-- Templates: \`list-templates\`, \`get-template\`, \`create-template\`, \`delete-template\`
-- Packages: \`list-packages\`, \`get-package\`, \`export-package\`, \`import-package\`, \`delete-package\`
-- Plugins: \`list-plugins\`
-- Promotion: \`prepare-artifact-promotion\`
+- Workflows: `list-workflows`, `get-workflow`, `create-workflow`, `run-workflow`, `run-workflow-and-wait`, `list-workflow-executions`, `get-workflow-execution`, `export-workflow-file`, `scaffold-workflow-file`, `preflight-workflow-file`, `diff-workflow-file`, `import-workflow-file`, `delete-workflow`
+- Actions: `list-actions`, `get-action`, `create-action`, `export-action-file`, `preflight-action-file`, `diff-action-file`, `import-action-file`, `delete-action`
+- Configuration elements: `list-configurations`, `get-configuration`, `create-configuration`, `update-configuration`, `export-configuration-file`, `preflight-configuration-file`, `import-configuration-file`, `delete-configuration`
+- Resource elements: `list-resource-elements`, `export-resource-element`, `import-resource-element`, `update-resource-element`, `delete-resource-element`
+- Categories: `list-categories`
+- Subscriptions: `list-event-topics`, `list-subscriptions`, `get-subscription`, `create-subscription`, `update-subscription`, `delete-subscription`
+- Catalog items: `list-catalog-items`, `get-catalog-item`
+- Deployments: `list-deployments`, `get-deployment`, `create-deployment`, `delete-deployment`, `list-deployment-actions`, `run-deployment-action`
+- Templates: `list-templates`, `get-template`, `create-template`, `delete-template`
+- Packages: `list-packages`, `get-package`, `export-package`, `preflight-package`, `import-package`, `delete-package`
+- Plugins: `list-plugins`
+- Context and promotion: `collect-context-snapshot`, `prepare-artifact-promotion`
+
+## Operating Rules
+
+- Start with read-only discovery tools or `collect-context-snapshot` in unfamiliar environments.
+- Do not invent VCF Automation/vRO IDs, schemas, workflow parameters, action contracts, project IDs, category IDs, or blueprint YAML fields. If discovery cannot find a required fact, stop and report what is missing.
+- Use preflight tools before artifact imports. Use `prepare-artifact-promotion` when replacing live workflow, action, configuration, or package artifacts.
+- Run live write, import, day-2 action, and delete operations only after the user confirms the exact target and impact.
+- Keep local artifact paths inside configured directories such as `VCFA_ARTIFACT_DIR`, `VCFA_WORKFLOW_DIR`, `VCFA_ACTION_DIR`, `VCFA_CONFIGURATION_DIR`, `VCFA_RESOURCE_DIR`, `VCFA_PACKAGE_DIR`, and `VCFA_CONTEXT_DIR`.
 
 GitHub issue code convention:
 - Use `VCFO-###` for repo issue codes, starting at `VCFO-001` and incrementing sequentially.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,25 +7,31 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Build**: `npm run build` – compiles TypeScript to `dist/` and produces the executable at `dist/index.js`.
 - **Start**: `npm start` – runs the server with `tsx src/index.ts` (requires runtime environment variables).
 - **Inspect**: `npm run inspect` – launches the MCP Inspector for debugging the server.
-- **Environment**: The server reads VCFA_HOST, VCFA_USERNAME, VCFA_ORGANIZATION, VCFA_PASSWORD, and optionally VCFA_IGNORE_TLS, VCFA_PACKAGE_DIR, VCFA_RESOURCE_DIR, VCFA_WORKFLOW_DIR, VCFA_ACTION_DIR, and VCFA_CONFIGURATION_DIR from the environment (see `.env.example`).
+- **Validate**: `npm run validate` – builds, runs tests, enforces conservative coverage thresholds, checks docs/examples drift, builds docs, and validates npm package contents.
+- **Docs/examples drift**: `npm run validate:docs` – checks registered tool, prompt, and resource names against reference docs, validates local Markdown links, and verifies documented tool-call examples use current top-level argument names.
+- **Package contents**: `npm run validate:package` – runs `npm pack --dry-run --json` with an isolated temporary npm cache and verifies the published file set.
+- **Environment**: The server reads VCFA_HOST, VCFA_USERNAME, VCFA_ORGANIZATION, VCFA_PASSWORD, and optionally VCFA_IGNORE_TLS, VCFA_ARTIFACT_DIR, VCFA_PACKAGE_DIR, VCFA_RESOURCE_DIR, VCFA_WORKFLOW_DIR, VCFA_ACTION_DIR, VCFA_CONFIGURATION_DIR, and VCFA_CONTEXT_DIR from the environment (see `.env.example`).
 
 ## Architecture Overview
 
 The repository implements an MCP server that exposes VCF Automation Orchestrator (vRO), Service Broker, and Cloud Assembly REST API operations. Core modules:
 
-1. **src/index.ts** – Entry point that registers MCP tools.
+1. **src/index.ts** – Entry point that registers MCP tools, resources, prompts, and server instructions.
 2. **src/vro-client.ts** – Compatibility export for the public `VroClient` import path.
 3. **src/client/** – Modular VCF/vRO clients split by responsibility: shared HTTP/auth core, workflows, actions, configurations, categories, subscriptions, catalog, deployments, templates, packages, resources, and plugins.
 4. **src/tools/** – Directory containing individual tool implementations (workflow, action, deployment, catalog-item, subscription, template, configuration, package, resource, plugin).
-5. **src/types.ts** – Shared TypeScript types and interfaces used across the server.
-6. **dist/** – Compiled JavaScript output produced by `npm run build`.
+5. **src/resources/** and **src/prompts/** – MCP resource and prompt registrations that keep agents discovery-first.
+6. **src/types.ts** – Shared TypeScript types and interfaces used across the server.
+7. **dist/** – Compiled JavaScript output produced by `npm run build`.
 
 Key architectural concepts:
 
-- **MCP Server Model**: Tools are exposed as natural‑language commands (`list-workflows`, `create-action`, `run-workflow`, etc.). Each tool maps to a specific MCP endpoint.
+- **MCP Server Model**: Tools are exposed as natural-language commands (`list-workflows`, `create-action`, `run-workflow`, etc.). Each tool maps to a specific MCP endpoint.
 - **Plugin‑Style Extensibility**: Extensibility points (actions, blueprint templates, configuration elements) are organized by category and can be discovered via `list-*` commands.
 - **Configuration Management**: Settings are stored as configuration elements within the platform; the server treats them as first‑class data objects.
 - **Event‑Driven Subscriptions**: The server can subscribe to VMware event topics (e.g., `compute.allocation.pre`) and trigger ABX or VRO workflows.
+- **Artifact Safety**: Local artifact tools keep files inside configured artifact directories; imports should be preceded by preflight, diff, optional backup, and explicit confirmation.
+- **Discovery Guardrails**: Prompts and docs should tell agents to discover required workflow/action/template/category/project facts instead of inventing environment-specific values.
 
 ## Key Files for Navigation
 
@@ -33,13 +39,17 @@ Key architectural concepts:
 - `src/vro-client.ts` – Stable compatibility shim exporting `VroClient`.
 - `src/client/` – Client implementation modules; start with `src/client/index.ts` for the facade and `src/client/core.ts` for authentication/HTTP behavior.
 - `src/tools/` – Individual tool implementations; filenames correspond to tool names.
+- `src/resources/index.ts` and `src/prompts/index.ts` – MCP resources and agent prompt playbooks.
+- `scripts/validate-docs.mjs` and `scripts/validate-package.mjs` – Validation checks for docs/examples drift and package contents.
 - `package.json` – Scripts and dependencies; useful for understanding build and runtime commands.
 
 ## Development Workflow
 
 1. Make code changes.
-2. Run `npm run build` to compile.
+2. Run `npm run validate` before handing off broad changes.
 3. Use `npm start` to run the server locally (ensure environment variables are set).
 4. For debugging, launch `npm run inspect` to open the MCP Inspector in a browser.
 
 Automated tests use Node's built-in test runner. Run `npm test` to build and execute `test/*.test.mjs`.
+
+Live VCFA validation should stay separate from local validation. Read-only list/get smoke checks are acceptable against a sandbox environment; imports, deletes, deployment day-2 actions, and other writes require explicit user confirmation and disposable test assets.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Full documentation is available in the GitHub Pages site:
 
 The docs include installation, configuration, MCP client setup, tool references, resources/prompts, how-tos, artifact lifecycle guidance, safety notes, troubleshooting, and contributor guidance.
 
+Checked examples for common workflows are available in [examples/README.md](examples/README.md). These examples are validated against the registered tool and prompt names so stale snippets are caught during development.
+
 ## Quick Start
 
 Run directly from npm:
@@ -84,6 +86,8 @@ The server includes tools for:
 
 See the [tool reference](docs/reference/tools.md) for the full list.
 
+The source and reference docs are kept in sync by `npm run validate:docs`, which compares registered tools, prompts, and resources against the documentation and checks documented examples for stale tool names or top-level arguments.
+
 ## Prompt Examples
 
 Discover what is reusable before building:
@@ -135,6 +139,12 @@ npm run build
 # Run tests
 npm test
 
+# Run the full local validation gate
+npm run validate
+
+# Check docs/examples drift only
+npm run validate:docs
+
 # Run in dev mode
 VCFA_HOST=... VCFA_USERNAME=... VCFA_ORGANIZATION=... VCFA_PASSWORD=... npm start
 
@@ -145,6 +155,10 @@ npm run docs:build
 npm run docs:dev
 ```
 
+`npm run validate` builds the project, runs unit tests, enforces conservative coverage thresholds, validates docs/examples drift, builds the VitePress docs, and dry-runs npm packaging with package-content checks.
+
 ## Safety
 
 Use read-only discovery tools before live writes. Import, delete, deployment action, and overwrite operations require explicit confirmation. Local artifact tools only read or write under configured artifact directories and reject unsafe paths.
+
+Live VCFA validation should be run separately from local validation. Read-only list/get smoke checks are appropriate for sandbox environments; write, import, delete, and day-2 action tests should use disposable assets and explicit confirmation.

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -12,6 +12,7 @@ The server supports VCF 9 Automation and Aria Automation 8.x environments with R
 - Browse catalog items, create deployments, and discover day-2 actions.
 - Manage extensibility subscriptions that connect event topics to workflows or ABX actions.
 - Collect practical context through MCP resources and prompts so agents avoid inventing environment-specific details.
+- Validate docs, checked examples, coverage, docs builds, and npm package contents with one local command.
 
 ## Operating Model
 
@@ -34,6 +35,10 @@ When starting in a new VCFA or vRO environment, use the server to map current st
 5. Export existing assets before changing them. Then scaffold or edit local artifacts, run preflight and diff tools, and import only after explicit confirmation.
 
 Use the built-in MCP prompts when the assistant should follow a known workflow rather than free-form instructions. For example, use `vcfa-discover-capabilities` to inventory an unfamiliar environment conversationally, `vcfa-collect-context-snapshot` to persist reusable Markdown/JSON inventory with `collect-context-snapshot`, `vcfa-discovery-first-implementation-plan` to plan a change, `vcfa-build-workflow-from-action` to wrap a verified action, and `vcfa-review-artifact-import` before importing a local artifact. When you specifically need VMware baseline context, use `vcfa-collect-context-snapshot` with `profile: vcfaBuiltIns` to focus the snapshot on workflows in subfolders below `Library` and actions in `com.vmware` modules. See [Resources And Prompts](../reference/resources-prompts.md) for prompt arguments and examples.
+
+The repository also includes a root `examples/` directory with checked, high-value flows for workflow artifacts, artifact promotion, template/catalog/subscription planning, and context collection. `npm run validate:docs` verifies those examples against current registered tool and prompt names.
+
+For repository validation, run `npm run validate`. It builds, tests, checks coverage thresholds, validates docs/examples drift, builds the VitePress site, and verifies npm package contents.
 
 ## Documentation Map
 

--- a/docs/how-tos/artifacts.md
+++ b/docs/how-tos/artifacts.md
@@ -31,6 +31,13 @@ preflight-workflow-file(fileName: "ipam-updated.workflow")
 
 The workflow preflight validates archive structure, UTF-16 workflow XML, parameters, bindings, task flow, vRO type syntax, action references, and file path safety.
 
+Use the matching preflight for each artifact kind:
+
+1. `preflight-workflow-file(fileName: "ipam-updated.workflow")`
+2. `preflight-action-file(fileName: "ipam.action")`
+3. `preflight-configuration-file(fileName: "ipam-settings.vsoconf")`
+4. `preflight-package(fileName: "com.example.ipam.package")`
+
 ## Promote With A Backup And Diff
 
 Use `prepare-artifact-promotion` when replacing live artifacts. It can run preflight, export a live backup, summarize workflow/action diffs, and recommend the exact import call. It never imports by itself.
@@ -40,3 +47,10 @@ Recommended sequence:
 1. `prepare-artifact-promotion(...)`
 2. Review preflight errors, warnings, metadata, backup status, and diff summary.
 3. Run the recommended import call only after the user confirms the target and overwrite intent.
+
+For targeted diffs without the promotion wrapper:
+
+1. `diff-workflow-file(base: { source: "live", workflowId: "<workflow-id>" }, compare: { source: "file", fileName: "ipam-updated.workflow" })`
+2. `diff-action-file(base: { source: "live", actionId: "<action-id>" }, compare: { source: "file", fileName: "ipam.action" })`
+
+Local validation never imports. Live import remains a separate confirmed step.

--- a/docs/how-tos/workflows.md
+++ b/docs/how-tos/workflows.md
@@ -56,3 +56,20 @@ Before creating new workflow code, discover existing plugins and reusable action
 4. `get-action(id: "<candidate-action-id>")`
 
 If discovery does not find the required action, category, parameter, or plugin, stop and report the missing detail instead of inventing a schema.
+
+## Use Prompt-Driven Discovery
+
+When the environment is unfamiliar, start with a prompt or persisted snapshot instead of ad hoc guessing:
+
+```text
+Use prompt vcfa-discover-capabilities with:
+goal: "Find reusable VM provisioning workflows, actions, templates, catalog items, and subscriptions."
+```
+
+For reusable context that future agents can read:
+
+```text
+collect-context-snapshot(fileBaseName: "vm-provisioning-context", includeOptionalDomains: true, maxItemsPerDomain: 300, overwrite: true)
+```
+
+The snapshot output includes Markdown and JSON files plus `vcfa://context/latest` and `vcfa://context/snapshots/{fileName}` resource URIs for later discovery.

--- a/docs/operations/contributing.md
+++ b/docs/operations/contributing.md
@@ -6,7 +6,11 @@
 npm install
 npm run build
 npm test
+npm run test:coverage:check
+npm run validate:docs
 npm run docs:build
+npm run validate:package
+npm run validate
 ```
 
 ## Adding Tools
@@ -25,6 +29,8 @@ Resources and prompts are registered in the resource and prompt modules. Keep co
 
 When adding or changing a prompt, update the prompt reference with a collapsible parameters section directly under the prompt.
 
+`npm run validate:docs` compares registered tool, prompt, and resource names against the reference docs. It also checks documented tool-call examples for stale tool names and top-level argument names.
+
 ## Artifact Work
 
 When authoring or importing vRO artifacts, read the workflow authoring guide and run preflight before import. Prefer real importable artifacts over illustrative pseudocode.
@@ -35,14 +41,15 @@ Docs live under `docs/` and are built with VitePress.
 
 - Add pages to the sidebar in `docs/.vitepress/config.ts`.
 - Keep examples aligned with current tool names and schemas.
+- Add or update root `examples/` flows when new capabilities change common usage patterns.
 - Keep tool and prompt parameters documented directly under each tool or prompt in collapsible sections.
 - Distinguish read-only discovery from live write or destructive operations.
-- Run `npm run docs:build` before opening a docs PR.
+- Run `npm run validate:docs` and `npm run docs:build` before opening a docs PR.
 
 ## GitHub Actions
 
 The repository uses GitHub Actions for CI, dependency review, CodeQL analysis, package dry-runs, documentation deployment, and npm publishing. Keep workflow changes narrow and prefer official GitHub/npm actions where possible.
 
-- CI runs tests across supported Node versions and builds the docs site.
-- Package Check runs `npm pack --dry-run` for changes that affect published package contents.
+- CI runs tests across supported Node versions and runs the full validation gate on Node 24.
+- Package Check runs `npm run validate:package` for changes that affect published package contents.
 - Publish to npm runs only for published GitHub releases and expects npm trusted publishing to be configured.

--- a/docs/operations/safety.md
+++ b/docs/operations/safety.md
@@ -45,3 +45,7 @@ For subscriptions, disabling is often safer than deleting during testing.
 ## Discovery Guardrail
 
 Do not invent environment-specific values. If discovery does not return a required category, action, workflow, project, template, parameter, return type, or schema detail, stop and report the missing fact.
+
+## Live Validation
+
+Keep local repository validation separate from live VCFA validation. `npm run validate` should not contact VCFA. Live smoke checks may use read-only list/get tools against a sandbox environment, but imports, deletes, deployment day-2 actions, subscription changes, and template creation require explicit confirmation and disposable test assets.

--- a/docs/vro-artifact-authoring.md
+++ b/docs/vro-artifact-authoring.md
@@ -92,15 +92,14 @@ var props = new Properties();
 props.put("name", "value");
 ```
 
-Built-in action confirmed in this environment:
+Historical built-in action observed during one live validation session:
 
 - `com.vmware.library.vra.infrastructure.machine/getAllMachines`
-- ID: `9d533b42-de3f-4a32-912e-2be46d6bf2de`
 - Script: `return VraEntitiesFinder.getMachines(host)`
 - Input: `host (VRA:Host)`
 - Return: `Array/VRA:Machine`
 
-Action details can be inspected with MCP:
+Do not reuse live IDs from historical notes. Action details must be rediscovered in the target environment with MCP:
 
 - `list-actions` with a filter
 - `get-action` by ID
@@ -151,7 +150,7 @@ Runtime behavior:
   - `owner`
   - `address`
 
-Live validation on 2026-04-30:
+Historical live validation on 2026-04-30:
 
 - `projectName = "MainPrj"` completed successfully.
 - It returned `vmCount = 4` from the VRA machine inventory.
@@ -159,6 +158,8 @@ Live validation on 2026-04-30:
 - Deployment-aware fallback paths were attempted in the artifact, but this vRO runtime did not expose deployment listing through the tested scripting APIs.
 - Blank `projectName` failed with `projectName is required.`
 - Unknown project failed with `Project not found: __does_not_exist__`.
+
+Treat these validation results as an example of the checks to run, not as a portable environment contract. Different VCFA/vRO environments can expose different projects, host names, plugin object shapes, and inventory coverage.
 
 ## Validation Commands
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,15 @@
+# Examples
+
+These examples are current, import-safe patterns for using the MCP tools. They are intentionally concise and use placeholder IDs; discover real IDs with read-only tools before running write operations.
+
+## Example Set
+
+- [Workflow Artifact](./workflow-artifact.md): collect context, scaffold a workflow, preflight, import, and test it.
+- [Artifact Promotion](./artifact-promotion.md): preflight, diff, optional backup, and import recommendation.
+- [Template, Catalog, And Subscription](./template-catalog-subscription.md): review templates, inspect catalog/deployment behavior, and plan subscriptions.
+
+## Safety Defaults
+
+- Use `collect-context-snapshot` or read-only list/get tools before drafting changes.
+- Use preflight and diff tools before imports.
+- Treat live write tools as final steps that require confirmed target IDs and explicit user approval.

--- a/examples/artifact-promotion.md
+++ b/examples/artifact-promotion.md
@@ -1,0 +1,30 @@
+# Artifact Promotion Example
+
+Use this flow when replacing a live workflow, action, configuration, or package from a local artifact.
+
+## Prepare Promotion
+
+```text
+prepare-artifact-promotion(kind: "workflow", fileName: "echo-message.workflow", target: {
+  categoryId: "<workflow-category-id>",
+  workflowId: "<live-workflow-id>"
+}, backup: {
+  enabled: true,
+  fileName: "echo-message-backup.workflow",
+  overwrite: false
+}, overwrite: true)
+```
+
+The promotion tool runs local preflight, optionally exports a backup, summarizes workflow/action diffs when a live target is provided, and returns the exact import call to run later. It never imports by itself.
+
+## Final Import
+
+Only after reviewing the promotion output and confirming the target:
+
+```text
+import-workflow-file(categoryId: "<workflow-category-id>", fileName: "echo-message.workflow", overwrite: true, confirm: true)
+get-workflow(id: "<workflow-id>")
+run-workflow-and-wait(id: "<workflow-id>", inputs: [{ name: "message", value: "post-import check" }], timeoutSeconds: 60)
+```
+
+For action replacements, use `preflight-action-file(fileName: "example.action")` and `diff-action-file(base: { source: "live", actionId: "<action-id>" }, compare: { source: "file", fileName: "example.action" })` before importing.

--- a/examples/template-catalog-subscription.md
+++ b/examples/template-catalog-subscription.md
@@ -1,0 +1,45 @@
+# Template, Catalog, And Subscription Example
+
+Use this flow when a workflow, blueprint template, catalog item, deployment, and extensibility subscription need to line up.
+
+## Review Template And Catalog Shape
+
+```text
+Use prompt vcfa-integrate-workflow-template-subscription with:
+integrationGoal: "Run a tagging workflow after Ubuntu catalog deployment creation."
+workflowHint: "Tag VM"
+templateHint: "Ubuntu"
+```
+
+```text
+list-templates(search: "Ubuntu")
+get-template(id: "<template-id>")
+list-catalog-items(search: "Ubuntu")
+get-catalog-item(id: "<catalog-item-id>")
+list-deployments(search: "Ubuntu", projectId: "<project-id>")
+```
+
+## Validate Deployment Action Surface
+
+```text
+list-deployment-actions(deploymentId: "<deployment-id>")
+run-deployment-action(deploymentId: "<deployment-id>", actionId: "<safe-action-id>", inputs: {}, reason: "Validated maintenance action", confirm: true)
+```
+
+## Plan Or Create Subscription
+
+Discover the event topic and workflow contract first:
+
+```text
+list-event-topics()
+list-workflows(filter: "Tag VM")
+get-workflow(id: "<workflow-id>")
+list-subscriptions(projectId: "<project-id>")
+```
+
+Create the subscription only after the topic, workflow ID, blocking behavior, and timeout are confirmed:
+
+```text
+create-subscription(name: "Tag Ubuntu deployments", eventTopicId: "<event-topic-id>", runnableType: "extensibility.vro", runnableId: "<workflow-id>", projectId: "<project-id>", blocking: false, priority: 100, timeout: 10, disabled: true)
+get-subscription(id: "<subscription-id>")
+```

--- a/examples/workflow-artifact.md
+++ b/examples/workflow-artifact.md
@@ -1,0 +1,45 @@
+# Workflow Artifact Example
+
+Use this flow when the assistant needs to author a real importable `.workflow` artifact.
+
+## Discover And Snapshot
+
+```text
+Use prompt vcfa-collect-context-snapshot with:
+goal: "Collect reusable workflow and action context before authoring an Echo Message workflow."
+includeOptionalDomains: true
+```
+
+Direct tool call:
+
+```text
+collect-context-snapshot(fileBaseName: "echo-message-context", includeOptionalDomains: true, overwrite: true)
+```
+
+## Scaffold Locally
+
+```text
+scaffold-workflow-file(fileName: "echo-message.workflow", overwrite: false, workflow: {
+  name: "Echo Message",
+  description: "Return the supplied message.",
+  inputs: [{ name: "message", type: "string", description: "Message to echo" }],
+  outputs: [{ name: "result", type: "string", description: "Echoed message" }],
+  tasks: [{
+    displayName: "Echo",
+    script: "result = message;",
+    inBindings: [{ name: "message", type: "string", source: "message" }],
+    outBindings: [{ name: "result", type: "string", target: "result" }]
+  }]
+})
+```
+
+## Preflight, Import, And Verify
+
+```text
+preflight-workflow-file(fileName: "echo-message.workflow")
+list-categories(type: "WorkflowCategory", filter: "Development")
+import-workflow-file(categoryId: "<workflow-category-id>", fileName: "echo-message.workflow", overwrite: true, confirm: true)
+list-workflows(filter: "Echo Message")
+get-workflow(id: "<workflow-id>")
+run-workflow-and-wait(id: "<workflow-id>", inputs: [{ name: "message", value: "hello" }], timeoutSeconds: 60, pollIntervalSeconds: 2)
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1757,12 +1757,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1781,9 +1781,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -1797,9 +1797,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -1808,7 +1808,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -2054,9 +2055,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2123,9 +2124,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4374,6 +4375,21 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/zod": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "files": [
     "dist",
     "docs/**/*.md",
+    "examples/**/*.md",
     "README.md"
   ],
   "scripts": {
@@ -20,6 +21,10 @@
     "docs:preview": "vitepress preview docs",
     "test": "npm run build && node --test test/*.test.mjs",
     "test:coverage": "npm run build && node --test --experimental-test-coverage test/*.test.mjs",
+    "test:coverage:check": "npm run build && node --test --experimental-test-coverage --test-coverage-lines=80 --test-coverage-branches=70 --test-coverage-functions=80 test/*.test.mjs",
+    "validate:docs": "node scripts/validate-docs.mjs",
+    "validate:package": "node scripts/validate-package.mjs",
+    "validate": "npm run build && npm test && npm run test:coverage:check && npm run validate:docs && npm run docs:build && npm run validate:package",
     "prepublishOnly": "npm run build",
     "inspect": "npx @modelcontextprotocol/inspector node dist/index.js"
   },

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, extname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function read(path) {
+  return readFileSync(join(root, path), "utf8");
+}
+
+function walk(dir, predicate = () => true) {
+  const absolute = join(root, dir);
+  if (!existsSync(absolute)) return [];
+  return readdirSync(absolute, { withFileTypes: true }).flatMap((entry) => {
+    const relative = join(dir, entry.name);
+    if (entry.isDirectory()) return walk(relative, predicate);
+    return predicate(relative) ? [relative] : [];
+  });
+}
+
+function propertyName(node) {
+  if (!node) return undefined;
+  if (ts.isIdentifier(node) || ts.isStringLiteral(node)) return node.text;
+  return undefined;
+}
+
+function stringLiteral(node) {
+  return ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)
+    ? node.text
+    : undefined;
+}
+
+function objectProperty(objectLiteral, name) {
+  return objectLiteral.properties.find(
+    (prop) =>
+      ts.isPropertyAssignment(prop) && propertyName(prop.name) === name,
+  );
+}
+
+function objectKeys(node) {
+  if (!node) return new Set();
+  if (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === "object" &&
+    node.arguments[0] &&
+    ts.isObjectLiteralExpression(node.arguments[0])
+  ) {
+    return objectKeys(node.arguments[0]);
+  }
+  if (!ts.isObjectLiteralExpression(node)) return new Set();
+  return new Set(
+    node.properties
+      .filter(ts.isPropertyAssignment)
+      .map((prop) => propertyName(prop.name))
+      .filter(Boolean),
+  );
+}
+
+function callName(node) {
+  return ts.isPropertyAccessExpression(node.expression)
+    ? node.expression.name.text
+    : undefined;
+}
+
+function sourceFiles(paths) {
+  return paths.map((path) =>
+    ts.createSourceFile(path, read(path), ts.ScriptTarget.Latest, true),
+  );
+}
+
+function collectRegistry() {
+  const tools = new Map();
+  const prompts = new Map();
+  const resources = new Set();
+  const files = sourceFiles([
+    ...walk("src/tools", (path) => extname(path) === ".ts"),
+    "src/prompts/index.ts",
+    "src/resources/index.ts",
+  ]);
+
+  for (const sourceFile of files) {
+    const visit = (node) => {
+      if (ts.isCallExpression(node) && callName(node) === "registerTool") {
+        const name = stringLiteral(node.arguments[0]);
+        const config = node.arguments[1];
+        if (name && ts.isObjectLiteralExpression(config)) {
+          tools.set(
+            name,
+            objectKeys(objectProperty(config, "inputSchema")?.initializer),
+          );
+        }
+      }
+
+      if (ts.isCallExpression(node) && callName(node) === "registerPrompt") {
+        const name = stringLiteral(node.arguments[0]);
+        const config = node.arguments[1];
+        if (name && ts.isObjectLiteralExpression(config)) {
+          prompts.set(
+            name,
+            objectKeys(objectProperty(config, "argsSchema")?.initializer),
+          );
+        }
+      }
+
+      if (ts.isCallExpression(node) && callName(node) === "registerResource") {
+        const uriArg = node.arguments[1];
+        if (uriArg) {
+          const direct = stringLiteral(uriArg);
+          if (direct) resources.add(direct);
+          if (ts.isNewExpression(uriArg)) {
+            const template = stringLiteral(uriArg.arguments?.[0]);
+            if (template) resources.add(template);
+          }
+        }
+      }
+
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+  }
+
+  return { tools, prompts, resources };
+}
+
+function sorted(values) {
+  return [...values].sort((a, b) => a.localeCompare(b));
+}
+
+function diff(expected, actual) {
+  const actualSet = new Set(actual);
+  const expectedSet = new Set(expected);
+  return {
+    missing: sorted(expected).filter((value) => !actualSet.has(value)),
+    stale: sorted(actual).filter((value) => !expectedSet.has(value)),
+  };
+}
+
+function assertNoDiff(label, result) {
+  assert.deepEqual(result.missing, [], `${label} missing from docs`);
+  assert.deepEqual(result.stale, [], `${label} documented but not registered`);
+}
+
+function validateReferenceDrift(registry) {
+  const toolDocs = [
+    ...read("docs/reference/tools.md").matchAll(/^### `([^`]+)`/gm),
+  ].map((match) => match[1]);
+  const promptDocs = [
+    ...read("docs/reference/resources-prompts.md").matchAll(/^### `([^`]+)`/gm),
+  ]
+    .map((match) => match[1])
+    .filter((name) => name.startsWith("vcfa-"));
+  const resourceDocs = [
+    ...read("docs/reference/resources-prompts.md").matchAll(
+      /`(vcfa:\/\/[^`]+)`/g,
+    ),
+  ].map((match) => match[1]);
+
+  assertNoDiff("Tools", diff(registry.tools.keys(), toolDocs));
+  assertNoDiff("Prompts", diff(registry.prompts.keys(), promptDocs));
+  assertNoDiff("Resources", diff(registry.resources, resourceDocs));
+}
+
+function markdownFiles() {
+  return [
+    "README.md",
+    "AGENTS.md",
+    "CLAUDE.md",
+    ...walk("docs", (path) => extname(path) === ".md"),
+    ...walk("examples", (path) => extname(path) === ".md"),
+  ].filter((path) => existsSync(join(root, path)));
+}
+
+function validateMarkdownLinks(files) {
+  const failures = [];
+  for (const file of files) {
+    const text = read(file);
+    for (const match of text.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)) {
+      let target = match[1].trim();
+      if (target.startsWith("<") && target.endsWith(">")) {
+        target = target.slice(1, -1);
+      }
+      target = target.split(/\s+/)[0].split("#")[0];
+      if (
+        !target ||
+        target.startsWith("http://") ||
+        target.startsWith("https://") ||
+        target.startsWith("mailto:") ||
+        target.startsWith("vcfa://") ||
+        target.startsWith("#")
+      ) {
+        continue;
+      }
+      if (!existsSync(resolve(root, dirname(file), target))) {
+        failures.push(`${file}: missing link target ${match[1]}`);
+      }
+    }
+  }
+  assert.deepEqual(failures, [], "Broken local Markdown links");
+}
+
+function balancedText(text, openParenIndex) {
+  let depth = 1;
+  let quote;
+  let escaped = false;
+  for (let index = openParenIndex + 1; index < text.length; index += 1) {
+    const char = text[index];
+    if (quote) {
+      escaped = char === "\\" && !escaped;
+      if (char === quote && !escaped) quote = undefined;
+      if (char !== "\\") escaped = false;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "(" || char === "{" || char === "[") depth += 1;
+    if (char === ")" || char === "}" || char === "]") depth -= 1;
+    if (depth === 0) return text.slice(openParenIndex + 1, index);
+  }
+  return undefined;
+}
+
+function topLevelArgumentNames(argumentText) {
+  const names = new Set();
+  let depth = 0;
+  let quote;
+  let escaped = false;
+  for (let index = 0; index < argumentText.length; index += 1) {
+    const char = argumentText[index];
+    if (quote) {
+      escaped = char === "\\" && !escaped;
+      if (char === quote && !escaped) quote = undefined;
+      if (char !== "\\") escaped = false;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "(" || char === "{" || char === "[") depth += 1;
+    if (char === ")" || char === "}" || char === "]") depth -= 1;
+    if (depth !== 0 || !/[A-Za-z_]/.test(char)) continue;
+
+    const rest = argumentText.slice(index);
+    const match = /^([A-Za-z_][A-Za-z0-9_]*)\s*:/.exec(rest);
+    if (match) {
+      names.add(match[1]);
+      index += match[0].length - 1;
+    }
+  }
+  return names;
+}
+
+function validateExampleToolCalls(files, registry) {
+  const failures = [];
+  for (const file of files) {
+    const text = read(file);
+
+    for (const match of text.matchAll(/\b([a-z][a-z0-9]*(?:-[a-z0-9]+)+)\s*\(/g)) {
+      const name = match[1];
+      if (!registry.tools.has(name)) {
+        if (!registry.prompts.has(name)) {
+          failures.push(`${file}: unknown documented call ${name}()`);
+        }
+        continue;
+      }
+
+      const argumentText = balancedText(text, match.index + match[0].length - 1);
+      if (!argumentText) continue;
+      const allowed = registry.tools.get(name);
+      for (const argName of topLevelArgumentNames(argumentText)) {
+        if (!allowed.has(argName)) {
+          failures.push(`${file}: ${name}() uses unknown argument ${argName}`);
+        }
+      }
+    }
+
+    for (const match of text.matchAll(/Use prompt\s+([a-z0-9-]+)\s+with:/g)) {
+      if (!registry.prompts.has(match[1])) {
+        failures.push(`${file}: unknown prompt example ${match[1]}`);
+      }
+    }
+
+    for (const match of text.matchAll(/Use\s+([a-z0-9-]+)\s+with:/g)) {
+      if (match[1] === "prompt") continue;
+      if (!registry.tools.has(match[1])) {
+        failures.push(`${file}: unknown tool example ${match[1]}`);
+      }
+    }
+  }
+
+  assert.deepEqual(failures, [], "Documented examples must reference current tools and arguments");
+}
+
+const registry = collectRegistry();
+const files = markdownFiles();
+
+validateReferenceDrift(registry);
+validateMarkdownLinks(files);
+validateExampleToolCalls(files, registry);
+
+console.log(
+  `Validated docs drift and examples: ${registry.tools.size} tools, ${registry.prompts.size} prompts, ${registry.resources.size} resources, ${files.length} markdown files.`,
+);

--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const cacheDir = mkdtempSync(join(tmpdir(), "mcp-vcf-orchestrator-npm-cache-"));
+const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+
+try {
+  const result = spawnSync(npm, ["pack", "--dry-run", "--json"], {
+    cwd: root,
+    encoding: "utf8",
+    env: { ...process.env, npm_config_cache: cacheDir },
+  });
+
+  if (result.status !== 0) {
+    process.stderr.write(result.stdout);
+    process.stderr.write(result.stderr);
+    process.exit(result.status ?? 1);
+  }
+
+  const packages = JSON.parse(result.stdout);
+  const files = new Set(packages[0].files.map((file) => file.path));
+
+  const requiredFiles = [
+    "README.md",
+    "package.json",
+    "dist/index.js",
+    "dist/client/index.js",
+    "dist/tools/workflow-tools.js",
+    "docs/index.md",
+    "docs/reference/tools.md",
+    "docs/reference/resources-prompts.md",
+    "docs/vro-artifact-authoring.md",
+    "examples/README.md",
+    "examples/workflow-artifact.md",
+    "examples/artifact-promotion.md",
+    "examples/template-catalog-subscription.md",
+  ];
+
+  const forbiddenPatterns = [
+    /^src\//,
+    /^test\//,
+    /^scripts\//,
+    /^artifacts\//,
+    /^node_modules\//,
+    /^coverage\//,
+    /^docs\/\.vitepress\//,
+    /^\.env$/,
+    /^\.env\.example$/,
+    /^\.npmrc$/,
+    /^tsconfig\.json$/,
+    /^package-lock\.json$/,
+  ];
+
+  assert.deepEqual(
+    requiredFiles.filter((file) => !files.has(file)),
+    [],
+    "npm package is missing required files",
+  );
+
+  assert.deepEqual(
+    [...files].filter((file) =>
+      forbiddenPatterns.some((pattern) => pattern.test(file)),
+    ),
+    [],
+    "npm package contains files that should not be published",
+  );
+
+  console.log(
+    `Validated npm package contents: ${packages[0].files.length} files, ${packages[0].unpackedSize} unpacked bytes.`,
+  );
+} finally {
+  rmSync(cacheDir, { recursive: true, force: true });
+}

--- a/src/tools/package-tools.ts
+++ b/src/tools/package-tools.ts
@@ -20,7 +20,7 @@ export function registerPackageTools(
           .optional()
           .describe("Filter packages by name (substring match)"),
       }),
-      annotations: { readOnlyHint: false },
+      annotations: { readOnlyHint: true },
     },
     async ({ filter }): Promise<CallToolResult> => {
       try {
@@ -70,7 +70,7 @@ export function registerPackageTools(
             "The fully-qualified package name (e.g. com.example.mypackage)",
           ),
       }),
-      annotations: { readOnlyHint: false },
+      annotations: { readOnlyHint: true },
     },
     async ({ name }): Promise<CallToolResult> => {
       try {

--- a/test/artifact-tools.test.mjs
+++ b/test/artifact-tools.test.mjs
@@ -77,9 +77,21 @@ test("action tools format detail responses and pass create payloads", async () =
 });
 
 test("configuration tools format attributes and guard imports and deletes", async () => {
+  let created;
+  let updated;
+  let exported;
   let imported;
   let deletedId;
   const handlers = registeredTools(registerConfigTools, {
+    listConfigurations: async (filter) => ({
+      link: [
+        {
+          id: "config-1",
+          name: `Settings ${filter}`,
+          description: "Runtime settings",
+        },
+      ],
+    }),
     getConfiguration: async (id) => ({
       id,
       name: "Settings",
@@ -93,6 +105,17 @@ test("configuration tools format attributes and guard imports and deletes", asyn
         },
       ],
     }),
+    createConfiguration: async (categoryId, name, description, attributes) => {
+      created = { categoryId, name, description, attributes };
+      return { id: "config-2", name };
+    },
+    updateConfiguration: async (id, patch) => {
+      updated = { id, patch };
+    },
+    exportConfigurationFile: async (id, fileName, overwrite) => {
+      exported = { id, fileName, overwrite };
+      return `/tmp/configurations/${fileName}`;
+    },
     getConfigurationDirectory: () => "/tmp/configurations",
     importConfigurationFile: async (categoryId, fileName) => {
       imported = { categoryId, fileName };
@@ -102,10 +125,54 @@ test("configuration tools format attributes and guard imports and deletes", asyn
     },
   });
 
+  const list = await handlers.get("list-configurations")({ filter: "prod" });
+  assert.match(list.content[0].text, /Settings prod \(id: config-1\)/);
+  assert.match(list.content[0].text, /Runtime settings/);
+
   const detail = await handlers.get("get-configuration")({ id: "config-1" });
   assert.match(detail.content[0].text, /Configuration: Settings/);
   assert.match(detail.content[0].text, /host \(string\):/);
   assert.match(detail.content[0].text, /Host name/);
+
+  const createResult = await handlers.get("create-configuration")({
+    categoryId: "category-1",
+    name: "Settings",
+    description: "Runtime settings",
+    attributes: [{ name: "host", type: "string", value: "vcfa.example.test" }],
+  });
+  assert.deepEqual(created, {
+    categoryId: "category-1",
+    name: "Settings",
+    description: "Runtime settings",
+    attributes: [{ name: "host", type: "string", value: "vcfa.example.test" }],
+  });
+  assert.match(createResult.content[0].text, /ID: config-2/);
+
+  await handlers.get("update-configuration")({
+    id: "config-1",
+    description: "Updated settings",
+    attributes: [{ name: "enabled", type: "boolean", value: "true" }],
+  });
+  assert.deepEqual(updated, {
+    id: "config-1",
+    patch: {
+      name: undefined,
+      description: "Updated settings",
+      attributes: [{ name: "enabled", type: "boolean", value: "true" }],
+    },
+  });
+
+  const exportResult = await handlers.get("export-configuration-file")({
+    id: "config-1",
+    fileName: "settings.vsoconf",
+    overwrite: true,
+  });
+  assert.deepEqual(exported, {
+    id: "config-1",
+    fileName: "settings.vsoconf",
+    overwrite: true,
+  });
+  assert.match(exportResult.content[0].text, /exported successfully/);
 
   const importRefused = await handlers.get("import-configuration-file")({
     categoryId: "category-1",
@@ -225,6 +292,8 @@ test("diff-action-file is read-only, delegates exact params, and reports errors"
 });
 
 test("resource tools format lists and guard updates and deletes", async () => {
+  let exported;
+  let imported;
   let updated;
   let deleted;
   const handlers = registeredTools(registerResourceTools, {
@@ -239,6 +308,14 @@ test("resource tools format lists and guard updates and deletes", async () => {
         },
       ],
     }),
+    getResourceDirectory: () => "/tmp/resources",
+    exportResource: async (id, fileName, overwrite) => {
+      exported = { id, fileName, overwrite };
+      return `/tmp/resources/${fileName}`;
+    },
+    importResource: async (categoryId, fileName) => {
+      imported = { categoryId, fileName };
+    },
     updateResourceContent: async (id, fileName, changesetSha) => {
       updated = { id, fileName, changesetSha };
     },
@@ -255,6 +332,36 @@ test("resource tools format lists and guard updates and deletes", async () => {
     /Logo portal \(id: resource-1\) \[image\/png\]/,
   );
   assert.match(list.content[0].text, /category: Branding/);
+
+  const exportResult = await handlers.get("export-resource-element")({
+    id: "resource-1",
+    fileName: "logo.png",
+    overwrite: true,
+  });
+  assert.deepEqual(exported, {
+    id: "resource-1",
+    fileName: "logo.png",
+    overwrite: true,
+  });
+  assert.match(exportResult.content[0].text, /exported successfully/);
+
+  const importRefused = await handlers.get("import-resource-element")({
+    categoryId: "resource-category-1",
+    fileName: "logo.png",
+    confirm: false,
+  });
+  assert.equal(imported, undefined);
+  assert.match(importRefused.content[0].text, /\/tmp\/resources/);
+
+  await handlers.get("import-resource-element")({
+    categoryId: "resource-category-1",
+    fileName: "logo.png",
+    confirm: true,
+  });
+  assert.deepEqual(imported, {
+    categoryId: "resource-category-1",
+    fileName: "logo.png",
+  });
 
   const updateRefused = await handlers.get("update-resource-element")({
     id: "resource-1",

--- a/test/deployment-tools.test.mjs
+++ b/test/deployment-tools.test.mjs
@@ -28,6 +28,81 @@ test("list-deployment-actions reports empty action lists", async () => {
   );
 });
 
+test("deployment tools list, get, create, and delete with confirmation", async () => {
+  let createParams;
+  let deletedId;
+  const handlers = registeredDeploymentTools({
+    listDeployments: async (search, projectId) => ({
+      totalElements: 1,
+      content: [
+        {
+          id: "deployment-1",
+          name: `Ubuntu ${search}`,
+          status: "CREATE_SUCCESSFUL",
+          projectId,
+        },
+      ],
+    }),
+    getDeployment: async (id) => ({
+      id,
+      name: "Ubuntu VM",
+      status: "CREATE_SUCCESSFUL",
+      description: "Example deployment",
+      projectName: "Development",
+      catalogItemId: "catalog-1",
+    }),
+    createDeploymentFromCatalogItem: async (params) => {
+      createParams = params;
+      return { id: "request-1", name: params.deploymentName, status: "SUBMITTED" };
+    },
+    deleteDeployment: async (id) => {
+      deletedId = id;
+    },
+  });
+
+  const list = await handlers.get("list-deployments")({
+    search: "22.04",
+    projectId: "project-1",
+  });
+  assert.match(list.content[0].text, /Ubuntu 22\.04 \(id: deployment-1\)/);
+  assert.match(list.content[0].text, /projectId: project-1/);
+
+  const detail = await handlers.get("get-deployment")({ id: "deployment-1" });
+  assert.match(detail.content[0].text, /Deployment: Ubuntu VM/);
+  assert.match(detail.content[0].text, /Catalog Item ID: catalog-1/);
+
+  const created = await handlers.get("create-deployment")({
+    catalogItemId: "catalog-1",
+    deploymentName: "Ubuntu VM",
+    projectId: "project-1",
+    version: "1.0.0",
+    reason: "Test deployment",
+    inputs: { size: "small" },
+  });
+  assert.deepEqual(createParams, {
+    catalogItemId: "catalog-1",
+    deploymentName: "Ubuntu VM",
+    projectId: "project-1",
+    version: "1.0.0",
+    reason: "Test deployment",
+    inputs: { size: "small" },
+  });
+  assert.match(created.content[0].text, /ID: request-1/);
+
+  const refused = await handlers.get("delete-deployment")({
+    id: "deployment-1",
+    confirm: false,
+  });
+  assert.equal(deletedId, undefined);
+  assert.match(refused.content[0].text, /setting confirm to true/);
+
+  await handlers.get("delete-deployment")({
+    id: "deployment-1",
+    confirm: true,
+  });
+  assert.equal(deletedId, "deployment-1");
+});
+
 test("list-deployment-actions formats actions and input hints", async () => {
   const handlers = registeredDeploymentTools({
     listDeploymentActions: async () => ({

--- a/test/package-tools.test.mjs
+++ b/test/package-tools.test.mjs
@@ -13,6 +13,95 @@ function registeredPackageTools(client) {
   return handlers;
 }
 
+function registeredPackageToolsWithConfigs(client) {
+  const handlers = new Map();
+  const configs = new Map();
+  const server = {
+    registerTool(name, config, handler) {
+      configs.set(name, config);
+      handlers.set(name, handler);
+    },
+  };
+  registerPackageTools(server, client);
+  return { handlers, configs };
+}
+
+test("package list and get tools are read-only and format metadata", async () => {
+  const { handlers, configs } = registeredPackageToolsWithConfigs({
+    listPackages: async (filter) => ({
+      link: [
+        {
+          name: `com.example.${filter}`,
+          version: "1.2.3",
+          description: "Example package",
+        },
+      ],
+    }),
+    getPackage: async (name) => ({
+      name,
+      version: "1.2.3",
+      description: "Example package",
+    }),
+  });
+
+  assert.equal(configs.get("list-packages").annotations.readOnlyHint, true);
+  assert.equal(configs.get("get-package").annotations.readOnlyHint, true);
+
+  const list = await handlers.get("list-packages")({ filter: "demo" });
+  assert.match(list.content[0].text, /com\.example\.demo v1\.2\.3/);
+  assert.match(list.content[0].text, /Example package/);
+
+  const detail = await handlers.get("get-package")({
+    name: "com.example.demo",
+  });
+  assert.match(detail.content[0].text, /Package: com\.example\.demo/);
+  assert.match(detail.content[0].text, /Version: 1\.2\.3/);
+});
+
+test("package export and import delegate paths and confirmation", async () => {
+  let exported;
+  let imported;
+  const handlers = registeredPackageTools({
+    getPackageDirectory: () => "/tmp/packages",
+    exportPackage: async (name, fileName, overwrite) => {
+      exported = { name, fileName, overwrite };
+      return `/tmp/packages/${fileName}`;
+    },
+    importPackage: async (fileName, overwrite) => {
+      imported = { fileName, overwrite };
+    },
+  });
+
+  const exportResult = await handlers.get("export-package")({
+    name: "com.example.demo",
+    fileName: "com.example.demo.package",
+    overwrite: true,
+  });
+  assert.deepEqual(exported, {
+    name: "com.example.demo",
+    fileName: "com.example.demo.package",
+    overwrite: true,
+  });
+  assert.match(exportResult.content[0].text, /exported successfully/);
+
+  const refused = await handlers.get("import-package")({
+    fileName: "com.example.demo.package",
+    confirm: false,
+  });
+  assert.equal(imported, undefined);
+  assert.match(refused.content[0].text, /\/tmp\/packages/);
+
+  await handlers.get("import-package")({
+    fileName: "com.example.demo.package",
+    overwrite: false,
+    confirm: true,
+  });
+  assert.deepEqual(imported, {
+    fileName: "com.example.demo.package",
+    overwrite: false,
+  });
+});
+
 test("delete-package refuses to submit unless confirmed", async () => {
   let calls = 0;
   const handlers = registeredPackageTools({


### PR DESCRIPTION
## Summary

- Add a one-command project validation gate covering build, tests, coverage thresholds, docs/example drift, docs build, and npm package content checks.
- Add checked examples for workflow artifact creation, artifact promotion, and template/catalog/subscription workflows.
- Refresh README, operational docs, agent guidance, and environment sample for the new validation flow.
- Fix npm audit alerts by refreshing vulnerable transitive dependency versions in `package-lock.json`.

## Validation

- `npm audit --json` reported 0 vulnerabilities.
- `npm run validate` passed end to end.
- `git diff --check` passed.