### PR TITLE
[codex] Add package-first vRO publishing flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ VCFA_IGNORE_TLS=false
 # VCFA_RESOURCE_DIR=/custom/path/to/artifacts/resources
 # VCFA_PACKAGE_DIR=/custom/path/to/artifacts/packages
 
+# Optional: stable project package reused by package-first workflows
+# VCFA_PROJECT_PACKAGE_NAME=com.example.project
+# VCFA_PROJECT_PACKAGE_DESCRIPTION=Reusable package for this automation project
+
 # Optional: override persisted context snapshot output
 # If unset, snapshots prefer the MCP client's current workspace root at artifacts/context/
 # VCFA_CONTEXT_DIR=/custom/path/to/artifacts/context

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 docs/.vitepress/cache/
 docs/.vitepress/dist/
 .env
+artifacts/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ This custom agent assists with VCF Automation Orchestrator workflows, workflow e
 - Catalog items: `list-catalog-items`, `get-catalog-item`
 - Deployments: `list-deployments`, `get-deployment`, `create-deployment`, `delete-deployment`, `list-deployment-actions`, `run-deployment-action`
 - Templates: `list-templates`, `get-template`, `create-template`, `delete-template`
-- Packages: `list-packages`, `get-package`, `export-package`, `preflight-package`, `import-package`, `delete-package`
+- Packages: `list-packages`, `get-package`, `create-package`, `ensure-project-package`, `add-workflow-to-project-package`, `add-action-to-project-package`, `add-configuration-to-project-package`, `add-resource-to-project-package`, `rebuild-project-package`, `export-project-package`, `get-package-import-details`, `get-project-package-import-details`, `export-package`, `preflight-package`, `import-package`, `import-project-package`, `delete-package`
 - Plugins: `list-plugins`
 - Context and promotion: `collect-context-snapshot`, `prepare-artifact-promotion`
 
@@ -39,6 +39,12 @@ This custom agent assists with VCF Automation Orchestrator workflows, workflow e
 
 - Start with read-only discovery tools or `collect-context-snapshot` in unfamiliar environments.
 - Do not invent VCF Automation/vRO IDs, schemas, workflow parameters, action contracts, project IDs, category IDs, or blueprint YAML fields. If discovery cannot find a required fact, stop and report what is missing.
+- When a workflow step only invokes one existing vRO action, use a native action workflow item instead of a scriptable task that calls `System.getModule`. Use scriptable tasks for multiple action calls or additional orchestration logic.
+- Prefer horizontal left-to-right workflow layouts when authoring or editing workflow XML/package content.
+- Workflows with user inputs need a valid `input_form_` so they can be started from the vRO UI. Use UTF-16BE JSON with a BOM, page-level titles, section objects with only `id` and `fields`, field IDs that match `schema` keys, and `options.externalValidations: []`; do not add section `title` or unverified field properties such as `size`.
+- Publish reusable vRO content through the project package path by default: `ensure-project-package`, add the discovered workflow/action/configuration/resource to that exact package, `rebuild-project-package`, `export-project-package`, `get-project-package-import-details`, then `import-project-package`.
+- Reuse the exact `VCFA_PROJECT_PACKAGE_NAME` package for package-first work. Do not create new packages with random, timestamped, or task-specific names.
+- Use direct artifact imports such as `import-workflow-file` or `import-action-file` only for narrow validation or explicitly requested single-artifact tests; project content should move into vRO via packages.
 - Use preflight tools before artifact imports. Use `prepare-artifact-promotion` when replacing live workflow, action, configuration, or package artifacts.
 - Run live write, import, day-2 action, and delete operations only after the user confirms the exact target and impact.
 - Keep local artifact paths inside configured directories such as `VCFA_ARTIFACT_DIR`, `VCFA_WORKFLOW_DIR`, `VCFA_ACTION_DIR`, `VCFA_CONFIGURATION_DIR`, `VCFA_RESOURCE_DIR`, `VCFA_PACKAGE_DIR`, and `VCFA_CONTEXT_DIR`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Validate**: `npm run validate` – builds, runs tests, enforces conservative coverage thresholds, checks docs/examples drift, builds docs, and validates npm package contents.
 - **Docs/examples drift**: `npm run validate:docs` – checks registered tool, prompt, and resource names against reference docs, validates local Markdown links, and verifies documented tool-call examples use current top-level argument names.
 - **Package contents**: `npm run validate:package` – runs `npm pack --dry-run --json` with an isolated temporary npm cache and verifies the published file set.
-- **Environment**: The server reads VCFA_HOST, VCFA_USERNAME, VCFA_ORGANIZATION, VCFA_PASSWORD, and optionally VCFA_IGNORE_TLS, VCFA_ARTIFACT_DIR, VCFA_PACKAGE_DIR, VCFA_RESOURCE_DIR, VCFA_WORKFLOW_DIR, VCFA_ACTION_DIR, VCFA_CONFIGURATION_DIR, and VCFA_CONTEXT_DIR from the environment (see `.env.example`).
+- **Environment**: The server reads VCFA_HOST, VCFA_USERNAME, VCFA_ORGANIZATION, VCFA_PASSWORD, and optionally VCFA_IGNORE_TLS, VCFA_ARTIFACT_DIR, VCFA_PACKAGE_DIR, VCFA_RESOURCE_DIR, VCFA_WORKFLOW_DIR, VCFA_ACTION_DIR, VCFA_CONFIGURATION_DIR, VCFA_CONTEXT_DIR, VCFA_PROJECT_PACKAGE_NAME, and VCFA_PROJECT_PACKAGE_DESCRIPTION from the environment (see `.env.example`).
 
 ## Architecture Overview
 
@@ -31,6 +31,11 @@ Key architectural concepts:
 - **Configuration Management**: Settings are stored as configuration elements within the platform; the server treats them as first‑class data objects.
 - **Event‑Driven Subscriptions**: The server can subscribe to VMware event topics (e.g., `compute.allocation.pre`) and trigger ABX or VRO workflows.
 - **Artifact Safety**: Local artifact tools keep files inside configured artifact directories; imports should be preceded by preflight, diff, optional backup, and explicit confirmation.
+- **Workflow Authoring**: Use native vRO action workflow items for workflow steps that only invoke one existing action; use scriptable tasks for multiple action calls or additional orchestration logic. Prefer horizontal left-to-right workflow layouts.
+- **Workflow Input Forms**: Workflows with user inputs need a valid `input_form_` for the vRO start page. Use UTF-16BE JSON with a BOM, page-level titles, section objects with only `id` and `fields`, matching field/schema IDs, and `options.externalValidations: []`.
+- **Package Publishing**: Publish reusable vRO content through the project package path by default: ensure the exact project package, add discovered content, rebuild, export, inspect import details, and import the package.
+- **Package Reuse**: Package-first workflows must reuse the exact project package from `VCFA_PROJECT_PACKAGE_NAME` or an explicit `packageName`; do not create random, timestamped, or task-specific packages.
+- **Direct Imports**: Use direct workflow/action/configuration imports only for narrow validation or explicitly requested single-artifact tests; project content should move into vRO via packages.
 - **Discovery Guardrails**: Prompts and docs should tell agents to discover required workflow/action/template/category/project facts instead of inventing environment-specific values.
 
 ## Key Files for Navigation

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Useful optional variables:
 | `VCFA_ACTION_DIR` | Override action artifact directory. |
 | `VCFA_CONFIGURATION_DIR` | Override configuration artifact directory. |
 | `VCFA_CONTEXT_DIR` | Override persisted context snapshot directory. If unset, context snapshots prefer the MCP client's current workspace root at `artifacts/context/`, falling back to `VCFA_ARTIFACT_DIR/context`. |
+| `VCFA_PROJECT_PACKAGE_NAME` | Stable fully-qualified vRO package name reused by package-first project workflows, for example `com.example.project`. |
+| `VCFA_PROJECT_PACKAGE_DESCRIPTION` | Optional description used only when the exact project package is explicitly created. |
 
 ## Tool Coverage
 
@@ -74,7 +76,7 @@ The server includes tools for:
 - Workflows, workflow executions, workflow artifact scaffold/preflight/diff/import/export
 - Actions and action artifact import/export/preflight/diff
 - Configuration elements and resource elements
-- vRO packages and plugins
+- vRO packages and plugins, including package-first project package reuse
 - Categories
 - Service Broker catalog items and deployments
 - Deployment day-2 actions

--- a/docs/artifacts/lifecycle.md
+++ b/docs/artifacts/lifecycle.md
@@ -12,7 +12,31 @@ Use read-only tools to identify the live asset and target category:
 - `list-packages`, `get-package`
 - `list-categories`
 
-## 2. Export
+## 2. Reuse The Project Package
+
+For package-first workflows, set `VCFA_PROJECT_PACKAGE_NAME` to one stable fully-qualified package name per project. Start with `ensure-project-package`; it reuses the exact package and creates it only when both `createIfMissing` and `confirm` are true. Do not create timestamped or task-specific packages.
+
+Publish reusable project content through this package path by default. Direct artifact imports are useful for narrow validation and one-off tests, but normal promotion into vRO should add content to the project package, rebuild it, export it, inspect package import details, and import the package.
+
+This is the default way to push content into vRO:
+
+1. Create or update the workflow, action, configuration, or resource in vRO or as a local artifact.
+2. Verify the content with read-only inspection or preflight tools.
+3. Add the live content to the stable project package.
+4. Rebuild and export that package.
+5. Inspect the exported package with `get-project-package-import-details`.
+6. Import the package only after the package name and element list match the intended project change.
+
+Add content to that package with:
+
+- `add-workflow-to-project-package`
+- `add-action-to-project-package`
+- `add-configuration-to-project-package`
+- `add-resource-to-project-package`
+
+Run `rebuild-project-package` before export.
+
+## 3. Export
 
 Export live artifacts before modifying or replacing them:
 
@@ -21,12 +45,17 @@ Export live artifacts before modifying or replacing them:
 - `export-configuration-file`
 - `export-resource-element`
 - `export-package`
+- `export-project-package`
 
 Export targets must be plain file names under the configured artifact directory. Existing targets require `overwrite: true`.
 
-## 3. Create Or Update Locally
+## 4. Create Or Update Locally
 
 Use `scaffold-workflow-file` to generate `.workflow` artifacts from structured metadata and linear scriptable tasks.
+
+For reusable workflows, a local scaffold is an authoring and validation artifact. After preflight and any live validation, publish the workflow into vRO through the project package path rather than treating the direct workflow import as the final promotion mechanism.
+
+Use native action workflow items for workflow steps that only execute one existing vRO action. Use scriptable tasks when the workflow item performs multiple action calls or additional JavaScript logic. When editing XML/package content, prefer horizontal item placement for simple linear workflows.
 
 For other artifact types, place local files in the matching configured directory:
 
@@ -36,7 +65,7 @@ For other artifact types, place local files in the matching configured directory
 - packages: `.package` or `.zip`
 - resources: any supported binary/text resource file
 
-## 4. Preflight
+## 5. Preflight
 
 Run preflight before any import:
 
@@ -44,10 +73,11 @@ Run preflight before any import:
 - `preflight-action-file`
 - `preflight-configuration-file`
 - `preflight-package`
+- `get-project-package-import-details`
 
 Preflight catches local path safety issues, malformed archives, encoding problems, recognizable metadata, and workflow/action-specific concerns before live upload.
 
-## 5. Diff
+## 6. Diff
 
 Use diffs when replacing workflow or action artifacts:
 
@@ -56,11 +86,11 @@ Use diffs when replacing workflow or action artifacts:
 
 Diffs can compare two local artifacts or a live export against a local artifact.
 
-## 6. Promote
+## 7. Promote
 
 Use `prepare-artifact-promotion` for a reviewable summary before import. It can combine preflight, optional backup export, diff summaries, target validation, and an exact recommended import call.
 
-## 7. Import With Confirmation
+## 8. Import With Confirmation
 
 Imports and destructive operations require explicit confirmation. Recommended final checks:
 
@@ -70,7 +100,18 @@ Imports and destructive operations require explicit confirmation. Recommended fi
 - Diffs match the intended change.
 - Backup export succeeded when required.
 
-## 8. Verify
+For project content, use:
+
+1. `ensure-project-package`
+2. `add-*-to-project-package`
+3. `rebuild-project-package`
+4. `export-project-package`
+5. `get-project-package-import-details`
+6. `import-project-package`
+
+`import-project-package` validates that the local package file identifies the same package name requested by `packageName` or `VCFA_PROJECT_PACKAGE_NAME`. If the file contains a different package, stop and export the correct project package before importing.
+
+## 9. Verify
 
 After import, verify with read-only or execution tools:
 

--- a/docs/artifacts/workflow-authoring.md
+++ b/docs/artifacts/workflow-authoring.md
@@ -11,7 +11,35 @@ A `.workflow` file is a ZIP archive containing at least:
 
 `workflow-content` is XML encoded as UTF-16 with a BOM. The XML root is a vRO workflow document with metadata such as `id`, `version`, and `api-version`.
 
-Workflow inputs live under `<input>`, outputs under `<output>`, and scriptable task logic lives in `<workflow-item type="task">` nodes.
+Workflow inputs live under `<input>` and outputs under `<output>`. Scriptable task logic lives in `<workflow-item type="task">` nodes.
+
+When a workflow only needs to execute one existing vRO action, model that step as a native vRO action workflow item instead of a scriptable task that calls `System.getModule(...)`. Use a scriptable task when the workflow item performs more than one action call or needs extra JavaScript logic such as branching, input shaping, validation, or result aggregation.
+
+Prefer horizontal workflow layouts in authored XML/package content. Place sequential items from left to right by increasing `x` positions while keeping `y` positions stable unless a branch needs vertical separation.
+
+## Native Action Item Shape
+
+In exported vRO workflow XML, a native action item is still represented as a `type="task"` workflow item, but it includes a `script-module="<module>/<actionName>"` attribute. vRO also exports a generated script that assigns the action return value to `actionResult`; keep that generated shape when manually authoring package content.
+
+```xml
+<workflow-item name="item0" out-name="item1" type="task" script-module="com.example.actions/echo">
+  <display-name><![CDATA[Call echo]]></display-name>
+  <script encoded="false"><![CDATA[actionResult = System.getModule("com.example.actions").echo(message);]]></script>
+  <in-binding>
+    <bind name="message" type="string" export-name="message"/>
+  </in-binding>
+  <out-binding>
+    <bind name="actionResult" type="string" export-name="result"/>
+  </out-binding>
+  <position y="100.0" x="180.0"/>
+</workflow-item>
+<workflow-item name="item1" type="end" end-mode="0">
+  <in-binding/>
+  <position y="100.0" x="420.0"/>
+</workflow-item>
+```
+
+Do not omit the generated `actionResult = System.getModule(...).action(...)` script when hand-editing exported package content. A `script-module` attribute without the generated script can import and run but may return `undefined`.
 
 ## Scriptable Task Bindings
 
@@ -38,6 +66,8 @@ Use `scaffold-workflow-file` with:
 - explicit in/out bindings per task
 
 Then run `preflight-workflow-file` before import.
+
+The current scaffold tool emits scriptable task items. For a single-action wrapper that must use a native action element, start from an exported valid workflow/package shape or manually author the action item before publishing through the project package flow.
 
 ## Robust Script Helpers
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -31,6 +31,8 @@ It uses the returned bearer token for later VCF Automation, Service Broker, Clou
 | `VCFA_ACTION_DIR` | Override the action artifact directory. |
 | `VCFA_CONFIGURATION_DIR` | Override the configuration artifact directory. |
 | `VCFA_CONTEXT_DIR` | Override the persisted context snapshot directory. If unset, context snapshots prefer the MCP client's current workspace root at `artifacts/context/`, falling back to `VCFA_ARTIFACT_DIR/context`. |
+| `VCFA_PROJECT_PACKAGE_NAME` | Stable fully-qualified package name reused by package-first workflows, for example `com.example.project`. |
+| `VCFA_PROJECT_PACKAGE_DESCRIPTION` | Optional description used if the exact project package is explicitly created. |
 
 ## Artifact Directories
 

--- a/docs/how-tos/workflows.md
+++ b/docs/how-tos/workflows.md
@@ -17,9 +17,13 @@ Recommended tool sequence:
 
 `run-workflow-and-wait` validates inputs before running and polls until completion. If the workflow fails, the response includes current item details, stack information, log excerpts, and warnings when diagnostics cannot be fetched.
 
-## Scaffold, Import, And Test A Workflow
+## Scaffold, Publish, And Test A Workflow
 
 Use `scaffold-workflow-file` for real importable `.workflow` artifacts instead of hand-building ZIP/XML content.
+
+For workflows that only call one existing vRO action, prefer a native action workflow item and publish it through the project package flow. Use a scriptable task when the workflow item performs multiple action calls or extra JavaScript logic. For authored XML/package content, arrange simple linear workflows horizontally from left to right.
+
+Generated workflow artifacts include an `input_form_` entry for workflow inputs so the vRO UI can render the start form. The form uses UTF-16BE with a BOM, a single `page_general` page, section objects with only `id` and `fields`, and field entries that reference matching schema keys. Do not add section titles or ad hoc field properties such as `size`; vRO rejects those shapes when opening the workflow start page.
 
 ```text
 User: Create a simple workflow artifact called Echo Message. It should take
@@ -30,10 +34,17 @@ Recommended tool sequence:
 
 1. `scaffold-workflow-file` with workflow inputs, outputs, tasks, and bindings.
 2. `preflight-workflow-file(fileName: "echo-message.workflow")`.
-3. `list-categories(type: "WorkflowCategory", filter: "Dev")`.
-4. `import-workflow-file(..., confirm: true)`.
-5. `list-workflows(filter: "Echo Message")`.
-6. `run-workflow-and-wait(...)`.
+3. For a narrow validation run only, `list-categories(type: "WorkflowCategory", filter: "Dev")` and `import-workflow-file(..., confirm: true)`.
+4. Verify the workflow with `list-workflows(filter: "Echo Message")`, `get-workflow`, and `run-workflow-and-wait(...)`.
+5. Publish reusable project content through the project package:
+   - `ensure-project-package(packageName: "com.example.project")`
+   - `add-workflow-to-project-package(packageName: "com.example.project", workflowId: "<workflow-id>", confirm: true)`
+   - `rebuild-project-package(packageName: "com.example.project", confirm: true)`
+   - `export-project-package(packageName: "com.example.project", fileName: "com.example.project.package", overwrite: true)`
+   - `get-project-package-import-details(packageName: "com.example.project", fileName: "com.example.project.package")`
+   - `import-project-package(packageName: "com.example.project", fileName: "com.example.project.package", overwrite: true, confirm: true)`
+
+Direct `import-workflow-file` is a validation or one-off test path. The project package path is the normal way to push reusable workflow content into vRO.
 
 Example scaffold task:
 
@@ -45,6 +56,25 @@ Example scaffold task:
   "outBindings": [{ "name": "result", "type": "string", "target": "result" }]
 }
 ```
+
+This scaffold example is appropriate because it contains custom inline echo logic. If the workflow were only wrapping an existing `echo` action, use a native action workflow item instead of a scriptable task that only calls the action.
+
+Native action wrapper XML should preserve vRO's exported action-item shape:
+
+```xml
+<workflow-item name="item0" out-name="item1" type="task" script-module="com.example.actions/echo">
+  <script encoded="false"><![CDATA[actionResult = System.getModule("com.example.actions").echo(message);]]></script>
+  <in-binding>
+    <bind name="message" type="string" export-name="message"/>
+  </in-binding>
+  <out-binding>
+    <bind name="actionResult" type="string" export-name="result"/>
+  </out-binding>
+  <position y="100.0" x="180.0"/>
+</workflow-item>
+```
+
+The `script-module` attribute marks the item as a native action item. The generated `actionResult` script and output binding are still required for the action return value to reach the workflow output.
 
 ## Inspect Platform Capabilities Before Writing Code
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -89,7 +89,7 @@ Get detailed information about a specific workflow including its input and outpu
 
 ### `create-workflow`
 
-Create a new empty workflow in VCF Automation Orchestrator. Use `list-categories` first to find a workflow category ID. For real workflow content, prefer `scaffold-workflow-file` followed by `import-workflow-file`.
+Create a new empty workflow in VCF Automation Orchestrator. Use `list-categories` first to find a workflow category ID. For reusable workflow content, prefer publishing through the project package path after local authoring and validation.
 
 ::: details Parameters
 | Parameter | Type | Required | Default | Description |
@@ -188,7 +188,7 @@ Export a vRO workflow as a `.workflow` file under the configured workflow artifa
 
 ### `scaffold-workflow-file`
 
-Generate a local importable `.workflow` artifact under the configured workflow artifact directory from structured metadata, linear scriptable tasks, scripts, and bindings. Use `import-workflow-file` to upload it afterwards.
+Generate a local importable `.workflow` artifact under the configured workflow artifact directory from structured metadata, linear scriptable tasks, scripts, bindings, and a vRO-compatible `input_form_` for declared inputs. Use this scaffold when a scriptable task is appropriate, such as custom JavaScript logic, multiple action calls, or orchestration around an action. For a workflow step that only invokes one existing vRO action, prefer a native action workflow item in authored XML/package content. For reusable project content, publish the resulting workflow through the project package flow after preflight; use `import-workflow-file` only for narrow validation or explicitly requested one-off tests.
 
 ::: details Parameters
 | Parameter | Type | Required | Default | Description |
@@ -202,7 +202,7 @@ Generate a local importable `.workflow` artifact under the configured workflow a
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `name` | string | Yes | - | Workflow display name. |
-| `tasks` | array | Yes | - | Linear sequence of scriptable tasks. At least one task is required. |
+| `tasks` | array | Yes | - | Linear sequence of scriptable tasks. At least one task is required. Prefer native action workflow items outside this scaffold when a step only invokes one existing vRO action. |
 | `id` | string | No | generated UUID | Workflow UUID. |
 | `description` | string | No | - | Workflow description. |
 | `version` | string | No | `1.0.0` | Workflow version metadata. |
@@ -210,6 +210,8 @@ Generate a local importable `.workflow` artifact under the configured workflow a
 | `inputs` | array | No | `[]` | Workflow input parameters. |
 | `outputs` | array | No | `[]` | Workflow output parameters. |
 | `attributes` | array | No | `[]` | Workflow-scoped attributes. |
+
+The generated `input_form_` is UTF-16BE JSON with a BOM. It places workflow inputs on a `page_general` page, uses section objects with only `id` and `fields`, maps common vRO types to compatible controls, and includes `options.externalValidations: []` for vRO UI compatibility.
 
 Workflow parameter object, used for `inputs`, `outputs`, and `attributes`:
 
@@ -270,7 +272,7 @@ Both `base` and `compare` are discriminated unions selected by `source`:
 
 ### `import-workflow-file`
 
-Import a `.workflow` file from the configured workflow artifact directory into a workflow category. Use `list-categories` with type `WorkflowCategory` to find a category ID first.
+Import a `.workflow` file from the configured workflow artifact directory into a workflow category. Use this direct import path for narrow validation or explicitly requested one-off tests; publish reusable project content through `ensure-project-package`, `add-workflow-to-project-package`, `rebuild-project-package`, `export-project-package`, `get-project-package-import-details`, and `import-project-package`.
 
 ::: details Parameters
 | Parameter | Type | Required | Default | Description |
@@ -367,7 +369,7 @@ Both `base` and `compare` are discriminated unions selected by `source`:
 
 ### `import-action-file`
 
-Import a `.action` file from the configured action artifact directory into an action category. Use `list-categories` with type `ActionCategory` to find the category name first.
+Import a `.action` file from the configured action artifact directory into an action category. Use this direct import path for narrow validation or explicitly requested one-off tests; publish reusable project content through the project package tools.
 
 ::: details Parameters
 | Parameter | Type | Required | Default | Description |
@@ -746,6 +748,148 @@ Export a vRO package as a ZIP file under the configured package artifact directo
 | `name` | string | Yes | - | Fully qualified package name to export, for example `com.example.mypackage`. |
 | `fileName` | string | Yes | - | Plain `.package` or `.zip` file name to save under the configured package artifact directory. Do not pass a path. |
 | `overwrite` | boolean | No | `false` | Overwrite the file if it already exists. |
+| `exportConfigurationAttributeValues` | boolean | No | - | Include configuration attribute values when supported by vRO. |
+| `exportGlobalTags` | boolean | No | - | Include global tags when supported by vRO. |
+| `exportVersionHistory` | boolean | No | - | Include version history when supported by vRO. |
+| `exportConfigSecureStringAttributeValues` | boolean | No | - | Include secure string configuration values when supported by vRO. |
+:::
+
+### `get-package-import-details`
+
+Analyze a local package file before import and return package elements and certificate details.
+
+::: details Parameters
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `fileName` | string | Yes | - | Plain `.package` or `.zip` file name under the configured package artifact directory. |
+:::
+
+### `create-package`
+
+Create a vRO package by exact fully qualified name. Refuses to create if the package already exists.
+
+::: details Parameters
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `name` | string | Yes | - | Exact fully qualified package name. |
+| `description` | string | No | - | Package description. |
+| `confirm` | boolean | Yes | - | Must be `true` to create the package. |
+:::
+
+### `ensure-project-package`
+
+Resolve and reuse the exact configured project package. Creates it only when `createIfMissing` and `confirm` are both `true`.
+
+::: details Parameters
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `packageName` | string | No | `VCFA_PROJECT_PACKAGE_NAME` | Exact project package name. |
+| `description` | string | No | `VCFA_PROJECT_PACKAGE_DESCRIPTION` | Description used only when the package is created. |
+| `createIfMissing` | boolean | No | `false` | Create the exact package if it is missing. |
+| `confirm` | boolean | No | `false` | Must be `true` with `createIfMissing` to create. |
+:::
+
+### `add-workflow-to-project-package`
+
+Add a workflow and dependencies to the exact project package.
+
+::: details Parameters
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `packageName` | string | No | `VCFA_PROJECT_PACKAGE_NAME` | Exact package name. |
+| `workflowId` | string | Yes | - | Workflow ID to add. |
+| `confirm` | boolean | Yes | - | Must be `true` to add content. |
+:::
+
+### `add-action-to-project-package`
+
+Add an action and dependencies to the exact project package.
+
+::: details Parameters
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `packageName` | string | No | `VCFA_PROJECT_PACKAGE_NAME` | Exact package name. |
+| `categoryName` | string | Yes | - | Action category/module name. |
+| `actionName` | string | Yes | - | Action name. |
+| `confirm` | boolean | Yes | - | Must be `true` to add content. |
+:::
+
+### `add-configuration-to-project-package`
+
+Add a configuration element and dependencies to the exact project package.
+
+::: details Parameters
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `packageName` | string | No | `VCFA_PROJECT_PACKAGE_NAME` | Exact package name. |
+| `configurationId` | string | Yes | - | Configuration element ID. |
+| `confirm` | boolean | Yes | - | Must be `true` to add content. |
+:::
+
+### `add-resource-to-project-package`
+
+Add a resource element and dependencies to the exact project package.
+
+::: details Parameters
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `packageName` | string | No | `VCFA_PROJECT_PACKAGE_NAME` | Exact package name. |
+| `resourceId` | string | Yes | - | Resource element ID. |
+| `confirm` | boolean | Yes | - | Must be `true` to add content. |
+:::
+
+### `rebuild-project-package`
+
+Rebuild the exact project package after adding content.
+
+::: details Parameters
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `packageName` | string | No | `VCFA_PROJECT_PACKAGE_NAME` | Exact package name. |
+| `confirm` | boolean | Yes | - | Must be `true` to rebuild. |
+:::
+
+### `export-project-package`
+
+Export the exact project package to the configured package artifact directory.
+
+::: details Parameters
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `packageName` | string | No | `VCFA_PROJECT_PACKAGE_NAME` | Exact package name. |
+| `fileName` | string | No | `{packageName}.package` | Output package file name. |
+| `overwrite` | boolean | No | `false` | Overwrite the local package file if it exists. |
+| `exportConfigurationAttributeValues` | boolean | No | - | Include configuration attribute values when supported by vRO. |
+| `exportGlobalTags` | boolean | No | - | Include global tags when supported by vRO. |
+| `exportVersionHistory` | boolean | No | - | Include version history when supported by vRO. |
+| `exportConfigSecureStringAttributeValues` | boolean | No | - | Include secure string configuration values when supported by vRO. |
+:::
+
+### `get-project-package-import-details`
+
+Analyze an exported project package file before import.
+
+::: details Parameters
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `packageName` | string | No | `VCFA_PROJECT_PACKAGE_NAME` | Exact package name used for default file naming. |
+| `fileName` | string | No | `{packageName}.package` | Package file name to analyze. |
+:::
+
+### `import-project-package`
+
+Import an exported project package file.
+
+::: details Parameters
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `packageName` | string | No | `VCFA_PROJECT_PACKAGE_NAME` | Exact package name used for default file naming. |
+| `fileName` | string | No | `{packageName}.package` | Package file name to import. |
+| `overwrite` | boolean | No | `true` | Whether to overwrite existing package contents. |
+| `confirm` | boolean | Yes | - | Must be `true` to import. |
+| `importConfigurationAttributeValues` | boolean | No | - | Import configuration attribute values when supported by vRO. |
+| `tagImportMode` | enum | No | - | Tag import mode: `DoNotImport`, `ImportAndOverwriteExistingValue`, or `ImportButPreserveExistingValue`. |
+| `importConfigSecureStringAttributeValues` | boolean | No | - | Import secure string configuration values when supported by vRO. |
 :::
 
 ### `preflight-package`
@@ -768,6 +912,9 @@ Import a vRO package from the configured package artifact directory into the Orc
 | `fileName` | string | Yes | - | Plain `.package` or `.zip` file name under the configured package artifact directory to import. |
 | `overwrite` | boolean | No | `true` | Whether to overwrite existing package contents. |
 | `confirm` | boolean | Yes | - | Must be `true` to confirm import. If `false`, import is not performed. |
+| `importConfigurationAttributeValues` | boolean | No | - | Import configuration attribute values when supported by vRO. |
+| `tagImportMode` | enum | No | - | Tag import mode: `DoNotImport`, `ImportAndOverwriteExistingValue`, or `ImportButPreserveExistingValue`. |
+| `importConfigSecureStringAttributeValues` | boolean | No | - | Import secure string configuration values when supported by vRO. |
 :::
 
 ### `delete-package`

--- a/docs/vro-artifact-authoring.md
+++ b/docs/vro-artifact-authoring.md
@@ -8,15 +8,70 @@ These notes capture the practical details learned while adding workflow artifact
 - The archive contains at least:
   - `workflow-info`
   - `workflow-content`
+  - `input_form_` for generated artifacts with UI-startable inputs
 - `workflow-content` is XML encoded as UTF-16 with a BOM.
+- `input_form_` is JSON encoded as UTF-16BE with a BOM.
 - The XML root looks like:
   - `<workflow xmlns="http://vmware.com/vco/workflow" ... id="..." version="..." api-version="6.0.0">`
 - User-facing inputs live under `<input>`.
 - Workflow outputs live under `<output>`.
 - Scriptable tasks are `<workflow-item type="task">` nodes with a `<script encoded="false"><![CDATA[...]]></script>` body.
+- Prefer native vRO action workflow items when a workflow step only executes one existing action. Avoid wrapping a single action in a scriptable task that only calls `System.getModule(...)`.
+- Use scriptable tasks when the item performs multiple action calls or additional orchestration logic such as validation, branching, input shaping, or result aggregation.
+- Prefer horizontal workflow layouts: arrange sequential items left-to-right with increasing `x` positions and stable `y` positions unless a branch needs vertical separation.
 - Task input/output bindings must connect workflow parameters to script variables:
   - `<in-binding><bind name="projectName" type="string" export-name="projectName"/></in-binding>`
   - `<out-binding><bind name="vms" type="Array/Properties" export-name="vms"/></out-binding>`
+
+## Workflow Input Forms
+
+Workflows intended to start from the vRO UI need a valid `input_form_` entry. The MCP scaffold builder generates this automatically from workflow inputs.
+
+Valid package/exported input form shape:
+
+```json
+{
+  "layout": {
+    "pages": [
+      {
+        "id": "page_general",
+        "sections": [
+          {
+            "id": "section_inputs",
+            "fields": [
+              {
+                "id": "message",
+                "display": "textField",
+                "signpostPosition": "right-middle",
+                "state": { "visible": true, "read-only": false }
+              }
+            ]
+          }
+        ],
+        "title": "General"
+      }
+    ]
+  },
+  "schema": {
+    "message": {
+      "id": "message",
+      "type": { "dataType": "string" },
+      "label": "Message",
+      "constraints": { "required": true }
+    }
+  },
+  "options": { "externalValidations": [] },
+  "itemId": ""
+}
+```
+
+Important compatibility notes:
+
+- Section objects must contain only `id` and `fields`; put the visible title on the page, not the section.
+- Field objects should use `id`, `display`, `signpostPosition`, and `state`. Avoid unverified properties such as `size`.
+- Field IDs must match keys in `schema`.
+- Use `textField` for string, `passwordField` for `SecureString`, `checkbox` for boolean, `decimalField` for number, and `valuePickerTree` for vRO reference types such as `VC:VirtualMachine`.
+- `preflight-workflow-file` and `preflight-package` validate `input_form_` entries and fail on the section/field shapes known to break the vRO start page.
 
 ## Import And Export Endpoints
 
@@ -91,6 +146,8 @@ var machinesViaAction = System.getModule("com.vmware.library.vra.infrastructure.
 var props = new Properties();
 props.put("name", "value");
 ```
+
+Use `System.getModule(...).actionName(...)` inside a scriptable task only when the script needs to coordinate multiple action calls or perform additional logic. For a single action call, author a native vRO action workflow item and bind its inputs/output directly.
 
 Historical built-in action observed during one live validation session:
 
@@ -171,10 +228,10 @@ npm test
 
 Before uploading local artifacts, run the matching preflight tool:
 
-- `preflight-workflow-file` checks `.workflow` ZIP structure, `workflow-info`, UTF-16 `workflow-content`, parameters, bindings, task flow, vRO type syntax, action references, and local import path safety.
+- `preflight-workflow-file` checks `.workflow` ZIP structure, `workflow-info`, UTF-16 `workflow-content`, `input_form_` JSON when present, parameters, bindings, task flow, vRO type syntax, action references, and local import path safety.
 - `preflight-action-file` checks `.action` ZIP/path safety and parses recognizable XML metadata conservatively.
 - `preflight-configuration-file` checks `.vsoconf` ZIP/path safety and parses recognizable XML metadata conservatively.
-- `preflight-package` checks `.package`/`.zip` import safety and inspects nested `.workflow`, `.action`, and `.vsoconf` artifacts when they are present.
+- `preflight-package` checks `.package`/`.zip` import safety, inspects nested `.workflow`, `.action`, and `.vsoconf` artifacts when they are present, and validates package element `input_form_` entries.
 
 The import tools run the same preflight checks and fail locally before authentication or multipart upload when blocking errors are found.
 
@@ -191,7 +248,11 @@ Workflow files are read from the `workflows` subdirectory of `VCFA_ARTIFACT_DIR`
 
 ## Common Pitfalls
 
-- `create-workflow` creates only an empty workflow shell; use `import-workflow-file` for real workflow content.
+- `create-workflow` creates only an empty workflow shell; use authored artifacts and the project package publish flow for real reusable workflow content.
+- Do not use a plain scriptable task solely to invoke one action; use a native action workflow item for that case. In exported XML this is still a `type="task"` item, but it has `script-module="<module>/<actionName>"`, a generated `actionResult = System.getModule("<module>").<actionName>(...)` script, and an `out-binding` from `actionResult` to the workflow output.
+- Avoid vertical-only layouts for simple linear workflows; horizontal layouts are easier to scan and match project conventions.
+- Do not omit `input_form_` for workflows with user inputs that should be started from the vRO UI.
+- Do not add `title` to input form sections or unverified properties like `size` to fields; vRO can reject the start page with schema validation errors.
 - `.workflow` content must preserve UTF-16 encoding with BOM.
 - Multipart imports break if `Content-Type` is set manually without the boundary.
 - `VRA:Machine` inventory and VCFA deployments are not always a one-to-one match.

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,7 @@ These examples are current, import-safe patterns for using the MCP tools. They a
 ## Example Set
 
 - [Workflow Artifact](./workflow-artifact.md): collect context, scaffold a workflow, preflight, import, and test it.
+- [Project Package](./project-package.md): reuse one project package, add content, rebuild, export, and inspect before import.
 - [Artifact Promotion](./artifact-promotion.md): preflight, diff, optional backup, and import recommendation.
 - [Template, Catalog, And Subscription](./template-catalog-subscription.md): review templates, inspect catalog/deployment behavior, and plan subscriptions.
 
@@ -12,4 +13,5 @@ These examples are current, import-safe patterns for using the MCP tools. They a
 
 - Use `collect-context-snapshot` or read-only list/get tools before drafting changes.
 - Use preflight and diff tools before imports.
+- Reuse `VCFA_PROJECT_PACKAGE_NAME` for package-first workflows; do not create one-off packages.
 - Treat live write tools as final steps that require confirmed target IDs and explicit user approval.

--- a/examples/project-package.md
+++ b/examples/project-package.md
@@ -1,0 +1,42 @@
+# Project Package
+
+Use this flow to publish project content into vRO without creating duplicate packages. Configure `VCFA_PROJECT_PACKAGE_NAME` or pass the same exact `packageName` to each tool.
+
+Prefer this package path for reusable workflows, actions, configurations, and resources. Use direct artifact imports only for narrow validation or explicitly requested one-off tests.
+
+The package flow is intentionally explicit: first prove the content exists and behaves as expected, then add that discovered live content to the project package, rebuild the package, inspect the package import details, and only then import it. This keeps vRO package state reusable and prevents a trail of task-specific packages.
+
+```text
+ensure-project-package(packageName: "com.example.project")
+```
+
+If the package does not exist, create it only with explicit confirmation:
+
+```text
+ensure-project-package(packageName: "com.example.project", description: "Project automation", createIfMissing: true, confirm: true)
+```
+
+Add discovered content to the same package:
+
+```text
+add-workflow-to-project-package(packageName: "com.example.project", workflowId: "<workflow-id>", confirm: true)
+add-action-to-project-package(packageName: "com.example.project", categoryName: "com.example.actions", actionName: "echo", confirm: true)
+add-configuration-to-project-package(packageName: "com.example.project", configurationId: "<configuration-id>", confirm: true)
+add-resource-to-project-package(packageName: "com.example.project", resourceId: "<resource-id>", confirm: true)
+```
+
+Rebuild, export, and inspect before import:
+
+```text
+rebuild-project-package(packageName: "com.example.project", confirm: true)
+export-project-package(packageName: "com.example.project", fileName: "com.example.project.package", overwrite: true)
+get-project-package-import-details(packageName: "com.example.project", fileName: "com.example.project.package")
+```
+
+Import only after reviewing the package details:
+
+```text
+import-project-package(packageName: "com.example.project", fileName: "com.example.project.package", overwrite: true, confirm: true)
+```
+
+Before importing, confirm that `get-project-package-import-details` reports the expected package name and expected elements. If the package file contains a different package name, export the correct project package and retry instead of importing the wrong file.

--- a/examples/workflow-artifact.md
+++ b/examples/workflow-artifact.md
@@ -2,6 +2,8 @@
 
 Use this flow when the assistant needs to author a real importable `.workflow` artifact.
 
+When a workflow only executes one existing vRO action, prefer a native action workflow item and publish through the project package flow. Use scriptable task scaffolding when the workflow contains custom JavaScript logic, multiple action calls, or orchestration around an action. For manually authored XML/package content, prefer a horizontal left-to-right layout.
+
 ## Discover And Snapshot
 
 ```text

--- a/src/client/artifact-preflight.ts
+++ b/src/client/artifact-preflight.ts
@@ -452,6 +452,9 @@ function validateWorkflowArchive(
   report: ArtifactPreflightReport,
 ): void {
   inspectWorkflowArchiveFiles(files, report);
+  if (files["input_form_"]) {
+    validateInputFormEntry(files["input_form_"], "input_form_", report);
+  }
 }
 
 function inspectWorkflowArchiveFiles(
@@ -565,6 +568,8 @@ function validatePackageArchive(
       nestedArtifacts += 1;
       counts.configurations += 1;
       validateArchiveBuffer(content, nested, validateGenericXmlArchive);
+    } else if (lowerName.endsWith("/input_form_") || lowerName === "input_form_") {
+      validateInputFormEntry(content, name, report);
     } else {
       continue;
     }
@@ -577,6 +582,11 @@ function validatePackageArchive(
     report.warnings.push(
       ...nested.warnings.map((warning) => `${name}: ${warning}`),
     );
+    if (typeof nested.metadata.inputForms === "number") {
+      report.metadata.inputForms =
+        (typeof report.metadata.inputForms === "number" ? report.metadata.inputForms : 0) +
+        nested.metadata.inputForms;
+    }
   }
 
   report.metadata.workflowArtifacts = counts.workflows;
@@ -587,6 +597,156 @@ function validatePackageArchive(
     report.warnings.push(
       "No nested .workflow, .action, or .vsoconf entries were recognized; only package ZIP/import safety was validated",
     );
+  }
+}
+
+function validateInputFormEntry(
+  content: Uint8Array,
+  entryName: string,
+  report: ArtifactPreflightReport,
+): void {
+  const json = decodeUtf16TextWithBom(content, entryName, "JSON", report);
+  if (!json) return;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json.replace(/^\uFEFF/, ""));
+  } catch (error) {
+    report.errors.push(`${entryName} is not valid JSON: ${errorMessage(error)}`);
+    return;
+  }
+
+  if (!isObject(parsed)) {
+    report.errors.push(`${entryName} must contain a JSON object`);
+    return;
+  }
+
+  const layout = getObject(parsed, "layout");
+  const schema = getObject(parsed, "schema");
+  if (!layout) {
+    report.errors.push(`${entryName} is missing layout`);
+    return;
+  }
+  if (!schema) {
+    report.errors.push(`${entryName} is missing schema`);
+    return;
+  }
+
+  const pages = layout.pages;
+  if (!Array.isArray(pages)) {
+    report.errors.push(`${entryName} layout.pages must be an array`);
+    return;
+  }
+
+  for (const [pageIndex, page] of pages.entries()) {
+    if (!isObject(page)) {
+      report.errors.push(`${entryName} layout.pages/${pageIndex} must be an object`);
+      continue;
+    }
+
+    reportUnknownInputFormKeys(
+      page,
+      ["id", "sections", "title"],
+      `${entryName} layout.pages/${pageIndex}`,
+      report,
+    );
+
+    const sections = page.sections;
+    if (!Array.isArray(sections)) {
+      report.errors.push(`${entryName} layout.pages/${pageIndex}.sections must be an array`);
+      continue;
+    }
+
+    for (const [sectionIndex, section] of sections.entries()) {
+      if (!isObject(section)) {
+        report.errors.push(
+          `${entryName} layout.pages/${pageIndex}.sections/${sectionIndex} must be an object`,
+        );
+        continue;
+      }
+
+      reportUnknownInputFormKeys(
+        section,
+        ["id", "fields"],
+        `${entryName} layout.pages/${pageIndex}.sections/${sectionIndex}`,
+        report,
+      );
+
+      const fields = section.fields;
+      if (!Array.isArray(fields)) {
+        report.errors.push(
+          `${entryName} layout.pages/${pageIndex}.sections/${sectionIndex}.fields must be an array`,
+        );
+        continue;
+      }
+
+      for (const [fieldIndex, field] of fields.entries()) {
+        if (!isObject(field)) {
+          report.errors.push(
+            `${entryName} layout.pages/${pageIndex}.sections/${sectionIndex}.fields/${fieldIndex} must be an object`,
+          );
+          continue;
+        }
+
+        reportUnknownInputFormKeys(
+          field,
+          ["id", "display", "signpostPosition", "state"],
+          `${entryName} layout.pages/${pageIndex}.sections/${sectionIndex}.fields/${fieldIndex}`,
+          report,
+        );
+
+        const fieldId = stringValue(field.id);
+        if (!fieldId) {
+          report.errors.push(
+            `${entryName} layout.pages/${pageIndex}.sections/${sectionIndex}.fields/${fieldIndex} is missing id`,
+          );
+        } else if (!isObject(schema[fieldId])) {
+          report.errors.push(`${entryName} field ${fieldId} is missing a schema entry`);
+        }
+      }
+    }
+  }
+
+  for (const [name, definition] of Object.entries(schema)) {
+    if (!isObject(definition)) {
+      report.errors.push(`${entryName} schema.${name} must be an object`);
+      continue;
+    }
+    if (!stringValue(definition.id)) {
+      report.errors.push(`${entryName} schema.${name} is missing id`);
+    }
+    if (!isObject(definition.type) || !stringValue(definition.type.dataType)) {
+      report.errors.push(`${entryName} schema.${name} is missing type.dataType`);
+    }
+    if (!stringValue(definition.label)) {
+      report.errors.push(`${entryName} schema.${name} is missing label`);
+    }
+  }
+
+  const options = getObject(parsed, "options");
+  if (!options || !Array.isArray(options.externalValidations)) {
+    report.warnings.push(
+      `${entryName} should include options.externalValidations as an array for vRO input form compatibility`,
+    );
+  }
+
+  report.metadata.inputForms =
+    (typeof report.metadata.inputForms === "number" ? report.metadata.inputForms : 0) + 1;
+}
+
+function reportUnknownInputFormKeys(
+  value: XmlObject,
+  allowedKeys: string[],
+  path: string,
+  report: ArtifactPreflightReport,
+): void {
+  const allowed = new Set(allowedKeys);
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) {
+      report.errors.push(
+        `${path} must not have additional property ${key}`,
+      );
+    }
   }
 }
 
@@ -1023,6 +1183,15 @@ function decodeUtf16XmlWithBom(
   entryName: string,
   report: ArtifactPreflightReport,
 ): string | null {
+  return decodeUtf16TextWithBom(content, entryName, "XML", report);
+}
+
+function decodeUtf16TextWithBom(
+  content: Uint8Array,
+  entryName: string,
+  label: string,
+  report: ArtifactPreflightReport,
+): string | null {
   if (content.length < 2) {
     report.errors.push(`${entryName} is empty`);
     return null;
@@ -1030,7 +1199,7 @@ function decodeUtf16XmlWithBom(
   const littleEndian = content[0] === 0xff && content[1] === 0xfe;
   const bigEndian = content[0] === 0xfe && content[1] === 0xff;
   if (!littleEndian && !bigEndian) {
-    report.errors.push(`${entryName} must be UTF-16 XML with a BOM`);
+    report.errors.push(`${entryName} must be UTF-16 ${label} with a BOM`);
     return null;
   }
 
@@ -1038,7 +1207,7 @@ function decodeUtf16XmlWithBom(
   try {
     return new TextDecoder(encoding).decode(content);
   } catch (error) {
-    report.errors.push(`${entryName} is not valid ${encoding} XML: ${errorMessage(error)}`);
+    report.errors.push(`${entryName} is not valid ${encoding} ${label}: ${errorMessage(error)}`);
     return null;
   }
 }

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -13,6 +13,8 @@ export class VroHttpClient {
   readonly deploymentBaseUrl: string;
   readonly blueprintBaseUrl: string;
   readonly packageDir: string;
+  readonly projectPackageName?: string;
+  readonly projectPackageDescription?: string;
   readonly resourceDir: string;
   readonly workflowDir: string;
   readonly actionDir: string;
@@ -39,6 +41,8 @@ export class VroHttpClient {
     this.packageDir = resolve(
       config.packageDir ?? join(artifactDir, "packages"),
     );
+    this.projectPackageName = config.projectPackageName;
+    this.projectPackageDescription = config.projectPackageDescription;
     this.resourceDir = resolve(
       config.resourceDir ?? join(artifactDir, "resources"),
     );

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -13,7 +13,11 @@ import type {
   DeploymentRequest,
   DiffActionFileParams,
   DiffWorkflowFileParams,
+  PackageExportOptions,
+  PackageImportDetails,
+  PackageImportOptions,
   PrepareArtifactPromotionParams,
+  ProjectPackageResult,
   EventTopicList,
   ResourceElementList,
   ScaffoldWorkflowFileParams,
@@ -590,12 +594,84 @@ export class VroClient {
     name: string,
     fileName: string,
     overwrite = false,
+    options: PackageExportOptions = {},
   ): Promise<string> {
-    return this.packages.exportPackage(name, fileName, overwrite);
+    return this.packages.exportPackage(name, fileName, overwrite, options);
   }
 
   importPackage(fileName: string, overwrite = true): Promise<void> {
     return this.packages.importPackage(fileName, overwrite);
+  }
+
+  importPackageWithOptions(
+    fileName: string,
+    options: PackageImportOptions = {},
+  ): Promise<void> {
+    return this.packages.importPackageWithOptions(fileName, options);
+  }
+
+  getPackageImportDetails(fileName: string): Promise<PackageImportDetails> {
+    return this.packages.getPackageImportDetails(fileName);
+  }
+
+  ensureProjectPackage(params?: {
+    packageName?: string;
+    description?: string;
+    createIfMissing?: boolean;
+    confirm?: boolean;
+  }): Promise<ProjectPackageResult> {
+    return this.packages.ensureProjectPackage(params);
+  }
+
+  resolveProjectPackageName(packageName?: string): string {
+    return this.packages.resolveProjectPackageName(packageName);
+  }
+
+  createPackage(
+    name: string,
+    description?: string,
+    items?: {
+      workflows?: string[];
+      actions?: string[];
+      resources?: string[];
+      configurations?: string[];
+    },
+  ): Promise<void> {
+    return this.packages.createPackage(name, description, items);
+  }
+
+  rebuildPackage(name: string): Promise<void> {
+    return this.packages.rebuildPackage(name);
+  }
+
+  addWorkflowToPackage(packageName: string, workflowId: string): Promise<void> {
+    return this.packages.addWorkflowToPackage(packageName, workflowId);
+  }
+
+  addActionToPackage(
+    packageName: string,
+    categoryName: string,
+    actionName: string,
+  ): Promise<void> {
+    return this.packages.addActionToPackage(
+      packageName,
+      categoryName,
+      actionName,
+    );
+  }
+
+  addConfigurationToPackage(
+    packageName: string,
+    configurationId: string,
+  ): Promise<void> {
+    return this.packages.addConfigurationToPackage(
+      packageName,
+      configurationId,
+    );
+  }
+
+  addResourceToPackage(packageName: string, resourceId: string): Promise<void> {
+    return this.packages.addResourceToPackage(packageName, resourceId);
   }
 
   preflightPackageFile(fileName: string): Promise<ArtifactPreflightReport> {

--- a/src/client/package-client.ts
+++ b/src/client/package-client.ts
@@ -1,6 +1,13 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { extname } from "node:path";
-import type { VroPackage, VroPackageList } from "../types.js";
+import type {
+  PackageExportOptions,
+  PackageImportDetails,
+  PackageImportOptions,
+  ProjectPackageResult,
+  VroPackage,
+  VroPackageList,
+} from "../types.js";
 import { parseAttrs } from "./attrs.js";
 import {
   ensurePreflightPassed,
@@ -41,12 +48,28 @@ export class PackageClient {
   async getPackage(name: string): Promise<VroPackage> {
     const raw = await this.http.get<{
       attributes?: { name: string; value: string }[];
+      workflows?: unknown[];
+      actions?: unknown[];
+      configurations?: unknown[];
+      resources?: unknown[];
+      usedPlugins?: unknown[];
+      usedplugins?: unknown[];
+      id?: string;
+      href?: string;
+      name?: string;
+      description?: string;
     }>(`/packages/${encodeURIComponent(name)}`);
     const a = parseAttrs(raw.attributes);
     return {
-      name: a["name"] ?? name,
-      description: a["description"],
+      name: raw.name ?? a["name"] ?? name,
+      description: raw.description ?? a["description"],
       version: a["version"],
+      href: raw.href,
+      workflows: raw.workflows,
+      actions: raw.actions,
+      configurations: raw.configurations,
+      resources: raw.resources,
+      usedPlugins: raw.usedPlugins ?? raw.usedplugins,
     };
   }
 
@@ -71,11 +94,119 @@ export class PackageClient {
     );
   }
 
+  resolveProjectPackageName(packageName?: string): string {
+    const resolved = packageName ?? this.http.projectPackageName;
+    if (!resolved) {
+      throw new Error(
+        "Project package name is required. Pass packageName or set VCFA_PROJECT_PACKAGE_NAME.",
+      );
+    }
+    validatePackageName(resolved);
+    return resolved;
+  }
+
+  async ensureProjectPackage(params: {
+    packageName?: string;
+    description?: string;
+    createIfMissing?: boolean;
+    confirm?: boolean;
+  } = {}): Promise<ProjectPackageResult> {
+    const name = this.resolveProjectPackageName(params.packageName);
+    const existing = await this.tryGetPackage(name);
+    if (existing) {
+      return { name, created: false, package: existing };
+    }
+
+    if (!params.createIfMissing || !params.confirm) {
+      throw new Error(
+        `Package '${name}' was not found. Reuse requires an existing package; set createIfMissing and confirm to true to create this exact project package.`,
+      );
+    }
+
+    await this.putPackage(
+      name,
+      params.description ?? this.http.projectPackageDescription,
+    );
+    return { name, created: true };
+  }
+
+  async createPackage(
+    name: string,
+    description?: string,
+    items?: {
+      workflows?: string[];
+      actions?: string[];
+      resources?: string[];
+      configurations?: string[];
+    },
+  ): Promise<void> {
+    validatePackageName(name);
+    const existing = await this.tryGetPackage(name);
+    if (existing) {
+      throw new Error(
+        `Package '${name}' already exists. Reuse the existing package instead of creating a new one.`,
+      );
+    }
+    await this.putPackage(name, description, items);
+  }
+
+  async rebuildPackage(name: string): Promise<void> {
+    validatePackageName(name);
+    await this.http.post<unknown>(
+      `/packages/${encodeURIComponent(name)}/rebuild`,
+      {},
+    );
+  }
+
+  async addWorkflowToPackage(packageName: string, workflowId: string): Promise<void> {
+    validatePackageName(packageName);
+    await this.http.post<unknown>(
+      `/packages/${encodeURIComponent(packageName)}/workflow/${encodeURIComponent(workflowId)}`,
+      {},
+    );
+  }
+
+  async addActionToPackage(
+    packageName: string,
+    categoryName: string,
+    actionName: string,
+  ): Promise<void> {
+    validatePackageName(packageName);
+    await this.http.post<unknown>(
+      `/packages/${encodeURIComponent(packageName)}/action/${encodeURIComponent(categoryName)}/${encodeURIComponent(actionName)}`,
+      {},
+    );
+  }
+
+  async addConfigurationToPackage(
+    packageName: string,
+    configurationId: string,
+  ): Promise<void> {
+    validatePackageName(packageName);
+    await this.http.post<unknown>(
+      `/packages/${encodeURIComponent(packageName)}/configuration/${encodeURIComponent(configurationId)}`,
+      {},
+    );
+  }
+
+  async addResourceToPackage(
+    packageName: string,
+    resourceId: string,
+  ): Promise<void> {
+    validatePackageName(packageName);
+    await this.http.post<unknown>(
+      `/packages/${encodeURIComponent(packageName)}/resource/${encodeURIComponent(resourceId)}`,
+      {},
+    );
+  }
+
   async exportPackage(
     name: string,
     fileName: string,
     overwrite = false,
+    options: PackageExportOptions = {},
   ): Promise<string> {
+    validatePackageName(name);
     const destPath = await this.resolvePackagePath(fileName);
     const existingFile = await getExistingFile(destPath);
     if (existingFile?.isSymbolicLink()) {
@@ -87,8 +218,10 @@ export class PackageClient {
       );
     }
     const token = await this.http.ensureAuthenticated();
-    const url = `${this.http.baseUrl}/packages/${encodeURIComponent(name)}?export=true`;
-    console.error(`[vro-client] GET /packages/${name}?export=true`);
+    const query = packageExportQuery(options);
+    const path = `/content/packages/${encodeURIComponent(name)}${query}`;
+    const url = `${this.http.baseUrl}${path}`;
+    console.error(`[vro-client] GET ${path}`);
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 60_000);
@@ -117,6 +250,13 @@ export class PackageClient {
   }
 
   async importPackage(fileName: string, overwrite = true): Promise<void> {
+    await this.importPackageWithOptions(fileName, { overwrite });
+  }
+
+  async importPackageWithOptions(
+    fileName: string,
+    options: PackageImportOptions = {},
+  ): Promise<void> {
     ensurePreflightPassed(await this.preflightPackageFile(fileName));
     const srcPath = await this.resolvePackagePath(fileName);
     await rejectSymlink(
@@ -132,8 +272,10 @@ export class PackageClient {
     const buffer = await readFile(srcPath);
     const form = new FormData();
     form.append("file", new Blob([new Uint8Array(buffer)]), fileName);
-    const url = `${this.http.baseUrl}/packages?overwrite=${overwrite}`;
-    console.error(`[vro-client] POST /packages?overwrite=${overwrite}`);
+    const query = packageImportQuery(options);
+    const path = `/packages${query}`;
+    const url = `${this.http.baseUrl}${path}`;
+    console.error(`[vro-client] POST ${path}`);
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 60_000);
@@ -159,7 +301,53 @@ export class PackageClient {
     }
   }
 
+  async getPackageImportDetails(fileName: string): Promise<PackageImportDetails> {
+    ensurePreflightPassed(await this.preflightPackageFile(fileName));
+    const srcPath = await this.resolvePackagePath(fileName);
+    await rejectSymlink(
+      srcPath,
+      "Package import details source must not be a symbolic link",
+    );
+    await assertRealPathInside(
+      this.http.packageDir,
+      srcPath,
+      "Package file path resolves outside the configured package artifact directory",
+    );
+    const token = await this.http.ensureAuthenticated();
+    const buffer = await readFile(srcPath);
+    const form = new FormData();
+    form.append("file", new Blob([new Uint8Array(buffer)]), fileName);
+    const path = "/packages/import-details";
+    const url = `${this.http.baseUrl}${path}`;
+    console.error(`[vro-client] POST ${path}`);
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 60_000);
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/json",
+        },
+        body: form,
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(
+        `vRO API error: ${res.status} ${res.statusText} — package import details\n${text}`,
+      );
+    }
+    return (await res.json()) as PackageImportDetails;
+  }
+
   async deletePackage(name: string, deleteContents = false): Promise<void> {
+    validatePackageName(name);
     const option = deleteContents
       ? "deletePackageWithContent"
       : "deletePackage";
@@ -167,4 +355,72 @@ export class PackageClient {
       `/packages/${encodeURIComponent(name)}?option=${option}`,
     );
   }
+
+  private async tryGetPackage(name: string): Promise<VroPackage | null> {
+    try {
+      return await this.getPackage(name);
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        (error.message.includes("404") || error.message.includes("not found"))
+      ) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  private async putPackage(
+    name: string,
+    description?: string,
+    items?: {
+      workflows?: string[];
+      actions?: string[];
+      resources?: string[];
+      configurations?: string[];
+    },
+  ): Promise<void> {
+    const body: Record<string, unknown> = {};
+    if (description) body.description = description;
+    if (items) body.items = items;
+    await this.http.put<unknown>(`/packages/${encodeURIComponent(name)}`, body);
+  }
+}
+
+function validatePackageName(name: string): void {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)+$/.test(name)) {
+    throw new Error(
+      `Package name '${name}' must be fully qualified, for example com.example.project.`,
+    );
+  }
+}
+
+function packageExportQuery(options: PackageExportOptions): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(options)) {
+    if (value !== undefined) params.set(key, String(value));
+  }
+  const query = params.toString();
+  return query ? `?${query}` : "";
+}
+
+function packageImportQuery(options: PackageImportOptions): string {
+  const params = new URLSearchParams();
+  params.set("overwrite", String(options.overwrite ?? true));
+  if (options.importConfigurationAttributeValues !== undefined) {
+    params.set(
+      "importConfigurationAttributeValues",
+      String(options.importConfigurationAttributeValues),
+    );
+  }
+  if (options.tagImportMode !== undefined) {
+    params.set("tagImportMode", options.tagImportMode);
+  }
+  if (options.importConfigSecureStringAttributeValues !== undefined) {
+    params.set(
+      "importConfigSecureStringAttributeValues",
+      String(options.importConfigSecureStringAttributeValues),
+    );
+  }
+  return `?${params.toString()}`;
 }

--- a/src/client/workflow-artifact.ts
+++ b/src/client/workflow-artifact.ts
@@ -31,11 +31,18 @@ interface NormalizedSpec {
   tasks: NormalizedWorkflowArtifactTask[];
 }
 
+interface InputFormType {
+  dataType: string;
+  referenceType?: string;
+  itemType?: InputFormType;
+}
+
 export function buildWorkflowArtifact(spec: WorkflowArtifactSpec): Uint8Array {
   const normalized = normalizeWorkflowArtifactSpec(spec);
   return zipSync({
     "workflow-info": utf8Bytes(buildWorkflowInfo(normalized)),
     "workflow-content": utf16LeWithBom(renderWorkflowContentXml(normalized)),
+    "input_form_": utf16BeWithBom(renderWorkflowInputFormJson(normalized)),
   });
 }
 
@@ -58,6 +65,16 @@ export function buildWorkflowInfo(spec: WorkflowArtifactSpec): string {
     )}" version="${escapeXmlAttribute(normalized.version)}" />`,
     "",
   ].join("\n");
+}
+
+export function buildWorkflowInputForm(spec: WorkflowArtifactSpec): Uint8Array {
+  return utf16BeWithBom(
+    renderWorkflowInputFormJson(normalizeWorkflowArtifactSpec(spec)),
+  );
+}
+
+export function buildWorkflowInputFormJson(spec: WorkflowArtifactSpec): string {
+  return renderWorkflowInputFormJson(normalizeWorkflowArtifactSpec(spec));
 }
 
 export function normalizeWorkflowArtifactSpec(
@@ -268,7 +285,7 @@ function renderWorkflowContentXml(spec: NormalizedSpec): string {
     ...spec.tasks.map((task, index) =>
       renderTask(task, spec.tasks[index + 1]?.name),
     ),
-    "  <presentation />",
+    renderPresentation(spec.inputs),
     "  <workflow-note />",
     "</workflow>",
     "",
@@ -326,6 +343,108 @@ function renderTask(
   ].join("\n");
 }
 
+function renderPresentation(inputs: WorkflowArtifactParameter[]): string {
+  if (inputs.length === 0) {
+    return "  <presentation />";
+  }
+
+  return [
+    "  <presentation>",
+    "    <p-step>",
+    "      <title><![CDATA[General]]></title>",
+    "      <p-group>",
+    "        <title><![CDATA[Inputs]]></title>",
+    ...inputs.map(
+      (input) =>
+        `        <p-param name="${escapeXmlAttribute(input.name)}"><desc>${cdata(input.description ?? input.name)}</desc></p-param>`,
+    ),
+    "      </p-group>",
+    "    </p-step>",
+    "  </presentation>",
+  ].join("\n");
+}
+
+function renderWorkflowInputFormJson(spec: NormalizedSpec): string {
+  const schema = Object.fromEntries(
+    spec.inputs.map((input) => [
+      input.name,
+      {
+        id: input.name,
+        type: inputFormType(input.type),
+        label: input.description || input.name,
+        constraints: { required: true },
+      },
+    ]),
+  );
+
+  const pages = spec.inputs.length === 0
+    ? []
+    : [
+        {
+          id: "page_general",
+          sections: [
+            {
+              id: "section_inputs",
+              fields: spec.inputs.map((input) => ({
+                id: input.name,
+                display: inputFormDisplay(input.type),
+                signpostPosition: "right-middle",
+                state: { visible: true, "read-only": false },
+              })),
+            },
+          ],
+          title: "General",
+        },
+      ];
+
+  return `${JSON.stringify({
+    layout: { pages },
+    schema,
+    options: { externalValidations: [] },
+    itemId: "",
+  })}\n`;
+}
+
+function inputFormType(type: string): InputFormType {
+  const arrayItemType = type.match(/^Array\/(.+)$/)?.[1];
+  if (arrayItemType) {
+    return { dataType: "array", itemType: inputFormType(arrayItemType) };
+  }
+
+  if (type.includes(":")) {
+    return { dataType: "reference", referenceType: type };
+  }
+
+  switch (type) {
+    case "boolean":
+      return { dataType: "boolean" };
+    case "number":
+      return { dataType: "decimal" };
+    case "SecureString":
+      return { dataType: "secureString" };
+    case "string":
+    default:
+      return { dataType: "string" };
+  }
+}
+
+function inputFormDisplay(type: string): string {
+  if (type.startsWith("Array/")) return "multiValuePicker";
+  if (type.includes(":")) return "valuePickerTree";
+
+  switch (type) {
+    case "boolean":
+      return "checkbox";
+    case "number":
+      return "decimalField";
+    case "SecureString":
+      return "passwordField";
+    case "string":
+    default:
+      return "textField";
+  }
+}
+
 function renderBindings(
   elementName: "in-binding" | "out-binding",
   bindings: WorkflowArtifactBinding[],
@@ -360,6 +479,16 @@ function escapeXmlAttribute(value: string): string {
 
 function utf16LeWithBom(value: string): Uint8Array {
   return new Uint8Array([0xff, 0xfe, ...Buffer.from(value, "utf16le")]);
+}
+
+function utf16BeWithBom(value: string): Uint8Array {
+  const littleEndian = Buffer.from(value, "utf16le");
+  for (let index = 0; index < littleEndian.length; index += 2) {
+    const first = littleEndian[index];
+    littleEndian[index] = littleEndian[index + 1] ?? 0;
+    littleEndian[index + 1] = first;
+  }
+  return new Uint8Array([0xfe, 0xff, ...littleEndian]);
 }
 
 function utf8Bytes(value: string): Uint8Array {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,9 @@ async function main(): Promise<void> {
   const ignoreTls = process.env["VCFA_IGNORE_TLS"] === "true";
   const artifactDir = process.env["VCFA_ARTIFACT_DIR"] ?? DEFAULT_ARTIFACT_DIR;
   const packageDir = process.env["VCFA_PACKAGE_DIR"];
+  const projectPackageName = process.env["VCFA_PROJECT_PACKAGE_NAME"];
+  const projectPackageDescription =
+    process.env["VCFA_PROJECT_PACKAGE_DESCRIPTION"];
   const resourceDir = process.env["VCFA_RESOURCE_DIR"];
   const workflowDir = process.env["VCFA_WORKFLOW_DIR"];
   const actionDir = process.env["VCFA_ACTION_DIR"];
@@ -62,6 +65,8 @@ async function main(): Promise<void> {
     ignoreTls,
     artifactDir,
     packageDir,
+    projectPackageName,
+    projectPackageDescription,
     resourceDir,
     workflowDir,
     actionDir,
@@ -79,19 +84,20 @@ async function main(): Promise<void> {
         "Use get-workflow to inspect a workflow's input parameters before running it with run-workflow.",
         "Use run-workflow-and-wait for rapid development loops that validate workflow inputs, wait for completion, and return outputs or diagnostics.",
         "After starting a workflow execution with run-workflow, use get-workflow-execution to poll for completion and retrieve outputs.",
-        "Use export-workflow-file to save a workflow artifact under the configured workflow artifact directory; use import-workflow-file to upload a .workflow artifact from that directory into a workflow category.",
-        "Use scaffold-workflow-file to generate a local .workflow artifact from structured workflow metadata and linear scriptable tasks before importing it.",
+        "Use export-workflow-file to save a workflow artifact under the configured workflow artifact directory; use direct import-workflow-file only for narrow validation or explicitly requested single-artifact tests.",
+        "Use scaffold-workflow-file to generate a local .workflow artifact from structured workflow metadata and linear scriptable tasks before publishing or validating it.",
+        "When a workflow step only invokes one existing vRO action, prefer a native action workflow item instead of a scriptable task that calls System.getModule. Use scriptable tasks for multiple action calls or additional orchestration logic. Prefer horizontal left-to-right workflow layouts when authoring or editing XML/package content.",
         "Use preflight-workflow-file, preflight-action-file, preflight-configuration-file, and preflight-package to validate local artifacts before importing them.",
         "Use prepare-artifact-promotion before artifact imports when you need preflight, optional live backup export, workflow/action diff summaries, and the exact confirmed import call; it never imports.",
         "Use collect-context-snapshot to persist reusable Markdown and JSON summaries of workflows, actions, configurations, resources, categories, and optional VCFA domains for future agents.",
-        "Use export-action-file to save an action artifact under the configured action artifact directory; use import-action-file to upload a .action artifact from that directory into an action category by category name.",
+        "Use export-action-file to save an action artifact under the configured action artifact directory; use direct import-action-file only for narrow validation or explicitly requested single-artifact tests.",
         "Use export-configuration-file to save a configuration artifact under the configured configuration artifact directory; use import-configuration-file to upload a .vsoconf artifact from that directory into a configuration category.",
         "Use list-event-topics to discover available event topics before creating extensibility subscriptions.",
         "Use list-subscriptions to see existing event-driven triggers.",
         "Use list-catalog-items to browse the Service Broker catalog; use get-catalog-item to inspect a specific item by ID.",
         "Use list-deployments to see existing deployments; use create-deployment to deploy a catalog item, providing the catalogItemId, deploymentName, and projectId. Use list-deployment-actions to discover available deployment day-2 actions, then run-deployment-action with confirm set to true to submit one.",
         "Use list-templates to browse blueprint templates; use get-template to inspect a specific template by ID; use create-template to create a new template; use delete-template to remove one.",
-        "Use list-packages to browse vRO packages; use export-package to save a package file under the configured package artifact directory; use import-package to upload a package file from that directory; use delete-package with confirm set to true to remove a package.",
+        "Publish reusable vRO content through packages by default: use ensure-project-package, add content to the exact project package, rebuild-project-package, export-project-package, get-project-package-import-details, then import-project-package. Reuse the configured project package from VCFA_PROJECT_PACKAGE_NAME; never create one-off packages unless the user confirms the exact package name.",
         "Use list-resource-elements to browse vRO resource elements; use list-categories with type ResourceElementCategory before importing a resource element; exported and imported resource files are stored under the configured resource artifact directory.",
         "Use list-plugins to see all installed vRO plugins.",
       ].join(" "),

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -18,6 +18,10 @@ function discoveryGuardrails(): string[] {
   return [
     "Discovery guardrail: if a required workflow, action, template, category, project, parameter, or return type is not found, stop and report the missing fact. Do not invent IDs, parameter names, types, schemas, or provider-specific YAML.",
     "When action discovery is required, list-actions must produce an exact candidate and get-action must verify its contract. If list-actions returns no match or only partial/ambiguous action data, stop and ask for the missing action details instead of inventing parameter names or return types.",
+    "Workflow authoring preference: when a workflow only executes one existing vRO action, use a native action workflow item instead of a scriptable task that calls System.getModule. Use scriptable tasks when the workflow item performs multiple action calls or additional orchestration logic.",
+    "Workflow layout preference: when authoring or editing workflow XML/package content, arrange sequential workflow items horizontally from left to right.",
+    "Workflow input form preference: generated workflows with inputs must include a valid input_form_ entry. Use page-level titles, section objects with only id and fields, field IDs that match schema keys, and options.externalValidations: []. Do not add section title or unverified field properties such as size.",
+    "Publish reusable vRO content through the configured project package by default: ensure-project-package, add content, rebuild-project-package, export-project-package, inspect import details, and import-project-package. Use direct artifact imports only for narrow validation or explicitly requested one-off tests.",
     "Prefer reading vcfa://docs/artifact-authoring and the relevant vcfa://patterns/* or vcfa://schemas/* resource before drafting artifacts.",
   ];
 }
@@ -47,7 +51,7 @@ export function registerVcfaPrompts(server: McpServer): void {
           "Use VCFA MCP tools to inspect existing categories, workflows, and reusable actions before creating anything new.",
           ...discoveryGuardrails(),
           "Prefer scaffold-workflow-file for local artifact generation, then run preflight-workflow-file and summarize any errors or warnings.",
-          "Only recommend import-workflow-file after preflight passes and the user has confirmed the target category and import intent.",
+          "For reusable workflow content, recommend adding the workflow to the project package and importing the package. Only recommend direct import-workflow-file for narrow validation or explicitly requested one-off tests after preflight passes and the user confirms the target category and import intent.",
         ]
           .filter((line): line is string => line !== undefined)
           .join("\n"),
@@ -77,7 +81,7 @@ export function registerVcfaPrompts(server: McpServer): void {
           "Run the matching preflight tool for this artifact and summarize blocking errors, warnings, metadata, parameters, and action references.",
           ...discoveryGuardrails(),
           "Check the target category or package context with list-categories, list-packages, list-workflows, list-actions, or list-configurations as appropriate.",
-          "Recommend the exact import tool call only after explaining risks and required confirmation.",
+          "For reusable project content, recommend the package import path. Recommend a direct artifact import only after explaining why it is a validation or one-off import, plus the risks and required confirmation.",
         ].join("\n"),
       ),
   );
@@ -207,7 +211,7 @@ export function registerVcfaPrompts(server: McpServer): void {
           "Use list-actions with a focused filter, then get-action on the exact match to verify module, name, inputs, return type, and script behavior.",
           "Use list-categories for WorkflowCategory if the category is not already known.",
           ...discoveryGuardrails(),
-          "Scaffold the wrapper with scaffold-workflow-file, preflight it, and summarize the exact import-workflow-file call only after preflight passes and the user confirms import.",
+          "For a single-action wrapper, prefer a native vRO action workflow item in a horizontally arranged workflow. Use scaffold-workflow-file only when a scriptable task is appropriate, such as multiple action calls or additional orchestration logic. Publish reusable wrappers through the project package path.",
         ]
           .filter((line): line is string => line !== undefined)
           .join("\n"),

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -22,6 +22,10 @@ const WORKFLOW_SCAFFOLD_SCHEMA = {
   tool: "scaffold-workflow-file",
   purpose:
     "Generate a local importable .workflow artifact from structured workflow metadata and linear scriptable tasks.",
+  scope:
+    "This scaffold contract emits scriptable task workflow items. When authoring a workflow that only executes one existing vRO action, prefer a native vRO action workflow item in the workflow XML/package instead of wrapping the action in a scriptable task. Use scriptable tasks when the workflow performs more than one action call or needs additional orchestration logic.",
+  layout:
+    "Prefer horizontal workflow layouts. Place sequential workflow items left-to-right by increasing x positions while keeping y positions stable unless a branch needs vertical separation.",
   fileSafety: {
     fileName:
       "Plain .workflow file name under the configured workflow artifact directory; no paths or traversal.",
@@ -107,6 +111,8 @@ const WORKFLOW_BASIC_SCRIPTABLE_TASK_PATTERN = `# Workflow Pattern: basic-script
 
 Use this pattern when one workflow can be represented as a linear scriptable task with explicit inputs and outputs.
 
+Prefer native action workflow items when the workflow only invokes one existing vRO action. Use a scriptable task for custom JavaScript logic, input shaping, branching, or when one item performs more than one action call.
+
 Discovery first:
 
 - Run \`list-categories\` for \`WorkflowCategory\` when the target category is unknown.
@@ -117,7 +123,9 @@ Implementation shape:
 
 - Declare workflow inputs, outputs, and attributes explicitly in \`scaffold-workflow-file\`.
 - Bind every script variable through \`inBindings\` or \`outBindings\`; binding types must match the referenced workflow parameter or attribute.
+- The scaffold emits a vRO-compatible \`input_form_\` for declared inputs. It uses UTF-16BE JSON with a BOM, page-level titles, section objects with only \`id\` and \`fields\`, field IDs that match schema keys, and \`options.externalValidations: []\`.
 - Keep the script readable because vRO runtime errors often point to item line numbers.
+- Use a horizontal layout when editing workflow XML directly: sequence items left-to-right with increasing x coordinates and a stable y coordinate.
 - Validate required inputs early and fail with clear messages.
 
 Validation flow:
@@ -125,7 +133,8 @@ Validation flow:
 1. \`scaffold-workflow-file\`
 2. \`preflight-workflow-file\`
 3. \`diff-workflow-file\` when replacing an existing workflow
-4. \`import-workflow-file\` only after preflight passes and the user confirms category and overwrite intent
+4. For reusable project content, publish via the project package: \`ensure-project-package\`, \`add-workflow-to-project-package\`, \`rebuild-project-package\`, \`export-project-package\`, \`get-project-package-import-details\`, \`import-project-package\`
+5. Use direct \`import-workflow-file\` only for narrow validation or explicitly requested one-off tests after preflight passes and the user confirms category and overwrite intent
 `;
 
 const WORKFLOW_ACTION_WRAPPER_PATTERN = `# Workflow Pattern: action-wrapper
@@ -142,8 +151,13 @@ Implementation shape:
 
 - Mirror action inputs as workflow inputs unless the user asks for a different public contract.
 - Use action parameter names and types exactly as discovered.
-- Call the action through \`System.getModule("<module>").<actionName>(...)\` only after the module and action name were verified.
+- Prefer a native vRO action workflow item for a single action call. Do not wrap a single action in a scriptable task just to call \`System.getModule("<module>").<actionName>(...)\`.
+- Use a scriptable task only when the workflow item performs multiple action calls or additional orchestration logic beyond a single action invocation.
+- Exported native action items are represented as \`<workflow-item type="task" script-module="<module>/<actionName>">\` with a generated \`<script>\` that assigns the return value to \`actionResult\`, for example \`actionResult = System.getModule("<module>").<actionName>(...);\`. Preserve that generated script and bind \`actionResult\` to the workflow output.
 - Bind the action result to a workflow output with the discovered return type.
+- Prefer horizontal workflow layout when authoring or editing XML/package content: start on the left, place the action item to the right of the start/root item, and place the end item further right.
+- The current \`scaffold-workflow-file\` contract emits scriptable task items. For a single-action wrapper that must use a native action item, author from an exported valid workflow/package shape or extend the artifact manually before package publishing.
+- Preserve or generate a valid \`input_form_\` when the wrapper has workflow inputs so it can be started from the vRO UI.
 
 Validation flow:
 

--- a/src/tools/package-tools.ts
+++ b/src/tools/package-tools.ts
@@ -4,6 +4,76 @@ import { z } from "zod";
 import { formatPreflightReport } from "../client/artifact-preflight.js";
 import type { VroClient } from "../vro-client.js";
 
+const packageExportOptionsSchema = {
+  exportConfigurationAttributeValues: z.boolean().optional(),
+  exportGlobalTags: z.boolean().optional(),
+  exportVersionHistory: z.boolean().optional(),
+  exportConfigSecureStringAttributeValues: z.boolean().optional(),
+};
+
+const packageImportOptionsSchema = {
+  importConfigurationAttributeValues: z.boolean().optional(),
+  tagImportMode: z
+    .enum([
+      "DoNotImport",
+      "ImportAndOverwriteExistingValue",
+      "ImportButPreserveExistingValue",
+    ])
+    .optional(),
+  importConfigSecureStringAttributeValues: z.boolean().optional(),
+};
+
+function packageFileName(packageName: string): string {
+  return `${packageName}.package`;
+}
+
+function formatProjectPackage(result: {
+  name: string;
+  created: boolean;
+  package?: { description?: string };
+}): string {
+  return [
+    `Project package: ${result.name}`,
+    `Status: ${result.created ? "created" : "reused"}`,
+    result.package?.description
+      ? `Description: ${result.package.description}`
+      : undefined,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function formatImportDetails(details: {
+  packageName?: string;
+  packageAlreadyExists?: boolean;
+  contentVerified?: boolean;
+  certificateValid?: boolean;
+  certificateTrusted?: boolean;
+  certificateUnknown?: boolean;
+  importElementDetails?: unknown[];
+}): string {
+  return [
+    `Package import details: ${details.packageName ?? "(unknown)"}`,
+    `Already exists: ${String(details.packageAlreadyExists ?? false)}`,
+    `Content verified: ${String(details.contentVerified ?? false)}`,
+    `Certificate valid: ${String(details.certificateValid ?? false)}`,
+    `Certificate trusted: ${String(details.certificateTrusted ?? false)}`,
+    `Certificate unknown: ${String(details.certificateUnknown ?? false)}`,
+    `Elements: ${details.importElementDetails?.length ?? 0}`,
+  ].join("\n");
+}
+
+function assertProjectPackageImportMatches(
+  details: { packageName?: string },
+  expectedPackageName: string,
+): void {
+  if (details.packageName && details.packageName !== expectedPackageName) {
+    throw new Error(
+      `Package file contains '${details.packageName}', but project package '${expectedPackageName}' was requested.`,
+    );
+  }
+}
+
 export function registerPackageTools(
   server: McpServer,
   client: VroClient,
@@ -116,15 +186,30 @@ export function registerPackageTools(
           .boolean()
           .optional()
           .describe("Overwrite the file if it already exists (default: false)"),
+        ...packageExportOptionsSchema,
       }),
       annotations: { readOnlyHint: true },
     },
-    async ({ name, fileName, overwrite }): Promise<CallToolResult> => {
+    async ({
+      name,
+      fileName,
+      overwrite,
+      exportConfigurationAttributeValues,
+      exportGlobalTags,
+      exportVersionHistory,
+      exportConfigSecureStringAttributeValues,
+    }): Promise<CallToolResult> => {
       try {
         const savedPath = await client.exportPackage(
           name,
           fileName,
           overwrite ?? false,
+          {
+            exportConfigurationAttributeValues,
+            exportGlobalTags,
+            exportVersionHistory,
+            exportConfigSecureStringAttributeValues,
+          },
         );
         return {
           content: [
@@ -207,10 +292,18 @@ export function registerPackageTools(
           .describe(
             "Must be set to true to confirm import. If false, the import will not proceed.",
           ),
+        ...packageImportOptionsSchema,
       }),
       annotations: { readOnlyHint: false },
     },
-    async ({ fileName, overwrite, confirm }): Promise<CallToolResult> => {
+    async ({
+      fileName,
+      overwrite,
+      confirm,
+      importConfigurationAttributeValues,
+      tagImportMode,
+      importConfigSecureStringAttributeValues,
+    }): Promise<CallToolResult> => {
       if (!confirm) {
         return {
           content: [
@@ -222,7 +315,12 @@ export function registerPackageTools(
         };
       }
       try {
-        await client.importPackage(fileName, overwrite ?? true);
+        await client.importPackageWithOptions(fileName, {
+          overwrite: overwrite ?? true,
+          importConfigurationAttributeValues,
+          tagImportMode,
+          importConfigSecureStringAttributeValues,
+        });
         return {
           content: [
             {
@@ -237,6 +335,562 @@ export function registerPackageTools(
             {
               type: "text",
               text: `Failed to import package: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "get-package-import-details",
+    {
+      title: "Get Package Import Details",
+      description:
+        "Analyze a local package file before import and return package elements and certificate details.",
+      inputSchema: z.object({
+        fileName: z
+          .string()
+          .describe("Package file name under the configured package artifact directory"),
+      }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ fileName }): Promise<CallToolResult> => {
+      try {
+        const details = await client.getPackageImportDetails(fileName);
+        return { content: [{ type: "text", text: formatImportDetails(details) }] };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to get package import details: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "create-package",
+    {
+      title: "Create Project Package",
+      description:
+        "Create a vRO package by exact fully-qualified name. Refuses to create if the package already exists.",
+      inputSchema: z.object({
+        name: z.string().describe("Exact fully-qualified package name"),
+        description: z.string().optional().describe("Package description"),
+        confirm: z
+          .boolean()
+          .describe("Must be true to create this exact package."),
+      }),
+      annotations: { readOnlyHint: false },
+    },
+    async ({ name, description, confirm }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Confirm creation of package '${name}' by setting confirm to true.`,
+            },
+          ],
+        };
+      }
+      try {
+        await client.createPackage(name, description);
+        return {
+          content: [{ type: "text", text: `Package '${name}' created.` }],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to create package: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "ensure-project-package",
+    {
+      title: "Ensure Project Package",
+      description:
+        "Resolve and reuse the exact configured project package. Creates it only when createIfMissing and confirm are both true.",
+      inputSchema: z.object({
+        packageName: z
+          .string()
+          .optional()
+          .describe("Exact package name. Defaults to VCFA_PROJECT_PACKAGE_NAME."),
+        description: z
+          .string()
+          .optional()
+          .describe("Description to use only if the package is created."),
+        createIfMissing: z
+          .boolean()
+          .optional()
+          .describe("Create the exact project package if it is missing."),
+        confirm: z
+          .boolean()
+          .optional()
+          .describe("Must be true together with createIfMissing to create."),
+      }),
+      annotations: { readOnlyHint: false },
+    },
+    async ({
+      packageName,
+      description,
+      createIfMissing,
+      confirm,
+    }): Promise<CallToolResult> => {
+      try {
+        const result = await client.ensureProjectPackage({
+          packageName,
+          description,
+          createIfMissing,
+          confirm,
+        });
+        return { content: [{ type: "text", text: formatProjectPackage(result) }] };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to ensure project package: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "rebuild-project-package",
+    {
+      title: "Rebuild Project Package",
+      description:
+        "Rebuild the exact project package after adding content. Reuses the configured package name.",
+      inputSchema: z.object({
+        packageName: z.string().optional().describe("Exact package name"),
+        confirm: z.boolean().describe("Must be true to rebuild the package."),
+      }),
+      annotations: { readOnlyHint: false },
+    },
+    async ({ packageName, confirm }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "Confirm rebuild of the project package by setting confirm to true.",
+            },
+          ],
+        };
+      }
+      try {
+        const result = await client.ensureProjectPackage({ packageName });
+        await client.rebuildPackage(result.name);
+        return {
+          content: [
+            { type: "text", text: `Package '${result.name}' rebuilt.` },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to rebuild project package: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "add-workflow-to-project-package",
+    {
+      title: "Add Workflow To Project Package",
+      description:
+        "Add a workflow and dependencies to the exact project package. Reuses the configured package.",
+      inputSchema: z.object({
+        packageName: z.string().optional().describe("Exact package name"),
+        workflowId: z.string().describe("Workflow ID to add"),
+        confirm: z.boolean().describe("Must be true to add content."),
+      }),
+      annotations: { readOnlyHint: false },
+    },
+    async ({
+      packageName,
+      workflowId,
+      confirm,
+    }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Confirm adding workflow ${workflowId} to the project package by setting confirm to true.`,
+            },
+          ],
+        };
+      }
+      try {
+        const result = await client.ensureProjectPackage({ packageName });
+        await client.addWorkflowToPackage(result.name, workflowId);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Workflow ${workflowId} added to package '${result.name}'.`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to add workflow to project package: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "add-action-to-project-package",
+    {
+      title: "Add Action To Project Package",
+      description:
+        "Add an action and dependencies to the exact project package. Reuses the configured package.",
+      inputSchema: z.object({
+        packageName: z.string().optional().describe("Exact package name"),
+        categoryName: z.string().describe("Action category/module name"),
+        actionName: z.string().describe("Action name"),
+        confirm: z.boolean().describe("Must be true to add content."),
+      }),
+      annotations: { readOnlyHint: false },
+    },
+    async ({
+      packageName,
+      categoryName,
+      actionName,
+      confirm,
+    }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Confirm adding action ${categoryName}/${actionName} to the project package by setting confirm to true.`,
+            },
+          ],
+        };
+      }
+      try {
+        const result = await client.ensureProjectPackage({ packageName });
+        await client.addActionToPackage(result.name, categoryName, actionName);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Action ${categoryName}/${actionName} added to package '${result.name}'.`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to add action to project package: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "add-configuration-to-project-package",
+    {
+      title: "Add Configuration To Project Package",
+      description:
+        "Add a configuration element and dependencies to the exact project package.",
+      inputSchema: z.object({
+        packageName: z.string().optional().describe("Exact package name"),
+        configurationId: z.string().describe("Configuration element ID"),
+        confirm: z.boolean().describe("Must be true to add content."),
+      }),
+      annotations: { readOnlyHint: false },
+    },
+    async ({
+      packageName,
+      configurationId,
+      confirm,
+    }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Confirm adding configuration ${configurationId} to the project package by setting confirm to true.`,
+            },
+          ],
+        };
+      }
+      try {
+        const result = await client.ensureProjectPackage({ packageName });
+        await client.addConfigurationToPackage(result.name, configurationId);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Configuration ${configurationId} added to package '${result.name}'.`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to add configuration to project package: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "add-resource-to-project-package",
+    {
+      title: "Add Resource To Project Package",
+      description:
+        "Add a resource element and dependencies to the exact project package.",
+      inputSchema: z.object({
+        packageName: z.string().optional().describe("Exact package name"),
+        resourceId: z.string().describe("Resource element ID"),
+        confirm: z.boolean().describe("Must be true to add content."),
+      }),
+      annotations: { readOnlyHint: false },
+    },
+    async ({
+      packageName,
+      resourceId,
+      confirm,
+    }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Confirm adding resource ${resourceId} to the project package by setting confirm to true.`,
+            },
+          ],
+        };
+      }
+      try {
+        const result = await client.ensureProjectPackage({ packageName });
+        await client.addResourceToPackage(result.name, resourceId);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Resource ${resourceId} added to package '${result.name}'.`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to add resource to project package: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "export-project-package",
+    {
+      title: "Export Project Package",
+      description:
+        "Export the exact project package to the configured package artifact directory.",
+      inputSchema: z.object({
+        packageName: z.string().optional().describe("Exact package name"),
+        fileName: z
+          .string()
+          .optional()
+          .describe("Output .package file name. Defaults to packageName.package."),
+        overwrite: z.boolean().optional(),
+        ...packageExportOptionsSchema,
+      }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({
+      packageName,
+      fileName,
+      overwrite,
+      exportConfigurationAttributeValues,
+      exportGlobalTags,
+      exportVersionHistory,
+      exportConfigSecureStringAttributeValues,
+    }): Promise<CallToolResult> => {
+      try {
+        const result = await client.ensureProjectPackage({ packageName });
+        const savedPath = await client.exportPackage(
+          result.name,
+          fileName ?? packageFileName(result.name),
+          overwrite ?? false,
+          {
+            exportConfigurationAttributeValues,
+            exportGlobalTags,
+            exportVersionHistory,
+            exportConfigSecureStringAttributeValues,
+          },
+        );
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Project package '${result.name}' exported successfully to: ${savedPath}`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to export project package: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "get-project-package-import-details",
+    {
+      title: "Get Project Package Import Details",
+      description:
+        "Analyze an exported project package file before import.",
+      inputSchema: z.object({
+        packageName: z.string().optional().describe("Exact package name"),
+        fileName: z
+          .string()
+          .optional()
+          .describe("Package file name. Defaults to packageName.package."),
+      }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ packageName, fileName }): Promise<CallToolResult> => {
+      try {
+        const resolvedPackageName = client.resolveProjectPackageName(packageName);
+        const details = await client.getPackageImportDetails(
+          fileName ?? packageFileName(resolvedPackageName),
+        );
+        return { content: [{ type: "text", text: formatImportDetails(details) }] };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to get project package import details: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "import-project-package",
+    {
+      title: "Import Project Package",
+      description:
+        "Import an exported project package file. Reuses the configured project package name for the default file name.",
+      inputSchema: z.object({
+        packageName: z.string().optional().describe("Exact package name"),
+        fileName: z
+          .string()
+          .optional()
+          .describe("Package file name. Defaults to packageName.package."),
+        overwrite: z.boolean().optional(),
+        confirm: z.boolean().describe("Must be true to import the package."),
+        ...packageImportOptionsSchema,
+      }),
+      annotations: { readOnlyHint: false },
+    },
+    async ({
+      packageName,
+      fileName,
+      overwrite,
+      confirm,
+      importConfigurationAttributeValues,
+      tagImportMode,
+      importConfigSecureStringAttributeValues,
+    }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "Confirm import of the project package by setting confirm to true.",
+            },
+          ],
+        };
+      }
+      try {
+        const resolvedPackageName = client.resolveProjectPackageName(packageName);
+        const resolvedFileName = fileName ?? packageFileName(resolvedPackageName);
+        const details = await client.getPackageImportDetails(resolvedFileName);
+        assertProjectPackageImportMatches(details, resolvedPackageName);
+        await client.importPackageWithOptions(resolvedFileName, {
+          overwrite: overwrite ?? true,
+          importConfigurationAttributeValues,
+          tagImportMode,
+          importConfigSecureStringAttributeValues,
+        });
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Project package '${resolvedPackageName}' imported from: ${resolvedFileName}`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to import project package: ${error instanceof Error ? error.message : String(error)}`,
             },
           ],
           isError: true,

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -1016,7 +1016,7 @@ export function registerWorkflowTools(
     {
       title: "Scaffold Workflow File",
       description:
-        "Generate a local importable .workflow artifact under the configured workflow artifact directory from structured metadata, linear scriptable tasks, scripts, and bindings. Use import-workflow-file to upload it afterwards.",
+        "Generate a local importable .workflow artifact under the configured workflow artifact directory from structured metadata, linear scriptable tasks, scripts, and bindings. Use native action workflow items outside this scaffold for single-action workflow steps; use scriptable tasks for custom logic, multiple action calls, or orchestration. Publish reusable content through the project package path; use import-workflow-file only for validation or one-off tests.",
       inputSchema: z.object({
         fileName: z
           .string()
@@ -1105,7 +1105,9 @@ export function registerWorkflowTools(
               }),
             )
             .min(1)
-            .describe("Linear sequence of scriptable tasks"),
+            .describe(
+              "Linear sequence of scriptable tasks. Prefer a native action workflow item outside this scaffold for a step that only invokes one existing vRO action.",
+            ),
         }),
       }),
       annotations: { readOnlyHint: false },
@@ -1121,7 +1123,7 @@ export function registerWorkflowTools(
           content: [
             {
               type: "text",
-              text: `Workflow scaffold generated successfully at: ${savedPath}\nUse import-workflow-file to upload it into a workflow category.`,
+              text: `Workflow scaffold generated successfully at: ${savedPath}\nFor reusable content, publish through the project package path. Use import-workflow-file only for validation or one-off tests.`,
             },
           ],
         };

--- a/src/types.ts
+++ b/src/types.ts
@@ -450,11 +450,50 @@ export interface VroPackage {
   description?: string;
   version?: string;
   href?: string;
+  workflows?: unknown[];
+  actions?: unknown[];
+  configurations?: unknown[];
+  resources?: unknown[];
+  usedPlugins?: unknown[];
 }
 
 export interface VroPackageList {
   total?: number;
   link: VroPackage[];
+}
+
+export interface ProjectPackageResult {
+  name: string;
+  created: boolean;
+  package?: VroPackage;
+}
+
+export interface PackageImportDetails {
+  packageName?: string;
+  packageAlreadyExists?: boolean;
+  contentVerified?: boolean;
+  certificateValid?: boolean;
+  certificateTrusted?: boolean;
+  certificateUnknown?: boolean;
+  importElementDetails?: unknown[];
+  certificateInfo?: Record<string, unknown>;
+}
+
+export interface PackageExportOptions {
+  exportConfigurationAttributeValues?: boolean;
+  exportGlobalTags?: boolean;
+  exportVersionHistory?: boolean;
+  exportConfigSecureStringAttributeValues?: boolean;
+}
+
+export interface PackageImportOptions {
+  overwrite?: boolean;
+  importConfigurationAttributeValues?: boolean;
+  tagImportMode?:
+    | "DoNotImport"
+    | "ImportAndOverwriteExistingValue"
+    | "ImportButPreserveExistingValue";
+  importConfigSecureStringAttributeValues?: boolean;
 }
 
 // --- Resource Elements ---
@@ -501,6 +540,8 @@ export interface VroClientConfig {
   ignoreTls?: boolean;
   artifactDir?: string;
   packageDir?: string;
+  projectPackageName?: string;
+  projectPackageDescription?: string;
   resourceDir?: string;
   workflowDir?: string;
   actionDir?: string;

--- a/test/artifact-preflight.test.mjs
+++ b/test/artifact-preflight.test.mjs
@@ -239,7 +239,66 @@ test("preflightPackageFile summarizes nested recognizable artifacts", async () =
     assert.equal(report.metadata.workflowArtifacts, 1);
     assert.equal(report.metadata.actionArtifacts, 0);
     assert.equal(report.metadata.configurationArtifacts, 0);
+    assert.equal(report.metadata.inputForms, 1);
     assert.equal(report.parameters.length, 2);
+  } finally {
+    await rm(packageDir, { recursive: true, force: true });
+  }
+});
+
+test("preflightPackageFile rejects package input forms with invalid section fields", async () => {
+  const packageDir = await mkdtemp(join(tmpdir(), "vcfa-preflight-packages-"));
+  const invalidInputForm = {
+    layout: {
+      pages: [
+        {
+          id: "page_general",
+          sections: [
+            {
+              id: "section_inputs",
+              title: "Inputs",
+              fields: [
+                {
+                  id: "message",
+                  display: "value",
+                  size: 1,
+                  state: { visible: true, "read-only": false },
+                },
+              ],
+            },
+          ],
+          title: "General",
+        },
+      ],
+    },
+    schema: {
+      message: {
+        id: "message",
+        type: { dataType: "string" },
+        label: "Message",
+      },
+    },
+    itemId: "",
+  };
+  await writeFile(
+    join(packageDir, "invalid-form.package"),
+    zipSync({
+      "elements/workflow-1/input_form_": utf16BeWithBom(JSON.stringify(invalidInputForm)),
+      "manifest.xml": new TextEncoder().encode("<package />"),
+    }),
+  );
+
+  try {
+    const report = await preflightPackageFile(packageDir, "invalid-form.package");
+    assert.equal(report.valid, false);
+    assert.match(
+      report.errors.join("\n"),
+      /sections\/0 must not have additional property title/,
+    );
+    assert.match(
+      report.errors.join("\n"),
+      /fields\/0 must not have additional property size/,
+    );
   } finally {
     await rm(packageDir, { recursive: true, force: true });
   }
@@ -467,6 +526,16 @@ test("malformed imports fail preflight before authentication or upload", async (
 
 function utf16LeWithBom(value) {
   return new Uint8Array([0xff, 0xfe, ...Buffer.from(value, "utf16le")]);
+}
+
+function utf16BeWithBom(value) {
+  const littleEndian = Buffer.from(value, "utf16le");
+  for (let index = 0; index < littleEndian.length; index += 2) {
+    const first = littleEndian[index];
+    littleEndian[index] = littleEndian[index + 1] ?? 0;
+    littleEndian[index + 1] = first;
+  }
+  return new Uint8Array([0xfe, 0xff, ...littleEndian]);
 }
 
 function workflowArchiveWithFlow(outName) {

--- a/test/package-tools.test.mjs
+++ b/test/package-tools.test.mjs
@@ -58,6 +58,24 @@ test("package list and get tools are read-only and format metadata", async () =>
   assert.match(detail.content[0].text, /Version: 1\.2\.3/);
 });
 
+test("package list and get tools report empty lists and client errors", async () => {
+  const handlers = registeredPackageTools({
+    listPackages: async () => ({ link: [] }),
+    getPackage: async () => {
+      throw new Error("package lookup failed");
+    },
+  });
+
+  const empty = await handlers.get("list-packages")({});
+  assert.match(empty.content[0].text, /No packages found/);
+
+  const detail = await handlers.get("get-package")({
+    name: "com.example.missing",
+  });
+  assert.equal(detail.isError, true);
+  assert.match(detail.content[0].text, /package lookup failed/);
+});
+
 test("package export and import delegate paths and confirmation", async () => {
   let exported;
   let imported;
@@ -113,6 +131,78 @@ test("package export and import delegate paths and confirmation", async () => {
   });
 });
 
+test("package export, preflight, import details, and import report client errors", async () => {
+  const handlers = registeredPackageTools({
+    getPackageDirectory: () => "/tmp/packages",
+    exportPackage: async () => {
+      throw new Error("export failed");
+    },
+    preflightPackageFile: async () => {
+      throw new Error("preflight failed");
+    },
+    getPackageImportDetails: async () => {
+      throw new Error("details failed");
+    },
+    importPackageWithOptions: async () => {
+      throw new Error("import failed");
+    },
+  });
+
+  const exported = await handlers.get("export-package")({
+    name: "com.example.demo",
+    fileName: "demo.package",
+  });
+  assert.equal(exported.isError, true);
+  assert.match(exported.content[0].text, /export failed/);
+
+  const preflight = await handlers.get("preflight-package")({
+    fileName: "demo.package",
+  });
+  assert.equal(preflight.isError, true);
+  assert.match(preflight.content[0].text, /preflight failed/);
+
+  const details = await handlers.get("get-package-import-details")({
+    fileName: "demo.package",
+  });
+  assert.equal(details.isError, true);
+  assert.match(details.content[0].text, /details failed/);
+
+  const imported = await handlers.get("import-package")({
+    fileName: "demo.package",
+    confirm: true,
+  });
+  assert.equal(imported.isError, true);
+  assert.match(imported.content[0].text, /import failed/);
+});
+
+test("create-package requires confirmation and reports creation results", async () => {
+  let created;
+  const handlers = registeredPackageTools({
+    createPackage: async (name, description) => {
+      created = { name, description };
+    },
+  });
+
+  const refused = await handlers.get("create-package")({
+    name: "com.example.project",
+    description: "Project package",
+    confirm: false,
+  });
+  assert.equal(created, undefined);
+  assert.match(refused.content[0].text, /Confirm creation/);
+
+  const result = await handlers.get("create-package")({
+    name: "com.example.project",
+    description: "Project package",
+    confirm: true,
+  });
+  assert.deepEqual(created, {
+    name: "com.example.project",
+    description: "Project package",
+  });
+  assert.match(result.content[0].text, /created/);
+});
+
 test("project package tools reuse exact package and require confirmation to create", async () => {
   const calls = [];
   const handlers = registeredPackageTools({
@@ -156,6 +246,45 @@ test("project package tools reuse exact package and require confirmation to crea
   ]);
 });
 
+test("ensure-project-package reports client errors", async () => {
+  const handlers = registeredPackageTools({
+    ensureProjectPackage: async () => {
+      throw new Error("missing package name");
+    },
+  });
+
+  const result = await handlers.get("ensure-project-package")({});
+  assert.equal(result.isError, true);
+  assert.match(result.content[0].text, /missing package name/);
+});
+
+test("rebuild-project-package requires confirmation and rebuilds resolved package", async () => {
+  let rebuilt;
+  const handlers = registeredPackageTools({
+    ensureProjectPackage: async ({ packageName }) => ({
+      name: packageName,
+      created: false,
+    }),
+    rebuildPackage: async (packageName) => {
+      rebuilt = packageName;
+    },
+  });
+
+  const refused = await handlers.get("rebuild-project-package")({
+    packageName: "com.example.project",
+    confirm: false,
+  });
+  assert.equal(rebuilt, undefined);
+  assert.match(refused.content[0].text, /Confirm rebuild/);
+
+  const result = await handlers.get("rebuild-project-package")({
+    packageName: "com.example.project",
+    confirm: true,
+  });
+  assert.equal(rebuilt, "com.example.project");
+  assert.match(result.content[0].text, /rebuilt/);
+});
+
 test("add project package content gates live package mutation", async () => {
   let added;
   let ensureParams;
@@ -191,6 +320,120 @@ test("add project package content gates live package mutation", async () => {
     packageName: "com.example.project",
     workflowId: "workflow-1",
   });
+});
+
+test("add project package tools support actions, configurations, and resources", async () => {
+  const added = [];
+  const handlers = registeredPackageTools({
+    ensureProjectPackage: async ({ packageName }) => ({
+      name: packageName,
+      created: false,
+    }),
+    addActionToPackage: async (packageName, categoryName, actionName) => {
+      added.push(["action", packageName, categoryName, actionName]);
+    },
+    addConfigurationToPackage: async (packageName, configurationId) => {
+      added.push(["configuration", packageName, configurationId]);
+    },
+    addResourceToPackage: async (packageName, resourceId) => {
+      added.push(["resource", packageName, resourceId]);
+    },
+  });
+
+  const actionRefused = await handlers.get("add-action-to-project-package")({
+    packageName: "com.example.project",
+    categoryName: "com.example.actions",
+    actionName: "echo",
+    confirm: false,
+  });
+  assert.match(actionRefused.content[0].text, /Confirm adding action/);
+
+  await handlers.get("add-action-to-project-package")({
+    packageName: "com.example.project",
+    categoryName: "com.example.actions",
+    actionName: "echo",
+    confirm: true,
+  });
+  await handlers.get("add-configuration-to-project-package")({
+    packageName: "com.example.project",
+    configurationId: "configuration-1",
+    confirm: true,
+  });
+  await handlers.get("add-resource-to-project-package")({
+    packageName: "com.example.project",
+    resourceId: "resource-1",
+    confirm: true,
+  });
+
+  assert.deepEqual(added, [
+    ["action", "com.example.project", "com.example.actions", "echo"],
+    ["configuration", "com.example.project", "configuration-1"],
+    ["resource", "com.example.project", "resource-1"],
+  ]);
+});
+
+test("project package mutation tools report client errors", async () => {
+  const handlers = registeredPackageTools({
+    ensureProjectPackage: async () => ({
+      name: "com.example.project",
+      created: false,
+    }),
+    rebuildPackage: async () => {
+      throw new Error("rebuild failed");
+    },
+    addWorkflowToPackage: async () => {
+      throw new Error("workflow add failed");
+    },
+    addActionToPackage: async () => {
+      throw new Error("action add failed");
+    },
+    addConfigurationToPackage: async () => {
+      throw new Error("configuration add failed");
+    },
+    addResourceToPackage: async () => {
+      throw new Error("resource add failed");
+    },
+  });
+
+  const rebuild = await handlers.get("rebuild-project-package")({
+    packageName: "com.example.project",
+    confirm: true,
+  });
+  assert.equal(rebuild.isError, true);
+  assert.match(rebuild.content[0].text, /rebuild failed/);
+
+  const workflow = await handlers.get("add-workflow-to-project-package")({
+    packageName: "com.example.project",
+    workflowId: "workflow-1",
+    confirm: true,
+  });
+  assert.equal(workflow.isError, true);
+  assert.match(workflow.content[0].text, /workflow add failed/);
+
+  const action = await handlers.get("add-action-to-project-package")({
+    packageName: "com.example.project",
+    categoryName: "com.example.actions",
+    actionName: "echo",
+    confirm: true,
+  });
+  assert.equal(action.isError, true);
+  assert.match(action.content[0].text, /action add failed/);
+
+  const configuration = await handlers.get("add-configuration-to-project-package")({
+    packageName: "com.example.project",
+    configurationId: "configuration-1",
+    confirm: true,
+  });
+  assert.equal(configuration.isError, true);
+  assert.match(configuration.content[0].text, /configuration add failed/);
+
+  const resource = await handlers.get("add-resource-to-project-package")({
+    packageName: "com.example.project",
+    resourceId: "resource-1",
+    confirm: true,
+  });
+  assert.equal(resource.isError, true);
+  assert.match(resource.content[0].text, /resource add failed/);
 });
 
 test("project package import details and import do not require live package lookup", async () => {
@@ -263,6 +506,109 @@ test("import-project-package rejects package files for a different package", asy
   assert.equal(result.isError, true);
   assert.match(result.content[0].text, /contains 'com\.example\.other'/);
   assert.match(result.content[0].text, /project package 'com\.example\.project'/);
+});
+
+test("export-project-package resolves defaults and forwards package export options", async () => {
+  let exported;
+  const handlers = registeredPackageTools({
+    ensureProjectPackage: async ({ packageName }) => ({
+      name: packageName ?? "com.example.project",
+      created: false,
+    }),
+    exportPackage: async (name, fileName, overwrite, options) => {
+      exported = { name, fileName, overwrite, options };
+      return `/tmp/packages/${fileName}`;
+    },
+  });
+
+  const result = await handlers.get("export-project-package")({
+    packageName: "com.example.project",
+    overwrite: true,
+    exportConfigurationAttributeValues: true,
+    exportGlobalTags: false,
+    exportVersionHistory: true,
+    exportConfigSecureStringAttributeValues: true,
+  });
+
+  assert.deepEqual(exported, {
+    name: "com.example.project",
+    fileName: "com.example.project.package",
+    overwrite: true,
+    options: {
+      exportConfigurationAttributeValues: true,
+      exportGlobalTags: false,
+      exportVersionHistory: true,
+      exportConfigSecureStringAttributeValues: true,
+    },
+  });
+  assert.match(result.content[0].text, /exported successfully/);
+});
+
+test("project package import tools handle confirmation and option forwarding", async () => {
+  let imported;
+  const handlers = registeredPackageTools({
+    resolveProjectPackageName: (packageName) => packageName ?? "com.example.project",
+    getPackageImportDetails: async () => ({ packageName: "com.example.project" }),
+    importPackageWithOptions: async (fileName, options) => {
+      imported = { fileName, options };
+    },
+  });
+
+  const refused = await handlers.get("import-project-package")({
+    packageName: "com.example.project",
+    confirm: false,
+  });
+  assert.equal(imported, undefined);
+  assert.match(refused.content[0].text, /Confirm import/);
+
+  const result = await handlers.get("import-project-package")({
+    packageName: "com.example.project",
+    fileName: "project.package",
+    overwrite: true,
+    importConfigurationAttributeValues: true,
+    tagImportMode: "ImportButPreserveExistingValue",
+    importConfigSecureStringAttributeValues: true,
+    confirm: true,
+  });
+
+  assert.deepEqual(imported, {
+    fileName: "project.package",
+    options: {
+      overwrite: true,
+      importConfigurationAttributeValues: true,
+      tagImportMode: "ImportButPreserveExistingValue",
+      importConfigSecureStringAttributeValues: true,
+    },
+  });
+  assert.match(result.content[0].text, /imported from: project\.package/);
+});
+
+test("project package file tools report client errors", async () => {
+  const handlers = registeredPackageTools({
+    resolveProjectPackageName: () => "com.example.project",
+    ensureProjectPackage: async () => ({
+      name: "com.example.project",
+      created: false,
+    }),
+    exportPackage: async () => {
+      throw new Error("project export failed");
+    },
+    getPackageImportDetails: async () => {
+      throw new Error("project details failed");
+    },
+  });
+
+  const exported = await handlers.get("export-project-package")({
+    packageName: "com.example.project",
+  });
+  assert.equal(exported.isError, true);
+  assert.match(exported.content[0].text, /project export failed/);
+
+  const details = await handlers.get("get-project-package-import-details")({
+    packageName: "com.example.project",
+  });
+  assert.equal(details.isError, true);
+  assert.match(details.content[0].text, /project details failed/);
 });
 
 test("delete-package refuses to submit unless confirmed", async () => {

--- a/test/package-tools.test.mjs
+++ b/test/package-tools.test.mjs
@@ -63,12 +63,12 @@ test("package export and import delegate paths and confirmation", async () => {
   let imported;
   const handlers = registeredPackageTools({
     getPackageDirectory: () => "/tmp/packages",
-    exportPackage: async (name, fileName, overwrite) => {
-      exported = { name, fileName, overwrite };
+    exportPackage: async (name, fileName, overwrite, options) => {
+      exported = { name, fileName, overwrite, options };
       return `/tmp/packages/${fileName}`;
     },
-    importPackage: async (fileName, overwrite) => {
-      imported = { fileName, overwrite };
+    importPackageWithOptions: async (fileName, options) => {
+      imported = { fileName, options };
     },
   });
 
@@ -81,6 +81,12 @@ test("package export and import delegate paths and confirmation", async () => {
     name: "com.example.demo",
     fileName: "com.example.demo.package",
     overwrite: true,
+    options: {
+      exportConfigurationAttributeValues: undefined,
+      exportGlobalTags: undefined,
+      exportVersionHistory: undefined,
+      exportConfigSecureStringAttributeValues: undefined,
+    },
   });
   assert.match(exportResult.content[0].text, /exported successfully/);
 
@@ -98,8 +104,165 @@ test("package export and import delegate paths and confirmation", async () => {
   });
   assert.deepEqual(imported, {
     fileName: "com.example.demo.package",
+    options: {
+      overwrite: false,
+      importConfigurationAttributeValues: undefined,
+      tagImportMode: undefined,
+      importConfigSecureStringAttributeValues: undefined,
+    },
+  });
+});
+
+test("project package tools reuse exact package and require confirmation to create", async () => {
+  const calls = [];
+  const handlers = registeredPackageTools({
+    ensureProjectPackage: async (params) => {
+      calls.push(params);
+      if (params.createIfMissing && params.confirm) {
+        return { name: params.packageName, created: true };
+      }
+      return {
+        name: params.packageName,
+        created: false,
+        package: { description: "Project package" },
+      };
+    },
+  });
+
+  const reused = await handlers.get("ensure-project-package")({
+    packageName: "com.example.project",
+  });
+  assert.match(reused.content[0].text, /Status: reused/);
+
+  const created = await handlers.get("ensure-project-package")({
+    packageName: "com.example.project",
+    createIfMissing: true,
+    confirm: true,
+  });
+  assert.match(created.content[0].text, /Status: created/);
+  assert.deepEqual(calls, [
+    {
+      packageName: "com.example.project",
+      description: undefined,
+      createIfMissing: undefined,
+      confirm: undefined,
+    },
+    {
+      packageName: "com.example.project",
+      description: undefined,
+      createIfMissing: true,
+      confirm: true,
+    },
+  ]);
+});
+
+test("add project package content gates live package mutation", async () => {
+  let added;
+  let ensureParams;
+  const handlers = registeredPackageTools({
+    ensureProjectPackage: async (params) => {
+      ensureParams = params;
+      return {
+        name: params.packageName,
+        created: false,
+      };
+    },
+    addWorkflowToPackage: async (packageName, workflowId) => {
+      added = { packageName, workflowId };
+    },
+  });
+
+  const refused = await handlers.get("add-workflow-to-project-package")({
+    packageName: "com.example.project",
+    workflowId: "workflow-1",
+    confirm: false,
+  });
+  assert.equal(added, undefined);
+  assert.match(refused.content[0].text, /Confirm adding workflow/);
+
+  await handlers.get("add-workflow-to-project-package")({
+    packageName: "com.example.project",
+    workflowId: "workflow-1",
+    createIfMissing: true,
+    confirm: true,
+  });
+  assert.deepEqual(ensureParams, { packageName: "com.example.project" });
+  assert.deepEqual(added, {
+    packageName: "com.example.project",
+    workflowId: "workflow-1",
+  });
+});
+
+test("project package import details and import do not require live package lookup", async () => {
+  let ensureCalls = 0;
+  let importDetailsFileName;
+  let imported;
+  const handlers = registeredPackageTools({
+    resolveProjectPackageName: (packageName) => packageName ?? "com.example.project",
+    ensureProjectPackage: async () => {
+      ensureCalls += 1;
+      throw new Error("should not check live package");
+    },
+    getPackageImportDetails: async (fileName) => {
+      importDetailsFileName = fileName;
+      return {
+        packageName: "com.example.project",
+        contentVerified: true,
+        importElementDetails: [{ id: "workflow-1" }],
+      };
+    },
+    importPackageWithOptions: async (fileName, options) => {
+      imported = { fileName, options };
+    },
+  });
+
+  const details = await handlers.get("get-project-package-import-details")({
+    packageName: "com.example.project",
+  });
+  assert.equal(importDetailsFileName, "com.example.project.package");
+  assert.match(details.content[0].text, /Elements: 1/);
+
+  await handlers.get("import-project-package")({
+    packageName: "com.example.project",
+    confirm: true,
     overwrite: false,
   });
+
+  assert.equal(ensureCalls, 0);
+  assert.deepEqual(imported, {
+    fileName: "com.example.project.package",
+    options: {
+      overwrite: false,
+      importConfigurationAttributeValues: undefined,
+      tagImportMode: undefined,
+      importConfigSecureStringAttributeValues: undefined,
+    },
+  });
+});
+
+test("import-project-package rejects package files for a different package", async () => {
+  let imported;
+  const handlers = registeredPackageTools({
+    resolveProjectPackageName: (packageName) => packageName ?? "com.example.project",
+    getPackageImportDetails: async () => ({
+      packageName: "com.example.other",
+      contentVerified: true,
+    }),
+    importPackageWithOptions: async (fileName, options) => {
+      imported = { fileName, options };
+    },
+  });
+
+  const result = await handlers.get("import-project-package")({
+    packageName: "com.example.project",
+    fileName: "com.example.other.package",
+    confirm: true,
+  });
+
+  assert.equal(imported, undefined);
+  assert.equal(result.isError, true);
+  assert.match(result.content[0].text, /contains 'com\.example\.other'/);
+  assert.match(result.content[0].text, /project package 'com\.example\.project'/);
 });
 
 test("delete-package refuses to submit unless confirmed", async () => {

--- a/test/vro-client.test.mjs
+++ b/test/vro-client.test.mjs
@@ -614,6 +614,159 @@ test("package import sends multipart file and overwrite query", async () => {
   }
 });
 
+test("package export uses content endpoint with package export options", async () => {
+  const packageDir = await mkdtemp(join(tmpdir(), "vcfa-packages-"));
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    return new Response("package-content", { status: 200 });
+  };
+
+  try {
+    const client = new VroClient(config({ packageDir }));
+    await client.exportPackage("com.example.project", "project.package", false, {
+      exportConfigurationAttributeValues: true,
+      exportGlobalTags: false,
+      exportVersionHistory: true,
+    });
+
+    assert.equal(
+      calls[1].url,
+      "https://vcfa.example.test/vco/api/content/packages/com.example.project?exportConfigurationAttributeValues=true&exportGlobalTags=false&exportVersionHistory=true",
+    );
+    assert.equal(calls[1].init.method, "GET");
+  } finally {
+    await rm(packageDir, { recursive: true, force: true });
+  }
+});
+
+test("project package reuse refuses to create without explicit confirmation", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    return new Response("missing", { status: 404, statusText: "Not Found" });
+  };
+
+  const client = new VroClient(
+    config({ projectPackageName: "com.example.project" }),
+  );
+  await assert.rejects(
+    () => client.ensureProjectPackage(),
+    /createIfMissing and confirm/,
+  );
+
+  assert.equal(
+    calls[1].url,
+    "https://vcfa.example.test/vco/api/packages/com.example.project",
+  );
+  assert.equal(calls.length, 2);
+});
+
+test("project package reuse creates exact package only when confirmed", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    if (calls.length === 2) {
+      return new Response("missing", { status: 404, statusText: "Not Found" });
+    }
+    return new Response("", { status: 201 });
+  };
+
+  const client = new VroClient(
+    config({ projectPackageName: "com.example.project" }),
+  );
+  const result = await client.ensureProjectPackage({
+    createIfMissing: true,
+    confirm: true,
+    description: "Project package",
+  });
+
+  assert.deepEqual(result, { name: "com.example.project", created: true });
+  assert.equal(calls[2].init.method, "PUT");
+  assert.equal(
+    calls[2].url,
+    "https://vcfa.example.test/vco/api/packages/com.example.project",
+  );
+  assert.deepEqual(JSON.parse(calls[2].init.body), {
+    description: "Project package",
+  });
+});
+
+test("package content helpers target the resolved package endpoints", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    return new Response("", { status: 200 });
+  };
+
+  const client = new VroClient(config());
+  await client.addWorkflowToPackage("com.example.project", "workflow-1");
+  await client.addActionToPackage("com.example.project", "com.example", "echo");
+  await client.addConfigurationToPackage("com.example.project", "config-1");
+  await client.addResourceToPackage("com.example.project", "resource-1");
+  await client.rebuildPackage("com.example.project");
+
+  assert.deepEqual(
+    calls.slice(1).map((call) => [call.init.method, call.url]),
+    [
+      [
+        "POST",
+        "https://vcfa.example.test/vco/api/packages/com.example.project/workflow/workflow-1",
+      ],
+      [
+        "POST",
+        "https://vcfa.example.test/vco/api/packages/com.example.project/action/com.example/echo",
+      ],
+      [
+        "POST",
+        "https://vcfa.example.test/vco/api/packages/com.example.project/configuration/config-1",
+      ],
+      [
+        "POST",
+        "https://vcfa.example.test/vco/api/packages/com.example.project/resource/resource-1",
+      ],
+      [
+        "POST",
+        "https://vcfa.example.test/vco/api/packages/com.example.project/rebuild",
+      ],
+    ],
+  );
+});
+
+test("package import details uploads package without importing it", async () => {
+  const packageDir = await mkdtemp(join(tmpdir(), "vcfa-packages-"));
+  await writeFile(join(packageDir, "payload.package"), xmlArchive("package"));
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    return Response.json({
+      packageName: "com.example.project",
+      contentVerified: true,
+      importElementDetails: [{ id: "workflow-1" }],
+    });
+  };
+
+  try {
+    const client = new VroClient(config({ packageDir }));
+    const details = await client.getPackageImportDetails("payload.package");
+
+    assert.equal(details.packageName, "com.example.project");
+    assert.equal(
+      calls[1].url,
+      "https://vcfa.example.test/vco/api/packages/import-details",
+    );
+    assert.equal(calls[1].init.method, "POST");
+    assert.equal(calls[1].init.body.get("file").name, "payload.package");
+  } finally {
+    await rm(packageDir, { recursive: true, force: true });
+  }
+});
+
 test("deletePackage sends documented option query", async () => {
   const calls = [];
   globalThis.fetch = async (url, init) => {

--- a/test/workflow-artifact.test.mjs
+++ b/test/workflow-artifact.test.mjs
@@ -15,6 +15,7 @@ import {
   buildWorkflowArtifact,
   buildWorkflowContent,
   buildWorkflowContentXml,
+  buildWorkflowInputFormJson,
 } from "../dist/client/workflow-artifact.js";
 import { VroClient } from "../dist/vro-client.js";
 
@@ -91,6 +92,7 @@ test("buildWorkflowArtifact creates a .workflow zip with required entries", () =
 
   assert.ok(files["workflow-info"]);
   assert.ok(files["workflow-content"]);
+  assert.ok(files["input_form_"]);
 
   const info = new TextDecoder().decode(files["workflow-info"]);
   assert.match(info, /workflow-info id="workflow-1"/);
@@ -100,6 +102,60 @@ test("buildWorkflowArtifact creates a .workflow zip with required entries", () =
   assert.equal(content[1], 0xfe);
   const xml = new TextDecoder("utf-16le").decode(content);
   assert.match(xml, /<script encoded="false"><!\[CDATA\[/);
+  assert.match(xml, /<presentation>/);
+
+  const form = files["input_form_"];
+  assert.equal(form[0], 0xfe);
+  assert.equal(form[1], 0xff);
+  const inputForm = JSON.parse(new TextDecoder("utf-16be").decode(form));
+  assert.deepEqual(inputForm.layout.pages[0], {
+    id: "page_general",
+    sections: [
+      {
+        id: "section_inputs",
+        fields: [
+          {
+            id: "projectName",
+            display: "textField",
+            signpostPosition: "right-middle",
+            state: { visible: true, "read-only": false },
+          },
+        ],
+      },
+    ],
+    title: "General",
+  });
+  assert.deepEqual(inputForm.schema.projectName, {
+    id: "projectName",
+    type: { dataType: "string" },
+    label: "Project",
+    constraints: { required: true },
+  });
+  assert.deepEqual(inputForm.options, { externalValidations: [] });
+});
+
+test("buildWorkflowInputFormJson maps common vRO input types", () => {
+  const inputForm = JSON.parse(
+    buildWorkflowInputFormJson({
+      ...workflow,
+      inputs: [
+        { name: "vm", type: "VC:VirtualMachine", description: "VM" },
+        { name: "enabled", type: "boolean", description: "Enabled" },
+        { name: "password", type: "SecureString", description: "Password" },
+      ],
+      outputs: [],
+      attributes: [],
+      tasks: [{ script: "System.log('form only');" }],
+    }),
+  );
+
+  assert.equal(inputForm.schema.vm.type.dataType, "reference");
+  assert.equal(inputForm.schema.vm.type.referenceType, "VC:VirtualMachine");
+  assert.equal(inputForm.layout.pages[0].sections[0].fields[0].display, "valuePickerTree");
+  assert.equal(inputForm.schema.enabled.type.dataType, "boolean");
+  assert.equal(inputForm.layout.pages[0].sections[0].fields[1].display, "checkbox");
+  assert.equal(inputForm.schema.password.type.dataType, "secureString");
+  assert.equal(inputForm.layout.pages[0].sections[0].fields[2].display, "passwordField");
 });
 
 test("buildWorkflowArtifact reuses generated workflow ID across archive entries", () => {


### PR DESCRIPTION
## Summary

- add project-package reuse tools for package-first vRO publishing
- add package import-details/export/import options and safety checks
- generate and preflight vRO workflow `input_form_` content for scaffolded workflows
- document package-first publishing, native action-item guidance, horizontal workflow layout, and input form rules

## Context

This captures the live VCFA/vRO validation lessons: reusable project content should move through one stable package, workflows with inputs need valid vRO input forms, and direct artifact imports should stay reserved for narrow validation or explicit one-off tests.

## Validation

- `npm run validate`

## Follow-up

Remaining workflow/package authoring gaps are tracked in #36.