### PR TITLE
[codex] Add vRA 8 read-run compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,22 +50,3 @@ jobs:
 
       - name: Run full validation gate
         run: npm run validate
-
-  docs:
-    name: Build documentation
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build documentation
-        run: npm run docs:build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,22 @@ jobs:
 
       - name: Run full validation gate
         run: npm run validate
+
+  docs:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build documentation
+        run: npm run docs:build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ trigger: "vcfa-orchestrator"
 
 # VCF Orchestrator Agent
 
-This repository builds an MCP server for VCF Automation Orchestrator (vRO), Service Broker, and Cloud Assembly. Agents working here should be discovery-first, conservative with live environments, and biased toward real importable artifacts over illustrative pseudocode.
+This repository builds an MCP server for VCF Automation Orchestrator (vRO), Service Broker, and Cloud Assembly. It also supports a vRA/vRO 8.12+ read/run mode through `VCFA_TARGET_PLATFORM=vra8`. Agents working here should be discovery-first, conservative with live environments, and biased toward real importable artifacts over illustrative pseudocode.
 
 Use these instructions for all work in this repository. If a more specific `AGENTS.md` exists in a subdirectory, apply that file for its subtree and keep compatible guidance from this file. When instructions conflict, the deeper file wins for files in its scope.
 
@@ -43,7 +43,7 @@ If the docs and source disagree, inspect the source, update the docs or examples
 Use the exact registered tool names. Start with list/get tools unless the user has already provided verified IDs and contracts.
 
 - Context and promotion: `collect-context-snapshot`, `prepare-artifact-promotion`
-- Workflows: `list-workflows`, `get-workflow`, `create-workflow`, `run-workflow`, `run-workflow-and-wait`, `list-workflow-executions`, `get-workflow-execution`, `export-workflow-file`, `scaffold-workflow-file`, `preflight-workflow-file`, `diff-workflow-file`, `import-workflow-file`, `delete-workflow`
+- Workflows: `list-workflows`, `get-workflow`, `create-workflow`, `run-workflow`, `run-workflow-and-wait`, `list-workflow-executions`, `get-workflow-execution`, `get-workflow-execution-logs`, `export-workflow-file`, `scaffold-workflow-file`, `preflight-workflow-file`, `diff-workflow-file`, `import-workflow-file`, `delete-workflow`
 - Actions: `list-actions`, `get-action`, `create-action`, `export-action-file`, `preflight-action-file`, `diff-action-file`, `import-action-file`, `delete-action`
 - Configuration elements: `list-configurations`, `get-configuration`, `create-configuration`, `update-configuration`, `export-configuration-file`, `preflight-configuration-file`, `import-configuration-file`, `delete-configuration`
 - Resource elements: `list-resource-elements`, `export-resource-element`, `import-resource-element`, `update-resource-element`, `delete-resource-element`
@@ -54,6 +54,8 @@ Use the exact registered tool names. Start with list/get tools unless the user h
 - Catalog and deployments: `list-catalog-items`, `get-catalog-item`, `list-deployments`, `get-deployment`, `create-deployment`, `delete-deployment`, `list-deployment-actions`, `run-deployment-action`
 
 Many write-capable tools require a `confirm: true` argument before they mutate state. That schema requirement does not replace user confirmation. Confirm the exact target, expected impact, and rollback or backup plan before calling live create, update, import, delete, deployment, day-2, package, or local overwrite tools.
+
+In `vra8` mode, support only vRO `/vco/api` read operations plus workflow execution and execution logs. Automation-service APIs such as catalog, deployments, templates, subscriptions, and event topics are intentionally unsupported in Basic-auth mode until token-auth support is added.
 
 ## Current MCP Prompts And Resources
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Useful optional variables:
 | `VCFA_PACKAGE_DIR` | Override package artifact directory. |
 | `VCFA_RESOURCE_DIR` | Override resource artifact directory. |
 | `VCFA_WORKFLOW_DIR` | Override workflow artifact directory. |
+| `VCFA_EXECUTION_LOG_DIR` | Override workflow execution log export directory. |
 | `VCFA_ACTION_DIR` | Override action artifact directory. |
 | `VCFA_CONFIGURATION_DIR` | Override configuration artifact directory. |
 | `VCFA_CONTEXT_DIR` | Override persisted context snapshot directory. If unset, context snapshots prefer the MCP client's current workspace root at `artifacts/context/`, falling back to `VCFA_ARTIFACT_DIR/context`. |
@@ -74,7 +75,7 @@ Useful optional variables:
 
 The server includes tools for:
 
-- Workflows, workflow executions, standalone execution logs, workflow artifact scaffold/preflight/diff/import/export
+- Workflows, workflow executions, inline/exported execution syslogs, workflow artifact scaffold/preflight/diff/import/export
 - Actions and action artifact import/export/preflight/diff
 - Configuration elements and resource elements
 - vRO packages and plugins, including package-first project package reuse

--- a/README.md
+++ b/README.md
@@ -52,12 +52,13 @@ Required environment variables:
 | `VCFA_HOST` | VCF Automation hostname, for example `vcfa.example.com`. |
 | `VCFA_USERNAME` | Username without organization, for example `admin`. |
 | `VCFA_ORGANIZATION` | Organization or tenant, for example `System` or `vsphere.local`. |
-| `VCFA_PASSWORD` | Password for the VCF Cloud API session. |
+| `VCFA_PASSWORD` | Password for the VCF Cloud API session, or the vRO Basic-auth password when `VCFA_TARGET_PLATFORM=vra8`. |
 
 Useful optional variables:
 
 | Variable | Description |
 | --- | --- |
+| `VCFA_TARGET_PLATFORM` | Target platform mode. Defaults to `vcfa`, which uses the VCF Cloud API session flow. Set to `vra8` for vRA/vRO 8.12+ Basic-auth mode against `/vco/api`; this mode supports vRO read operations plus workflow execution/logs and does not support Automation-service APIs such as catalog, deployments, templates, or subscriptions. |
 | `VCFA_IGNORE_TLS` | Set to `true` to skip TLS certificate verification in lab environments. |
 | `VCFA_ARTIFACT_DIR` | Root directory for local artifact files. Defaults to `artifacts/` in the MCP server process working directory, typically the open project. |
 | `VCFA_PACKAGE_DIR` | Override package artifact directory. |
@@ -73,7 +74,7 @@ Useful optional variables:
 
 The server includes tools for:
 
-- Workflows, workflow executions, workflow artifact scaffold/preflight/diff/import/export
+- Workflows, workflow executions, standalone execution logs, workflow artifact scaffold/preflight/diff/import/export
 - Actions and action artifact import/export/preflight/diff
 - Configuration elements and resource elements
 - vRO packages and plugins, including package-first project package reuse

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -31,6 +31,7 @@ For vRA/vRO 8.12+ read/run compatibility, set `VCFA_TARGET_PLATFORM=vra8`. In th
 | `VCFA_PACKAGE_DIR` | Override the package artifact directory. |
 | `VCFA_RESOURCE_DIR` | Override the resource element artifact directory. |
 | `VCFA_WORKFLOW_DIR` | Override the workflow artifact directory. |
+| `VCFA_EXECUTION_LOG_DIR` | Override the workflow execution log export directory. |
 | `VCFA_ACTION_DIR` | Override the action artifact directory. |
 | `VCFA_CONFIGURATION_DIR` | Override the configuration artifact directory. |
 | `VCFA_CONTEXT_DIR` | Override the persisted context snapshot directory. If unset, context snapshots prefer the MCP client's current workspace root at `artifacts/context/`, falling back to `VCFA_ARTIFACT_DIR/context`. |
@@ -46,6 +47,7 @@ VCFA_ARTIFACT_DIR/
   actions/
   configurations/
   context/
+  execution-logs/
   packages/
   resources/
   workflows/

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -9,7 +9,7 @@ The server reads all runtime configuration from environment variables.
 | `VCFA_HOST` | Yes | VCF Automation hostname, for example `vcfa.example.com`. |
 | `VCFA_USERNAME` | Yes | Username without organization, for example `admin`. |
 | `VCFA_ORGANIZATION` | Yes | Organization or tenant, for example `System` or `vsphere.local`. |
-| `VCFA_PASSWORD` | Yes | Password for the VCF Cloud API session. |
+| `VCFA_PASSWORD` | Yes | Password for the VCF Cloud API session, or the vRO Basic-auth password when `VCFA_TARGET_PLATFORM=vra8`. |
 
 The server authenticates by sending Basic Auth as `{VCFA_USERNAME}@{VCFA_ORGANIZATION}:{VCFA_PASSWORD}` to:
 
@@ -19,10 +19,13 @@ https://{VCFA_HOST}/cloudapi/1.0.0/sessions
 
 It uses the returned bearer token for later VCF Automation, Service Broker, Cloud Assembly, and vRO API calls.
 
+For vRA/vRO 8.12+ read/run compatibility, set `VCFA_TARGET_PLATFORM=vra8`. In that mode, the server skips the VCF Cloud API session endpoint and sends Basic auth directly to `/vco/api`. The vRA/vRO 8 mode supports vRO read operations plus workflow execution and execution logs; Automation-service APIs such as catalog, deployments, templates, subscriptions, and event topics are intentionally unsupported until token-auth support is added.
+
 ## Optional Variables
 
 | Variable | Description |
 | --- | --- |
+| `VCFA_TARGET_PLATFORM` | Target platform mode: `vcfa` (default) or `vra8`. |
 | `VCFA_IGNORE_TLS` | Set to `true` to disable TLS certificate verification for lab environments. |
 | `VCFA_ARTIFACT_DIR` | Root directory for local artifact import/export files. Defaults to `artifacts/` in the MCP server process working directory, typically the open project. |
 | `VCFA_PACKAGE_DIR` | Override the package artifact directory. |

--- a/docs/how-tos/workflows.md
+++ b/docs/how-tos/workflows.md
@@ -17,6 +17,47 @@ Recommended tool sequence:
 
 `run-workflow-and-wait` validates inputs before running and polls until completion. If the workflow fails, the response includes current item details, stack information, log excerpts, and warnings when diagnostics cannot be fetched.
 
+## Show Or Export Execution Logs
+
+Use `get-workflow-execution-logs` when you need the workflow execution syslog stream, including messages written by `System.log`, `System.debug`, `System.warn`, and `System.error`.
+
+Show all fetched syslogs inline:
+
+```text
+get-workflow-execution-logs(
+  workflowId: "<workflow-id>",
+  executionId: "<execution-id>",
+  maxResult: 50
+)
+```
+
+Show only error-level logs:
+
+```text
+get-workflow-execution-logs(
+  workflowId: "<workflow-id>",
+  executionId: "<execution-id>",
+  level: "error",
+  maxResult: 50
+)
+```
+
+Export info-and-higher logs to JSON under `VCFA_EXECUTION_LOG_DIR`, or `VCFA_ARTIFACT_DIR/execution-logs` when no override is set:
+
+```text
+get-workflow-execution-logs(
+  workflowId: "<workflow-id>",
+  executionId: "<execution-id>",
+  fileName: "execution-logs.json",
+  level: "info",
+  format: "json",
+  maxResult: 200,
+  overwrite: true
+)
+```
+
+Use a `.txt` file name and `format: "text"` for a human-readable export. The `level` filter is a minimum severity filter: `debug` includes all known severities plus unknown severities, `info` includes info/warning/error, and `error` includes only error entries. Inline display is unfiltered unless `level` is provided; exports default to `level: "info"`.
+
 ## Scaffold, Publish, And Test A Workflow
 
 Use `scaffold-workflow-file` for real importable `.workflow` artifacts instead of hand-building ZIP/XML content.

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -29,7 +29,11 @@ If a workflow was started asynchronously, use:
 
 1. `list-workflow-executions`
 2. `get-workflow-execution`
-3. execution logs when available
+3. `get-workflow-execution-logs`
+
+## vRA/vRO 8 Mode
+
+Set `VCFA_TARGET_PLATFORM=vra8` for vRA/vRO 8.12+ Basic-auth mode. This mode supports vRO `/vco/api` read operations, workflow execution, and execution logs. Catalog, deployment, template, subscription, and event-topic tools require Automation-service token auth and return an unsupported-mode message in this phase.
 
 ## Artifact Import Failures
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -31,6 +31,8 @@ If a workflow was started asynchronously, use:
 2. `get-workflow-execution`
 3. `get-workflow-execution-logs`
 
+`get-workflow-execution-logs` reads the execution `syslogs` stream, which is where vRO exposes workflow token messages such as `System.log`, `System.debug`, `System.warn`, and `System.error`. Use `level: "error"` to show only error entries, or provide `fileName` to export the filtered logs as `.json` or `.txt`.
+
 ## vRA/vRO 8 Mode
 
 Set `VCFA_TARGET_PLATFORM=vra8` for vRA/vRO 8.12+ Basic-auth mode. This mode supports vRO `/vco/api` read operations, workflow execution, and execution logs. Catalog, deployment, template, subscription, and event-topic tools require Automation-service token auth and return an unsupported-mode message in this phase.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -174,6 +174,18 @@ Check the status and outputs of a workflow execution.
 | `executionId` | string | Yes | - | Execution ID returned by `run-workflow`, `run-workflow-and-wait`, or `list-workflow-executions`. |
 :::
 
+### `get-workflow-execution-logs`
+
+Retrieve log entries for a workflow execution. Use this after `run-workflow`, `list-workflow-executions`, or `get-workflow-execution` when detailed execution logs are needed.
+
+::: details Parameters
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `workflowId` | string | Yes | - | Workflow ID associated with the execution. |
+| `executionId` | string | Yes | - | Execution ID returned by `run-workflow`, `run-workflow-and-wait`, or `list-workflow-executions`. |
+| `maxResult` | integer | No | - | Maximum number of execution log entries to return. |
+:::
+
 ### `export-workflow-file`
 
 Export a vRO workflow as a `.workflow` file under the configured workflow artifact directory.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -176,14 +176,18 @@ Check the status and outputs of a workflow execution.
 
 ### `get-workflow-execution-logs`
 
-Retrieve log entries for a workflow execution. Use this after `run-workflow`, `list-workflow-executions`, or `get-workflow-execution` when detailed execution logs are needed.
+Retrieve system/event log entries for a workflow execution, including workflow token messages such as `System.log`, `System.debug`, `System.warn`, and `System.error`. Use this after `run-workflow`, `list-workflow-executions`, or `get-workflow-execution` when detailed execution logs are needed. To save logs instead of returning them inline, provide `fileName`; exports are written under `VCFA_EXECUTION_LOG_DIR` or `VCFA_ARTIFACT_DIR/execution-logs`. The `level` parameter is a minimum severity filter for inline display and export: `debug` includes debug and all higher known severities plus unknown severities, `info` includes info, warning, and error logs, and `error` includes only error logs.
 
 ::: details Parameters
 | Parameter | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `workflowId` | string | Yes | - | Workflow ID associated with the execution. |
 | `executionId` | string | Yes | - | Execution ID returned by `run-workflow`, `run-workflow-and-wait`, or `list-workflow-executions`. |
-| `maxResult` | integer | No | - | Maximum number of execution log entries to return. |
+| `maxResult` | integer | No | - | Maximum number of execution log entries to fetch before filtering. |
+| `fileName` | string | No | - | Plain `.json` or `.txt` file name to export under the configured execution log artifact directory. Do not pass a path. |
+| `level` | `debug` \| `info` \| `error` | No | inline: none; export: `info` | Minimum log severity to display or export. |
+| `format` | `json` \| `text` | No | inferred from extension | Export format when `fileName` is provided. Must match the file extension when set. |
+| `overwrite` | boolean | No | `false` | Overwrite the export file if it already exists. |
 :::
 
 ### `export-workflow-file`

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,7 @@ These examples are current, import-safe patterns for using the MCP tools. They a
 - [Project Package](./project-package.md): reuse one project package, add content, rebuild, export, and inspect before import.
 - [Artifact Promotion](./artifact-promotion.md): preflight, diff, optional backup, and import recommendation.
 - [Template, Catalog, And Subscription](./template-catalog-subscription.md): review templates, inspect catalog/deployment behavior, and plan subscriptions.
+- vRA/vRO 8.12+ read/run mode: set `VCFA_TARGET_PLATFORM=vra8`, use vRO list/get tools, run workflows with `run-workflow` or `run-workflow-and-wait`, and inspect logs with `get-workflow-execution-logs`.
 
 ## Safety Defaults
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,8 +7,9 @@ These examples are current, import-safe patterns for using the MCP tools. They a
 - [Workflow Artifact](./workflow-artifact.md): collect context, scaffold a workflow, preflight, import, and test it.
 - [Project Package](./project-package.md): reuse one project package, add content, rebuild, export, and inspect before import.
 - [Artifact Promotion](./artifact-promotion.md): preflight, diff, optional backup, and import recommendation.
+- [Workflow Execution Logs](./workflow-execution-logs.md): show, filter, and export execution syslogs from workflow runs.
 - [Template, Catalog, And Subscription](./template-catalog-subscription.md): review templates, inspect catalog/deployment behavior, and plan subscriptions.
-- vRA/vRO 8.12+ read/run mode: set `VCFA_TARGET_PLATFORM=vra8`, use vRO list/get tools, run workflows with `run-workflow` or `run-workflow-and-wait`, and inspect logs with `get-workflow-execution-logs`.
+- vRA/vRO 8.12+ read/run mode: set `VCFA_TARGET_PLATFORM=vra8`, use vRO list/get tools, run workflows with `run-workflow` or `run-workflow-and-wait`, and inspect/export syslogs with `get-workflow-execution-logs`.
 
 ## Safety Defaults
 

--- a/examples/workflow-execution-logs.md
+++ b/examples/workflow-execution-logs.md
@@ -1,0 +1,52 @@
+# Workflow Execution Logs Example
+
+Use this flow when a workflow has already run and you need to inspect or persist its execution syslogs. These logs include workflow token messages written with `System.log`, `System.debug`, `System.warn`, and `System.error`.
+
+## Find The Execution
+
+```text
+list-workflows(filter: "Test Wf")
+list-workflow-executions(workflowId: "<workflow-id>", maxResults: 20)
+get-workflow-execution(workflowId: "<workflow-id>", executionId: "<execution-id>")
+```
+
+## Show Logs Inline
+
+Show all fetched syslogs:
+
+```text
+get-workflow-execution-logs(
+  workflowId: "<workflow-id>",
+  executionId: "<execution-id>",
+  maxResult: 50
+)
+```
+
+Show only error entries:
+
+```text
+get-workflow-execution-logs(
+  workflowId: "<workflow-id>",
+  executionId: "<execution-id>",
+  level: "error",
+  maxResult: 50
+)
+```
+
+## Export Logs
+
+Export info-and-higher entries to JSON under `VCFA_EXECUTION_LOG_DIR`, or under `VCFA_ARTIFACT_DIR/execution-logs` when no override is set:
+
+```text
+get-workflow-execution-logs(
+  workflowId: "<workflow-id>",
+  executionId: "<execution-id>",
+  fileName: "execution-logs.json",
+  level: "info",
+  format: "json",
+  maxResult: 200,
+  overwrite: true
+)
+```
+
+Use `fileName: "execution-logs.txt"` and `format: "text"` for a human-readable export. File names must be plain `.json` or `.txt` names, not paths.

--- a/src/client/action-client.ts
+++ b/src/client/action-client.ts
@@ -156,8 +156,9 @@ export class ActionClient {
   }
 
   async exportActionBuffer(actionId: string): Promise<Buffer> {
-    const token = await this.http.ensureAuthenticated();
     const path = `/actions/${encodeURIComponent(actionId)}`;
+    this.http.assertOperationSupported("GET", path);
+    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] GET ${path}`);
 
@@ -168,7 +169,7 @@ export class ActionClient {
       res = await fetch(url, {
         method: "GET",
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: authorization,
           Accept: "application/zip",
         },
         signal: controller.signal,
@@ -219,6 +220,8 @@ export class ActionClient {
     categoryName: string,
     fileName: string,
   ): Promise<void> {
+    const path = "/actions";
+    this.http.assertOperationSupported("POST", path);
     ensurePreflightPassed(await this.preflightActionFile(fileName));
     const srcPath = await this.resolveActionPath(fileName);
     await rejectSymlink(
@@ -230,13 +233,13 @@ export class ActionClient {
       srcPath,
       "Action file path resolves outside the configured action artifact directory",
     );
-    const token = await this.http.ensureAuthenticated();
     const buffer = await readFile(srcPath);
     const form = new FormData();
     form.append("file", new Blob([new Uint8Array(buffer)]), fileName);
     form.append("categoryName", categoryName);
 
-    const path = "/actions";
+    this.http.assertOperationSupported("POST", path);
+    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] POST ${path}`);
 
@@ -247,7 +250,7 @@ export class ActionClient {
       res = await fetch(url, {
         method: "POST",
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: authorization,
           Accept: "application/json",
         },
         body: form,

--- a/src/client/configuration-client.ts
+++ b/src/client/configuration-client.ts
@@ -92,8 +92,9 @@ export class ConfigurationClient {
       );
     }
 
-    const token = await this.http.ensureAuthenticated();
     const path = `/configurations/${encodeURIComponent(id)}`;
+    this.http.assertOperationSupported("GET", path);
+    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] GET ${path}`);
 
@@ -104,7 +105,7 @@ export class ConfigurationClient {
       res = await fetch(url, {
         method: "GET",
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: authorization,
           Accept: "application/zip",
         },
         signal: controller.signal,
@@ -127,6 +128,8 @@ export class ConfigurationClient {
     categoryId: string,
     fileName: string,
   ): Promise<void> {
+    const path = "/configurations";
+    this.http.assertOperationSupported("POST", path);
     ensurePreflightPassed(await this.preflightConfigurationFile(fileName));
     const srcPath = await this.resolveConfigurationPath(fileName);
     await rejectSymlink(
@@ -138,13 +141,13 @@ export class ConfigurationClient {
       srcPath,
       "Configuration file path resolves outside the configured configuration artifact directory",
     );
-    const token = await this.http.ensureAuthenticated();
     const buffer = await readFile(srcPath);
     const form = new FormData();
     form.append("file", new Blob([new Uint8Array(buffer)]), fileName);
     form.append("categoryId", categoryId);
 
-    const path = "/configurations";
+    this.http.assertOperationSupported("POST", path);
+    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] POST ${path}`);
 
@@ -155,7 +158,7 @@ export class ConfigurationClient {
       res = await fetch(url, {
         method: "POST",
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: authorization,
           Accept: "application/json",
         },
         body: form,

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -37,6 +37,7 @@ export class VroHttpClient {
   readonly projectPackageDescription?: string;
   readonly resourceDir: string;
   readonly workflowDir: string;
+  readonly executionLogDir: string;
   readonly actionDir: string;
   readonly configurationDir: string;
   readonly contextDir: string;
@@ -69,6 +70,9 @@ export class VroHttpClient {
     );
     this.workflowDir = resolve(
       config.workflowDir ?? join(artifactDir, "workflows"),
+    );
+    this.executionLogDir = resolve(
+      config.executionLogDir ?? join(artifactDir, "execution-logs"),
     );
     this.actionDir = resolve(config.actionDir ?? join(artifactDir, "actions"));
     this.configurationDir = resolve(

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -1,12 +1,32 @@
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import type { VroClientConfig } from "../types.js";
+import type { VroClientConfig, VroTargetPlatform } from "../types.js";
+
+const UNSUPPORTED_AUTOMATION_SERVICES =
+  "Automation-service APIs (catalog, deployments, templates, subscriptions, and event topics) are not supported in VCFA_TARGET_PLATFORM=vra8 Basic-auth mode. This mode supports vRO /vco/api read operations plus workflow execution and execution logs.";
+
+const UNSUPPORTED_VRO_WRITE =
+  "This vRO operation is not supported in VCFA_TARGET_PLATFORM=vra8 mode. The vRA/vRO 8 compatibility phase supports read operations plus workflow execution and execution logs only.";
+
+function normalizeTargetPlatform(
+  value: VroClientConfig["targetPlatform"] | string | undefined,
+): VroTargetPlatform {
+  const normalized = value?.toLowerCase();
+  if (normalized === undefined || normalized === "" || normalized === "vcfa") {
+    return "vcfa";
+  }
+  if (normalized === "vra8") {
+    return "vra8";
+  }
+  throw new Error("targetPlatform must be one of: vcfa, vra8.");
+}
 
 /**
  * Shared HTTP/authentication layer for VCF Automation and vRO APIs.
  * Uses native fetch() (Node 18+).
  */
 export class VroHttpClient {
+  readonly targetPlatform: VroTargetPlatform;
   readonly baseUrl: string;
   readonly eventBrokerBaseUrl: string;
   readonly catalogBaseUrl: string;
@@ -26,6 +46,7 @@ export class VroHttpClient {
   private token: string | null = null;
 
   constructor(config: VroClientConfig) {
+    this.targetPlatform = normalizeTargetPlatform(config.targetPlatform);
     if (config.ignoreTls) {
       process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = "0";
     }
@@ -62,6 +83,9 @@ export class VroHttpClient {
   }
 
   async ensureAuthenticated(): Promise<string> {
+    if (this.targetPlatform === "vra8") {
+      return this.loginHeader;
+    }
     if (!this.token) {
       await this.authenticate();
     }
@@ -109,18 +133,49 @@ export class VroHttpClient {
     console.error("[vro-client] Authentication successful, token acquired.");
   }
 
+  async authorizationHeader(): Promise<string> {
+    if (this.targetPlatform === "vra8") {
+      return this.loginHeader;
+    }
+    return `Bearer ${await this.ensureAuthenticated()}`;
+  }
+
+  assertOperationSupported(
+    method: string,
+    path: string,
+    overrideBaseUrl?: string,
+  ): void {
+    if (this.targetPlatform !== "vra8") return;
+
+    if (overrideBaseUrl && overrideBaseUrl !== this.baseUrl) {
+      throw new Error(UNSUPPORTED_AUTOMATION_SERVICES);
+    }
+
+    const normalizedMethod = method.toUpperCase();
+    if (normalizedMethod === "GET") return;
+    if (
+      normalizedMethod === "POST" &&
+      /^\/workflows\/[^/]+\/executions(?:$|\?)/.test(path)
+    ) {
+      return;
+    }
+
+    throw new Error(UNSUPPORTED_VRO_WRITE);
+  }
+
   async request<T>(
     method: string,
     path: string,
     body?: unknown,
     overrideBaseUrl?: string,
   ): Promise<T> {
-    const token = await this.ensureAuthenticated();
+    this.assertOperationSupported(method, path, overrideBaseUrl);
+    const authorization = await this.authorizationHeader();
     const url = `${overrideBaseUrl ?? this.baseUrl}${path}`;
     console.error(`[vro-client] ${method} ${path}`);
 
     const headers: Record<string, string> = {
-      Authorization: `Bearer ${token}`,
+      Authorization: authorization,
       Accept: "application/json",
     };
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -13,6 +13,8 @@ import type {
   DeploymentRequest,
   DiffActionFileParams,
   DiffWorkflowFileParams,
+  ExportWorkflowExecutionLogsParams,
+  ExportWorkflowExecutionLogsResult,
   PackageExportOptions,
   PackageImportDetails,
   PackageImportOptions,
@@ -156,12 +158,22 @@ export class VroClient {
     return this.workflows.getWorkflowDirectory();
   }
 
+  getExecutionLogDirectory(): string {
+    return this.workflows.getExecutionLogDirectory();
+  }
+
   exportWorkflowFile(
     id: string,
     fileName: string,
     overwrite = false,
   ): Promise<string> {
     return this.workflows.exportWorkflowFile(id, fileName, overwrite);
+  }
+
+  exportWorkflowExecutionLogs(
+    params: ExportWorkflowExecutionLogsParams,
+  ): Promise<ExportWorkflowExecutionLogsResult> {
+    return this.workflows.exportWorkflowExecutionLogs(params);
   }
 
   exportWorkflowBuffer(id: string): Promise<Buffer> {

--- a/src/client/package-client.ts
+++ b/src/client/package-client.ts
@@ -217,9 +217,10 @@ export class PackageClient {
         `Package file already exists: ${fileName}. Set overwrite to true to replace it.`,
       );
     }
-    const token = await this.http.ensureAuthenticated();
     const query = packageExportQuery(options);
     const path = `/content/packages/${encodeURIComponent(name)}${query}`;
+    this.http.assertOperationSupported("GET", path);
+    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] GET ${path}`);
 
@@ -230,7 +231,7 @@ export class PackageClient {
       res = await fetch(url, {
         method: "GET",
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: authorization,
           Accept: "application/zip",
         },
         signal: controller.signal,
@@ -257,6 +258,9 @@ export class PackageClient {
     fileName: string,
     options: PackageImportOptions = {},
   ): Promise<void> {
+    const query = packageImportQuery(options);
+    const path = `/packages${query}`;
+    this.http.assertOperationSupported("POST", path);
     ensurePreflightPassed(await this.preflightPackageFile(fileName));
     const srcPath = await this.resolvePackagePath(fileName);
     await rejectSymlink(
@@ -268,12 +272,11 @@ export class PackageClient {
       srcPath,
       "Package file path resolves outside the configured package artifact directory",
     );
-    const token = await this.http.ensureAuthenticated();
     const buffer = await readFile(srcPath);
     const form = new FormData();
     form.append("file", new Blob([new Uint8Array(buffer)]), fileName);
-    const query = packageImportQuery(options);
-    const path = `/packages${query}`;
+    this.http.assertOperationSupported("POST", path);
+    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] POST ${path}`);
 
@@ -284,7 +287,7 @@ export class PackageClient {
       res = await fetch(url, {
         method: "POST",
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: authorization,
           Accept: "application/json",
         },
         body: form,
@@ -302,6 +305,8 @@ export class PackageClient {
   }
 
   async getPackageImportDetails(fileName: string): Promise<PackageImportDetails> {
+    const path = "/packages/import-details";
+    this.http.assertOperationSupported("POST", path);
     ensurePreflightPassed(await this.preflightPackageFile(fileName));
     const srcPath = await this.resolvePackagePath(fileName);
     await rejectSymlink(
@@ -313,11 +318,11 @@ export class PackageClient {
       srcPath,
       "Package file path resolves outside the configured package artifact directory",
     );
-    const token = await this.http.ensureAuthenticated();
     const buffer = await readFile(srcPath);
     const form = new FormData();
     form.append("file", new Blob([new Uint8Array(buffer)]), fileName);
-    const path = "/packages/import-details";
+    this.http.assertOperationSupported("POST", path);
+    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] POST ${path}`);
 
@@ -328,7 +333,7 @@ export class PackageClient {
       res = await fetch(url, {
         method: "POST",
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: authorization,
           Accept: "application/json",
         },
         body: form,

--- a/src/client/resource-client.ts
+++ b/src/client/resource-client.ts
@@ -67,8 +67,9 @@ export class ResourceClient {
         `Resource file already exists: ${fileName}. Set overwrite to true to replace it.`,
       );
     }
-    const token = await this.http.ensureAuthenticated();
     const path = `/resources/${encodeURIComponent(id)}`;
+    this.http.assertOperationSupported("GET", path);
+    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] GET ${path}`);
 
@@ -79,7 +80,7 @@ export class ResourceClient {
       res = await fetch(url, {
         method: "GET",
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: authorization,
           Accept: "*/*",
         },
         signal: controller.signal,
@@ -117,12 +118,13 @@ export class ResourceClient {
     form: FormData,
     changesetSha?: string,
   ): Promise<void> {
-    const token = await this.http.ensureAuthenticated();
+    this.http.assertOperationSupported("POST", path);
+    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] POST ${path}`);
 
     const headers: Record<string, string> = {
-      Authorization: `Bearer ${token}`,
+      Authorization: authorization,
       Accept: "application/json",
     };
     if (changesetSha) {
@@ -151,6 +153,7 @@ export class ResourceClient {
   }
 
   async importResource(categoryId: string, fileName: string): Promise<void> {
+    this.http.assertOperationSupported("POST", "/resources");
     const buffer = await this.readResourceFile(fileName);
     const form = new FormData();
     form.append("file", new Blob([new Uint8Array(buffer)]), fileName);
@@ -163,14 +166,12 @@ export class ResourceClient {
     fileName: string,
     changesetSha?: string,
   ): Promise<void> {
+    const path = `/resources/${encodeURIComponent(id)}`;
+    this.http.assertOperationSupported("POST", path);
     const buffer = await this.readResourceFile(fileName);
     const form = new FormData();
     form.append("file", new Blob([new Uint8Array(buffer)]), fileName);
-    await this.postResourceForm(
-      `/resources/${encodeURIComponent(id)}`,
-      form,
-      changesetSha,
-    );
+    await this.postResourceForm(path, form, changesetSha);
   }
 
   async deleteResource(id: string, force = false): Promise<void> {

--- a/src/client/workflow-client.ts
+++ b/src/client/workflow-client.ts
@@ -205,8 +205,9 @@ export class WorkflowClient {
   }
 
   async exportWorkflowBuffer(id: string): Promise<Buffer> {
-    const token = await this.http.ensureAuthenticated();
     const path = `/content/workflows/${encodeURIComponent(id)}`;
+    this.http.assertOperationSupported("GET", path);
+    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] GET ${path}`);
 
@@ -217,7 +218,7 @@ export class WorkflowClient {
       res = await fetch(url, {
         method: "GET",
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: authorization,
           Accept: "application/zip",
         },
         signal: controller.signal,
@@ -290,6 +291,8 @@ export class WorkflowClient {
     fileName: string,
     overwrite = true,
   ): Promise<void> {
+    const path = `/workflows?categoryId=${encodeURIComponent(categoryId)}&overwrite=${overwrite}`;
+    this.http.assertOperationSupported("POST", path);
     ensurePreflightPassed(await this.preflightWorkflowFile(fileName));
     const srcPath = await this.resolveWorkflowPath(fileName);
     await rejectSymlink(
@@ -301,12 +304,12 @@ export class WorkflowClient {
       srcPath,
       "Workflow file path resolves outside the configured workflow artifact directory",
     );
-    const token = await this.http.ensureAuthenticated();
     const buffer = await readFile(srcPath);
     const form = new FormData();
     form.append("file", new Blob([new Uint8Array(buffer)]), fileName);
 
-    const path = `/workflows?categoryId=${encodeURIComponent(categoryId)}&overwrite=${overwrite}`;
+    this.http.assertOperationSupported("POST", path);
+    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] POST ${path}`);
 
@@ -317,7 +320,7 @@ export class WorkflowClient {
       res = await fetch(url, {
         method: "POST",
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: authorization,
           Accept: "application/json",
         },
         body: form,

--- a/src/client/workflow-client.ts
+++ b/src/client/workflow-client.ts
@@ -2,15 +2,20 @@ import { readFile, writeFile } from "node:fs/promises";
 import { extname } from "node:path";
 import type {
   DiffWorkflowFileParams,
+  ExportWorkflowExecutionLogsParams,
+  ExportWorkflowExecutionLogsResult,
   ScaffoldWorkflowFileParams,
   SimpleParameter,
   Workflow,
   WorkflowExecution,
+  WorkflowExecutionLog,
+  WorkflowExecutionLogExportFormat,
+  WorkflowExecutionLogLevel,
   WorkflowExecutionList,
   WorkflowExecutionLogs,
   WorkflowList,
 } from "../types.js";
-import { parseAttrs } from "./attrs.js";
+import { getLinkAttrs, parseAttrs } from "./attrs.js";
 import type { VroHttpClient } from "./core.js";
 import {
   diffWorkflowArtifacts,
@@ -26,6 +31,205 @@ import {
   resolveFileInDirectory,
 } from "./files.js";
 import { buildWorkflowArtifact } from "./workflow-artifact.js";
+
+const LOG_SEVERITY_RANK: Record<string, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  warning: 30,
+  error: 40,
+};
+
+function normalizeLogLevel(level: string): WorkflowExecutionLogLevel {
+  const normalized = level.toLowerCase();
+  if (normalized === "debug" || normalized === "info" || normalized === "error") {
+    return normalized;
+  }
+  throw new Error("Execution log level must be one of: debug, info, error.");
+}
+
+function inferLogExportFormat(
+  fileName: string,
+  format?: WorkflowExecutionLogExportFormat,
+): WorkflowExecutionLogExportFormat {
+  const ext = extname(fileName).toLowerCase();
+  const inferred =
+    ext === ".json" ? "json" : ext === ".txt" ? "text" : undefined;
+  if (!inferred) {
+    throw new Error("Execution log export file name must end with .json or .txt");
+  }
+  if (format !== undefined && format !== inferred) {
+    throw new Error(
+      `Execution log export format ${format} does not match file extension ${ext}`,
+    );
+  }
+  return format ?? inferred;
+}
+
+function logSeverityRank(log: WorkflowExecutionLog): number | null {
+  const severity = log.severity?.toLowerCase();
+  if (!severity) return null;
+  return LOG_SEVERITY_RANK[severity] ?? null;
+}
+
+export function filterWorkflowExecutionLogsByMinimumLevel(
+  logs: WorkflowExecutionLog[],
+  level: WorkflowExecutionLogLevel,
+): WorkflowExecutionLog[] {
+  const threshold = LOG_SEVERITY_RANK[level];
+  return logs.filter((log) => {
+    const rank = logSeverityRank(log);
+    return rank === null ? level === "debug" : rank >= threshold;
+  });
+}
+
+function stringField(
+  source: Record<string, unknown>,
+  ...keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "string" && value.length > 0) return value;
+    if (typeof value === "number" || typeof value === "boolean") {
+      return String(value);
+    }
+  }
+  return undefined;
+}
+
+function numericField(
+  source: Record<string, unknown>,
+  ...keys: string[]
+): number | undefined {
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "number") return value;
+    if (typeof value === "string") {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return undefined;
+}
+
+function objectField(
+  source: Record<string, unknown>,
+  ...keys: string[]
+): Record<string, unknown> | undefined {
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+      return value as Record<string, unknown>;
+    }
+  }
+  return undefined;
+}
+
+function scalarSummary(source: Record<string, unknown>): string | undefined {
+  const skipped = new Set(["attributes", "attribute", "log", "entry"]);
+  const parts = Object.entries(source)
+    .filter(([key, value]) => !skipped.has(key) && value !== undefined && value !== null)
+    .filter(([, value]) =>
+      ["string", "number", "boolean"].includes(typeof value),
+    )
+    .map(([key, value]) => `${key}: ${String(value)}`);
+  return parts.length > 0 ? parts.join(", ") : undefined;
+}
+
+function normalizeWorkflowExecutionLog(
+  raw: WorkflowExecutionLog,
+): WorkflowExecutionLog {
+  const direct = raw as Record<string, unknown>;
+  const nested = objectField(direct, "log", "entry") ?? {};
+  const attributes = getLinkAttrs(raw);
+  const source = { ...direct, ...nested, ...attributes };
+  const normalized: WorkflowExecutionLog = {
+    ...raw,
+    ...nested,
+    ...attributes,
+  };
+
+  normalized.severity = stringField(source, "severity", "level", "logLevel");
+  normalized.origin = stringField(source, "origin", "source");
+  normalized.userName = stringField(source, "userName", "username", "user-name");
+  normalized.user = stringField(source, "user");
+  normalized["short-description"] = stringField(
+    source,
+    "short-description",
+    "shortDescription",
+    "message",
+    "msg",
+    "description",
+    "text",
+  );
+  normalized["long-description"] = stringField(
+    source,
+    "long-description",
+    "longDescription",
+    "details",
+    "detail",
+  );
+  normalized["time-stamp"] = stringField(
+    source,
+    "time-stamp",
+    "timeStamp",
+    "timestamp",
+    "date",
+  );
+  normalized["time-stamp-val"] = numericField(
+    source,
+    "time-stamp-val",
+    "timeStampVal",
+    "timestampValue",
+  );
+
+  if (!normalized["short-description"] && !normalized["long-description"]) {
+    normalized["short-description"] = scalarSummary(source);
+  }
+
+  return normalized;
+}
+
+export function formatWorkflowExecutionLogEntry(
+  log: WorkflowExecutionLog,
+): string {
+  const normalized = normalizeWorkflowExecutionLog(log);
+  const prefix = [
+    normalized["time-stamp"],
+    normalized.severity ? `[${normalized.severity}]` : undefined,
+    normalized.origin,
+  ].filter(Boolean);
+  const shortDescription = normalized["short-description"];
+  const longDescription = normalized["long-description"];
+  const description =
+    shortDescription && longDescription && shortDescription !== longDescription
+      ? `${shortDescription} — ${longDescription}`
+      : (shortDescription ?? longDescription ?? "(no description)");
+  return `${prefix.length > 0 ? `${prefix.join(" ")} ` : ""}${description}`;
+}
+
+function renderExecutionLogsText(params: {
+  workflowId: string;
+  executionId: string;
+  level: WorkflowExecutionLogLevel;
+  exportedAt: string;
+  fetchedCount: number;
+  logs: WorkflowExecutionLog[];
+}): string {
+  const header = [
+    `Workflow ID: ${params.workflowId}`,
+    `Execution ID: ${params.executionId}`,
+    `Minimum level: ${params.level}`,
+    `Exported at: ${params.exportedAt}`,
+    `Fetched log count: ${params.fetchedCount}`,
+    `Exported log count: ${params.logs.length}`,
+  ];
+  const body =
+    params.logs.length === 0
+      ? ["No execution logs matched the export level."]
+      : params.logs.map((log) => `• ${formatWorkflowExecutionLogEntry(log)}`);
+  return [...header, "", ...body, ""].join("\n");
+}
 
 export class WorkflowClient {
   constructor(private http: VroHttpClient) {}
@@ -120,8 +324,11 @@ export class WorkflowClient {
     }
     const query = params.length > 0 ? `?${params.join("&")}` : "";
     return this.http.get<WorkflowExecutionLogs>(
-      `/workflows/${encodeURIComponent(workflowId)}/executions/${encodeURIComponent(executionId)}/logs${query}`,
-    );
+      `/workflows/${encodeURIComponent(workflowId)}/executions/${encodeURIComponent(executionId)}/syslogs${query}`,
+    ).then((result) => ({
+      ...result,
+      logs: (result.logs ?? []).map(normalizeWorkflowExecutionLog),
+    }));
   }
 
   async listWorkflowExecutions(
@@ -166,6 +373,10 @@ export class WorkflowClient {
     return this.http.workflowDir;
   }
 
+  getExecutionLogDirectory(): string {
+    return this.http.executionLogDir;
+  }
+
   preflightWorkflowFile(fileName: string): Promise<ArtifactPreflightReport> {
     return preflightWorkflowFile(this.http.workflowDir, fileName);
   }
@@ -202,6 +413,86 @@ export class WorkflowClient {
     const buffer = await this.exportWorkflowBuffer(id);
     await writeFile(destPath, buffer, { flag: overwrite ? "w" : "wx" });
     return destPath;
+  }
+
+  private async resolveExecutionLogPath(
+    fileName: string,
+    format?: WorkflowExecutionLogExportFormat,
+  ): Promise<{
+    destPath: string;
+    format: WorkflowExecutionLogExportFormat;
+  }> {
+    const resolvedFormat = inferLogExportFormat(fileName, format);
+    const destPath = await resolveFileInDirectory(
+      this.http.executionLogDir,
+      fileName,
+      "Execution log export",
+      "the configured execution log artifact directory",
+    );
+    return { destPath, format: resolvedFormat };
+  }
+
+  async exportWorkflowExecutionLogs(
+    params: ExportWorkflowExecutionLogsParams,
+  ): Promise<ExportWorkflowExecutionLogsResult> {
+    const level = normalizeLogLevel(params.level ?? "info");
+    const { destPath, format } = await this.resolveExecutionLogPath(
+      params.fileName,
+      params.format,
+    );
+    const existingFile = await getExistingFile(destPath);
+    if (existingFile?.isSymbolicLink()) {
+      throw new Error("Execution log export target must not be a symbolic link");
+    }
+    if (existingFile && !params.overwrite) {
+      throw new Error(
+        `Execution log export file already exists: ${params.fileName}. Set overwrite to true to replace it.`,
+      );
+    }
+
+    const logs =
+      (
+        await this.getWorkflowExecutionLogs(params.workflowId, params.executionId, {
+          maxResult: params.maxResult,
+        })
+      ).logs ?? [];
+    const filteredLogs = filterWorkflowExecutionLogsByMinimumLevel(logs, level);
+    const exportedAt = new Date().toISOString();
+    const content =
+      format === "json"
+        ? `${JSON.stringify(
+            {
+              metadata: {
+                workflowId: params.workflowId,
+                executionId: params.executionId,
+                level,
+                format,
+                exportedAt,
+                fetchedCount: logs.length,
+                exportedCount: filteredLogs.length,
+              },
+              logs: filteredLogs,
+            },
+            null,
+            2,
+          )}\n`
+        : renderExecutionLogsText({
+            workflowId: params.workflowId,
+            executionId: params.executionId,
+            level,
+            exportedAt,
+            fetchedCount: logs.length,
+            logs: filteredLogs,
+          });
+
+    await writeFile(destPath, content, { flag: params.overwrite ? "w" : "wx" });
+    return {
+      path: destPath,
+      level,
+      format,
+      fetchedCount: logs.length,
+      exportedCount: filteredLogs.length,
+    };
   }
 
   async exportWorkflowBuffer(id: string): Promise<Buffer> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { VroClient } from "./vro-client.js";
 import { join, resolve } from "node:path";
 
 const DEFAULT_ARTIFACT_DIR = join(process.cwd(), "artifacts");
+const TARGET_PLATFORM_ENV = "VCFA_TARGET_PLATFORM";
 
 function getRequiredEnv(name: string): string {
   const value = process.env[name];
@@ -37,6 +38,7 @@ async function main(): Promise<void> {
   const username = getRequiredEnv("VCFA_USERNAME");
   const organization = getRequiredEnv("VCFA_ORGANIZATION");
   const password = getRequiredEnv("VCFA_PASSWORD");
+  const targetPlatform = normalizeTargetPlatform(process.env[TARGET_PLATFORM_ENV]);
   const ignoreTls = process.env["VCFA_IGNORE_TLS"] === "true";
   const artifactDir = process.env["VCFA_ARTIFACT_DIR"] ?? DEFAULT_ARTIFACT_DIR;
   const packageDir = process.env["VCFA_PACKAGE_DIR"];
@@ -62,6 +64,7 @@ async function main(): Promise<void> {
     username,
     organization,
     password,
+    targetPlatform,
     ignoreTls,
     artifactDir,
     packageDir,
@@ -79,11 +82,11 @@ async function main(): Promise<void> {
     { name: "vcfa-server", version: "1.0.0" },
     {
       instructions: [
-        "This server connects to a VCF Automation instance.",
+        "This server connects to a VCF Automation instance by default, or to vRA/vRO 8.12+ when VCFA_TARGET_PLATFORM is set to vra8.",
         "Use list-categories before creating workflows, actions, or configuration elements to find the target category ID.",
         "Use get-workflow to inspect a workflow's input parameters before running it with run-workflow.",
         "Use run-workflow-and-wait for rapid development loops that validate workflow inputs, wait for completion, and return outputs or diagnostics.",
-        "After starting a workflow execution with run-workflow, use get-workflow-execution to poll for completion and retrieve outputs.",
+        "After starting a workflow execution with run-workflow, use get-workflow-execution to poll for completion and retrieve outputs; use get-workflow-execution-logs to retrieve execution logs.",
         "Use export-workflow-file to save a workflow artifact under the configured workflow artifact directory; use direct import-workflow-file only for narrow validation or explicitly requested single-artifact tests.",
         "Use scaffold-workflow-file to generate a local .workflow artifact from structured workflow metadata and linear scriptable tasks before publishing or validating it.",
         "When a workflow step only invokes one existing vRO action, prefer a native action workflow item instead of a scriptable task that calls System.getModule. Use scriptable tasks for multiple action calls or additional orchestration logic. Prefer horizontal left-to-right workflow layouts when authoring or editing XML/package content.",
@@ -132,6 +135,20 @@ async function main(): Promise<void> {
     await server.close();
     process.exit(0);
   });
+}
+
+function normalizeTargetPlatform(value: string | undefined): "vcfa" | "vra8" {
+  const normalized = value?.toLowerCase();
+  if (normalized === undefined || normalized === "" || normalized === "vcfa") {
+    return "vcfa";
+  }
+  if (normalized === "vra8") {
+    return "vra8";
+  }
+  console.error(
+    `ERROR: ${TARGET_PLATFORM_ENV} must be one of: vcfa, vra8.`,
+  );
+  process.exit(1);
 }
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ async function main(): Promise<void> {
     process.env["VCFA_PROJECT_PACKAGE_DESCRIPTION"];
   const resourceDir = process.env["VCFA_RESOURCE_DIR"];
   const workflowDir = process.env["VCFA_WORKFLOW_DIR"];
+  const executionLogDir = process.env["VCFA_EXECUTION_LOG_DIR"];
   const actionDir = process.env["VCFA_ACTION_DIR"];
   const configurationDir = process.env["VCFA_CONFIGURATION_DIR"];
   const contextDir = process.env["VCFA_CONTEXT_DIR"];
@@ -72,6 +73,7 @@ async function main(): Promise<void> {
     projectPackageDescription,
     resourceDir,
     workflowDir,
+    executionLogDir,
     actionDir,
     configurationDir,
     contextDir,

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -10,6 +10,10 @@ import type {
   WorkflowExecutionStackItem,
 } from "../types.js";
 import { formatPreflightReport } from "../client/artifact-preflight.js";
+import {
+  filterWorkflowExecutionLogsByMinimumLevel,
+  formatWorkflowExecutionLogEntry,
+} from "../client/workflow-client.js";
 import type { VroClient } from "../vro-client.js";
 
 const DEFAULT_WORKFLOW_WAIT_TIMEOUT_SECONDS = 300;
@@ -245,21 +249,6 @@ function formatStackItem(item: WorkflowExecutionStackItem): string {
   return details.length > 0 ? `${label} (${details.join(", ")})` : label;
 }
 
-function formatLogEntry(log: WorkflowExecutionLog): string {
-  const prefix = [
-    log["time-stamp"],
-    log.severity ? `[${log.severity}]` : undefined,
-    log.origin,
-  ].filter(Boolean);
-  const shortDescription = log["short-description"];
-  const longDescription = log["long-description"];
-  const description =
-    shortDescription && longDescription && shortDescription !== longDescription
-      ? `${shortDescription} — ${longDescription}`
-      : (shortDescription ?? longDescription ?? "(no description)");
-  return `${prefix.length > 0 ? `${prefix.join(" ")} ` : ""}${description}`;
-}
-
 function appendDiagnostics(
   text: string,
   execution: WorkflowExecution,
@@ -289,7 +278,7 @@ function appendDiagnostics(
 
   if (logs.length > 0) {
     result += `\n\nLog Excerpts:\n${logs
-      .map((log) => `  • ${formatLogEntry(log)}`)
+      .map((log) => `  • ${formatWorkflowExecutionLogEntry(log)}`)
       .join("\n")}`;
   }
 
@@ -763,7 +752,7 @@ export function registerWorkflowTools(
     {
       title: "Get Workflow Execution Logs",
       description:
-        "Retrieve log entries for a workflow execution. Use after run-workflow or list-workflow-executions when detailed execution logs are needed.",
+        "Retrieve workflow execution system/event logs, including System.log, System.debug, System.warn, and System.error output. Use after run-workflow or list-workflow-executions when detailed execution logs are needed.",
       inputSchema: z.object({
         workflowId: z.string().describe("The workflow ID"),
         executionId: z.string().describe("The execution ID"),
@@ -772,18 +761,70 @@ export function registerWorkflowTools(
           .int()
           .positive()
           .optional()
-          .describe("Maximum number of log entries to return"),
+          .describe("Maximum number of log entries to fetch"),
+        fileName: z
+          .string()
+          .optional()
+          .describe("Optional plain .json or .txt file name to export under the configured execution log artifact directory"),
+        level: z
+          .enum(["debug", "info", "error"])
+          .optional()
+          .describe("Minimum log level to display or export"),
+        format: z
+          .enum(["json", "text"])
+          .optional()
+          .describe("Export format when fileName is provided. If omitted, inferred from fileName extension."),
+        overwrite: z
+          .boolean()
+          .optional()
+          .describe("Overwrite the export file if it already exists (default: false)"),
       }),
       annotations: { readOnlyHint: true },
     },
-    async ({ workflowId, executionId, maxResult }): Promise<CallToolResult> => {
+    async ({
+      workflowId,
+      executionId,
+      maxResult,
+      fileName,
+      level,
+      format,
+      overwrite,
+    }): Promise<CallToolResult> => {
       try {
+        if (fileName) {
+          const result = await client.exportWorkflowExecutionLogs({
+            workflowId,
+            executionId,
+            fileName,
+            level: level ?? "info",
+            format,
+            maxResult,
+            overwrite: overwrite ?? false,
+          });
+          return {
+            content: [
+              {
+                type: "text",
+                text:
+                  `Workflow execution logs exported successfully to: ${result.path}\n` +
+                  `Level: ${result.level}\n` +
+                  `Format: ${result.format}\n` +
+                  `Fetched log count: ${result.fetchedCount}\n` +
+                  `Exported log count: ${result.exportedCount}`,
+              },
+            ],
+          };
+        }
+
         const result = await client.getWorkflowExecutionLogs(
           workflowId,
           executionId,
           { maxResult },
         );
-        const logs = result.logs ?? [];
+        const logs =
+          level === undefined
+            ? (result.logs ?? [])
+            : filterWorkflowExecutionLogsByMinimumLevel(result.logs ?? [], level);
         if (logs.length === 0) {
           return {
             content: [{ type: "text", text: "No execution logs found." }],
@@ -794,7 +835,7 @@ export function registerWorkflowTools(
             {
               type: "text",
               text: `Found ${logs.length} execution log(s):\n\n${logs
-                .map((log) => `• ${formatLogEntry(log)}`)
+                .map((log) => `• ${formatWorkflowExecutionLogEntry(log)}`)
                 .join("\n")}`,
             },
           ],

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -759,6 +759,61 @@ export function registerWorkflowTools(
   );
 
   server.registerTool(
+    "get-workflow-execution-logs",
+    {
+      title: "Get Workflow Execution Logs",
+      description:
+        "Retrieve log entries for a workflow execution. Use after run-workflow or list-workflow-executions when detailed execution logs are needed.",
+      inputSchema: z.object({
+        workflowId: z.string().describe("The workflow ID"),
+        executionId: z.string().describe("The execution ID"),
+        maxResult: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Maximum number of log entries to return"),
+      }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ workflowId, executionId, maxResult }): Promise<CallToolResult> => {
+      try {
+        const result = await client.getWorkflowExecutionLogs(
+          workflowId,
+          executionId,
+          { maxResult },
+        );
+        const logs = result.logs ?? [];
+        if (logs.length === 0) {
+          return {
+            content: [{ type: "text", text: "No execution logs found." }],
+          };
+        }
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Found ${logs.length} execution log(s):\n\n${logs
+                .map((log) => `• ${formatLogEntry(log)}`)
+                .join("\n")}`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to get execution logs: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
     "list-workflow-executions",
     {
       title: "List Workflow Executions",

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,18 +142,50 @@ export interface WorkflowExecutionList {
 }
 
 export interface WorkflowExecutionLog {
+  [key: string]: unknown;
   severity?: string;
   userName?: string;
   user?: string;
   origin?: string;
+  message?: string;
+  msg?: string;
+  description?: string;
+  shortDescription?: string;
+  longDescription?: string;
+  timeStamp?: string;
+  timeStampVal?: number;
   "short-description"?: string;
   "long-description"?: string;
   "time-stamp"?: string;
   "time-stamp-val"?: number;
+  attributes?: { name: string; value: string }[];
+  attribute?: { name: string; value: string }[];
 }
 
 export interface WorkflowExecutionLogs {
   logs?: WorkflowExecutionLog[];
+}
+
+export type WorkflowExecutionLogLevel = "debug" | "info" | "error";
+
+export type WorkflowExecutionLogExportFormat = "json" | "text";
+
+export interface ExportWorkflowExecutionLogsParams {
+  workflowId: string;
+  executionId: string;
+  fileName: string;
+  level?: WorkflowExecutionLogLevel;
+  format?: WorkflowExecutionLogExportFormat;
+  maxResult?: number;
+  overwrite?: boolean;
+}
+
+export interface ExportWorkflowExecutionLogsResult {
+  path: string;
+  level: WorkflowExecutionLogLevel;
+  format: WorkflowExecutionLogExportFormat;
+  fetchedCount: number;
+  exportedCount: number;
 }
 
 // --- Actions ---
@@ -547,6 +579,7 @@ export interface VroClientConfig {
   projectPackageDescription?: string;
   resourceDir?: string;
   workflowDir?: string;
+  executionLogDir?: string;
   actionDir?: string;
   configurationDir?: string;
   contextDir?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -532,11 +532,14 @@ export interface VroPluginList {
 
 // --- Client config ---
 
+export type VroTargetPlatform = "vcfa" | "vra8";
+
 export interface VroClientConfig {
   host: string;
   username: string;
   organization: string;
   password: string;
+  targetPlatform?: VroTargetPlatform;
   ignoreTls?: boolean;
   artifactDir?: string;
   packageDir?: string;

--- a/test/vro-client.test.mjs
+++ b/test/vro-client.test.mjs
@@ -81,6 +81,125 @@ test("specific artifact directories override artifactDir", async () => {
   }
 });
 
+test("default vcfa platform authenticates with Cloud API session token", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    return Response.json({ link: [], total: 0 });
+  };
+
+  const client = new VroClient(config());
+  await client.listWorkflows();
+
+  assert.equal(
+    calls[0].url,
+    "https://vcfa.example.test/cloudapi/1.0.0/sessions",
+  );
+  assert.equal(calls[0].init.headers.Authorization, "Basic YWRtaW5Ab3JnOnNlY3JldA==");
+  assert.equal(calls[1].init.headers.Authorization, "Bearer token");
+});
+
+test("vra8 platform uses Basic auth directly against vRO APIs", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    return Response.json({
+      link: [
+        {
+          attributes: [
+            { name: "id", value: "workflow-1" },
+            { name: "name", value: "Workflow" },
+          ],
+        },
+      ],
+      total: 1,
+    });
+  };
+
+  const client = new VroClient(config({ targetPlatform: "vra8" }));
+  const workflows = await client.listWorkflows();
+
+  assert.equal(workflows.link[0].id, "workflow-1");
+  assert.equal(calls.length, 1);
+  assert.equal(
+    calls[0].url,
+    "https://vcfa.example.test/vco/api/workflows",
+  );
+  assert.equal(calls[0].init.headers.Authorization, "Basic YWRtaW5Ab3JnOnNlY3JldA==");
+});
+
+test("client rejects invalid target platform values", () => {
+  assert.throws(
+    () => new VroClient(config({ targetPlatform: "vro8" })),
+    /targetPlatform must be one of: vcfa, vra8/,
+  );
+});
+
+test("vra8 platform rejects Automation-service APIs with clear message", async () => {
+  const client = new VroClient(config({ targetPlatform: "vra8" }));
+
+  await assert.rejects(
+    () => client.listTemplates(),
+    /Automation-service APIs .* not supported .*vra8 Basic-auth mode/,
+  );
+  await assert.rejects(
+    () => client.listDeployments(),
+    /Automation-service APIs .* not supported .*vra8 Basic-auth mode/,
+  );
+  await assert.rejects(
+    () => client.listCatalogItems(),
+    /Automation-service APIs .* not supported .*vra8 Basic-auth mode/,
+  );
+  await assert.rejects(
+    () => client.listSubscriptions(),
+    /Automation-service APIs .* not supported .*vra8 Basic-auth mode/,
+  );
+});
+
+test("vra8 platform rejects vRO writes other than workflow execution", async () => {
+  const client = new VroClient(config({ targetPlatform: "vra8" }));
+
+  await assert.rejects(
+    () => client.createWorkflow("category-1", "Workflow"),
+    /read operations plus workflow execution and execution logs only/,
+  );
+});
+
+test("vra8 platform rejects artifact imports before local file checks", async () => {
+  const client = new VroClient(config({ targetPlatform: "vra8" }));
+  const expected = /read operations plus workflow execution and execution logs only/;
+
+  await assert.rejects(
+    () => client.importWorkflowFile("category-1", "missing.workflow"),
+    expected,
+  );
+  await assert.rejects(
+    () => client.importActionFile("category-name", "missing.action"),
+    expected,
+  );
+  await assert.rejects(
+    () => client.importConfigurationFile("category-1", "missing.vsoconf"),
+    expected,
+  );
+  await assert.rejects(
+    () => client.importPackage("missing.package"),
+    expected,
+  );
+  await assert.rejects(
+    () => client.getPackageImportDetails("missing.package"),
+    expected,
+  );
+  await assert.rejects(
+    () => client.importResource("category-1", "missing.bin"),
+    expected,
+  );
+  await assert.rejects(
+    () => client.updateResourceContent("resource-1", "missing.bin"),
+    expected,
+  );
+});
+
 function xmlArchive(rootName) {
   return zipSync({
     "artifact.xml": new TextEncoder().encode(`<${rootName} name="payload" />`),

--- a/test/vro-client.test.mjs
+++ b/test/vro-client.test.mjs
@@ -1,6 +1,13 @@
 import { zipSync } from "fflate";
 import assert from "node:assert/strict";
-import { mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import {
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -29,6 +36,10 @@ test("artifact directories default to temp subdirectories", () => {
   assert.equal(client.getPackageDirectory(), join(root, "packages"));
   assert.equal(client.getResourceDirectory(), join(root, "resources"));
   assert.equal(client.getWorkflowDirectory(), join(root, "workflows"));
+  assert.equal(
+    client.getExecutionLogDirectory(),
+    join(root, "execution-logs"),
+  );
   assert.equal(client.getActionDirectory(), join(root, "actions"));
   assert.equal(
     client.getConfigurationDirectory(),
@@ -46,6 +57,10 @@ test("artifactDir config derives artifact type subdirectories", async () => {
     assert.equal(client.getPackageDirectory(), join(artifactDir, "packages"));
     assert.equal(client.getResourceDirectory(), join(artifactDir, "resources"));
     assert.equal(client.getWorkflowDirectory(), join(artifactDir, "workflows"));
+    assert.equal(
+      client.getExecutionLogDirectory(),
+      join(artifactDir, "execution-logs"),
+    );
     assert.equal(client.getActionDirectory(), join(artifactDir, "actions"));
     assert.equal(
       client.getConfigurationDirectory(),
@@ -60,12 +75,16 @@ test("artifactDir config derives artifact type subdirectories", async () => {
 test("specific artifact directories override artifactDir", async () => {
   const artifactDir = await mkdtemp(join(tmpdir(), "vcfa-artifacts-"));
   const workflowDir = await mkdtemp(join(tmpdir(), "vcfa-workflows-"));
+  const executionLogDir = await mkdtemp(join(tmpdir(), "vcfa-execution-logs-"));
   const contextDir = await mkdtemp(join(tmpdir(), "vcfa-context-"));
 
   try {
-    const client = new VroClient(config({ artifactDir, workflowDir, contextDir }));
+    const client = new VroClient(
+      config({ artifactDir, workflowDir, executionLogDir, contextDir }),
+    );
 
     assert.equal(client.getWorkflowDirectory(), workflowDir);
+    assert.equal(client.getExecutionLogDirectory(), executionLogDir);
     assert.equal(client.getContextDirectory(), contextDir);
     assert.equal(client.getPackageDirectory(), join(artifactDir, "packages"));
     assert.equal(client.getResourceDirectory(), join(artifactDir, "resources"));
@@ -77,6 +96,7 @@ test("specific artifact directories override artifactDir", async () => {
   } finally {
     await rm(artifactDir, { recursive: true, force: true });
     await rm(workflowDir, { recursive: true, force: true });
+    await rm(executionLogDir, { recursive: true, force: true });
     await rm(contextDir, { recursive: true, force: true });
   }
 });
@@ -298,7 +318,7 @@ test("getWorkflowExecution can request detailed execution data", async () => {
   assert.equal(calls[1].init.method, "GET");
 });
 
-test("getWorkflowExecutionLogs calls workflow execution logs endpoint", async () => {
+test("getWorkflowExecutionLogs calls workflow execution syslogs endpoint", async () => {
   const calls = [];
   globalThis.fetch = async (url, init) => {
     calls.push({ url: String(url), init });
@@ -318,9 +338,252 @@ test("getWorkflowExecutionLogs calls workflow execution logs endpoint", async ()
   assert.equal(logs.logs[0]["short-description"], "hello");
   assert.equal(
     calls[1].url,
-    "https://vcfa.example.test/vco/api/workflows/workflow-1/executions/execution-1/logs?maxResult=3",
+    "https://vcfa.example.test/vco/api/workflows/workflow-1/executions/execution-1/syslogs?maxResult=3",
   );
   assert.equal(calls[1].init.method, "GET");
+});
+
+test("getWorkflowExecutionLogs normalizes alternate vRO log entry shapes", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    return Response.json({
+      logs: [
+        {
+          attributes: [
+            { name: "severity", value: "INFO" },
+            { name: "timeStamp", value: "2026-05-13T07:15:45Z" },
+            { name: "message", value: "hello from attributes" },
+          ],
+        },
+        {
+          log: {
+            level: "ERROR",
+            timestamp: "2026-05-13T07:15:46Z",
+            msg: "nested failure",
+          },
+        },
+      ],
+    });
+  };
+
+  const client = new VroClient(config());
+  const result = await client.getWorkflowExecutionLogs(
+    "workflow-1",
+    "execution-1",
+  );
+
+  assert.deepEqual(
+    result.logs.map((log) => ({
+      severity: log.severity,
+      timestamp: log["time-stamp"],
+      description: log["short-description"],
+    })),
+    [
+      {
+        severity: "INFO",
+        timestamp: "2026-05-13T07:15:45Z",
+        description: "hello from attributes",
+      },
+      {
+        severity: "ERROR",
+        timestamp: "2026-05-13T07:15:46Z",
+        description: "nested failure",
+      },
+    ],
+  );
+});
+
+test("exportWorkflowExecutionLogs writes JSON with info minimum level by default", async () => {
+  const executionLogDir = await mkdtemp(join(tmpdir(), "vcfa-execution-logs-"));
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    return Response.json({
+      logs: [
+        { severity: "DEBUG", "short-description": "debug detail" },
+        { severity: "INFO", "short-description": "started" },
+        { severity: "WARNING", "short-description": "careful" },
+        { severity: "ERROR", "short-description": "failed" },
+        { severity: "TRACE", "short-description": "unknown" },
+      ],
+    });
+  };
+
+  try {
+    const client = new VroClient(config({ executionLogDir }));
+    const result = await client.exportWorkflowExecutionLogs({
+      workflowId: "workflow-1",
+      executionId: "execution-1",
+      fileName: "execution-1.json",
+      maxResult: 5,
+    });
+    const exported = JSON.parse(await readFile(result.path, "utf8"));
+
+    assert.equal(result.level, "info");
+    assert.equal(result.format, "json");
+    assert.equal(result.fetchedCount, 5);
+    assert.equal(result.exportedCount, 3);
+    assert.equal(exported.metadata.workflowId, "workflow-1");
+    assert.equal(exported.metadata.executionId, "execution-1");
+    assert.deepEqual(
+      exported.logs.map((log) => log["short-description"]),
+      ["started", "careful", "failed"],
+    );
+    assert.equal(
+      calls[1].url,
+      "https://vcfa.example.test/vco/api/workflows/workflow-1/executions/execution-1/syslogs?maxResult=5",
+    );
+  } finally {
+    await rm(executionLogDir, { recursive: true, force: true });
+  }
+});
+
+test("exportWorkflowExecutionLogs writes text with debug minimum level", async () => {
+  const executionLogDir = await mkdtemp(join(tmpdir(), "vcfa-execution-logs-"));
+  const calls = [];
+  globalThis.fetch = async (_url, _init) => {
+    calls.push({});
+    if (calls.length === 1) return authResponse();
+    return Response.json({
+      logs: [
+        {
+          severity: "DEBUG",
+          origin: "item1",
+          "time-stamp": "2026-05-12T10:00:00Z",
+          "short-description": "debug detail",
+        },
+        { severity: "TRACE", "short-description": "unknown detail" },
+      ],
+    });
+  };
+
+  try {
+    const client = new VroClient(config({ executionLogDir }));
+    const result = await client.exportWorkflowExecutionLogs({
+      workflowId: "workflow-1",
+      executionId: "execution-1",
+      fileName: "execution-1.txt",
+      level: "debug",
+      format: "text",
+    });
+    const text = await readFile(result.path, "utf8");
+
+    assert.equal(result.exportedCount, 2);
+    assert.match(text, /Minimum level: debug/);
+    assert.match(
+      text,
+      /2026-05-12T10:00:00Z \[DEBUG\] item1 debug detail/,
+    );
+    assert.match(text, /unknown detail/);
+  } finally {
+    await rm(executionLogDir, { recursive: true, force: true });
+  }
+});
+
+test("exportWorkflowExecutionLogs filters error minimum level", async () => {
+  const executionLogDir = await mkdtemp(join(tmpdir(), "vcfa-execution-logs-"));
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    return Response.json({
+      logs: [
+        { severity: "INFO", "short-description": "started" },
+        { severity: "WARN", "short-description": "warning" },
+        { severity: "ERROR", "short-description": "failed" },
+      ],
+    });
+  };
+
+  try {
+    const client = new VroClient(config({ executionLogDir }));
+    const result = await client.exportWorkflowExecutionLogs({
+      workflowId: "workflow-1",
+      executionId: "execution-1",
+      fileName: "errors.json",
+      level: "error",
+      format: "json",
+    });
+    const exported = JSON.parse(await readFile(result.path, "utf8"));
+
+    assert.equal(result.exportedCount, 1);
+    assert.deepEqual(
+      exported.logs.map((log) => log["short-description"]),
+      ["failed"],
+    );
+  } finally {
+    await rm(executionLogDir, { recursive: true, force: true });
+  }
+});
+
+test("exportWorkflowExecutionLogs validates level, file names, and existing targets before network calls", async () => {
+  const executionLogDir = await mkdtemp(join(tmpdir(), "vcfa-execution-logs-"));
+  await writeFile(join(executionLogDir, "existing.json"), "{}");
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    return authResponse();
+  };
+
+  try {
+    const client = new VroClient(config({ executionLogDir }));
+    const base = {
+      workflowId: "workflow-1",
+      executionId: "execution-1",
+      fileName: "logs.json",
+    };
+
+    await assert.rejects(
+      () => client.exportWorkflowExecutionLogs({ ...base, level: "trace" }),
+      /level must be one of/,
+    );
+    await assert.rejects(
+      () => client.exportWorkflowExecutionLogs({ ...base, fileName: "logs.csv" }),
+      /must end with \.json or \.txt/,
+    );
+    await assert.rejects(
+      () => client.exportWorkflowExecutionLogs({ ...base, fileName: "../logs.json" }),
+      /must not contain path separators/,
+    );
+    await assert.rejects(
+      () =>
+        client.exportWorkflowExecutionLogs({
+          ...base,
+          fileName: "existing.json",
+        }),
+      /already exists/,
+    );
+    assert.equal(calls.length, 0);
+  } finally {
+    await rm(executionLogDir, { recursive: true, force: true });
+  }
+});
+
+test("exportWorkflowExecutionLogs rejects symbolic link targets", async () => {
+  const executionLogDir = await mkdtemp(join(tmpdir(), "vcfa-execution-logs-"));
+  const outsideFile = join(tmpdir(), `execution-logs-${Date.now()}.json`);
+  await writeFile(outsideFile, "{}");
+  await symlink(outsideFile, join(executionLogDir, "linked.json"));
+
+  try {
+    const client = new VroClient(config({ executionLogDir }));
+    await assert.rejects(
+      () =>
+        client.exportWorkflowExecutionLogs({
+          workflowId: "workflow-1",
+          executionId: "execution-1",
+          fileName: "linked.json",
+          overwrite: true,
+        }),
+      /must not be a symbolic link/,
+    );
+  } finally {
+    await rm(executionLogDir, { recursive: true, force: true });
+    await rm(outsideFile, { force: true });
+  }
 });
 
 test("diffActionFile compares live export to local action artifact as zip", async () => {

--- a/test/workflow-tools.test.mjs
+++ b/test/workflow-tools.test.mjs
@@ -285,6 +285,80 @@ test("get-workflow-execution-logs formats execution log entries", async () => {
   assert.match(result.content[0].text, /2026-05-12T10:00:00Z \[INFO\] item1 Started/);
 });
 
+test("get-workflow-execution-logs formats attribute-shaped log entries", async () => {
+  const handlers = registeredWorkflowTools({
+    getWorkflowExecutionLogs: async () => ({
+      logs: [
+        {
+          attributes: [
+            { name: "severity", value: "INFO" },
+            { name: "timeStamp", value: "2026-05-13T07:15:45Z" },
+            { name: "message", value: "hello from attributes" },
+          ],
+        },
+      ],
+    }),
+  });
+
+  const result = await handlers.get("get-workflow-execution-logs")({
+    workflowId: "workflow-1",
+    executionId: "execution-1",
+  });
+
+  assert.match(
+    result.content[0].text,
+    /2026-05-13T07:15:45Z \[INFO\] hello from attributes/,
+  );
+});
+
+test("get-workflow-execution-logs filters inline logs by minimum level", async () => {
+  const handlers = registeredWorkflowTools({
+    getWorkflowExecutionLogs: async () => ({
+      logs: [
+        {
+          severity: "INFO",
+          "short-description": "Started",
+        },
+        {
+          severity: "ERROR",
+          "short-description": "Failed",
+        },
+      ],
+    }),
+  });
+
+  const result = await handlers.get("get-workflow-execution-logs")({
+    workflowId: "workflow-1",
+    executionId: "execution-1",
+    level: "error",
+  });
+
+  assert.match(result.content[0].text, /Found 1 execution log/);
+  assert.doesNotMatch(result.content[0].text, /Started/);
+  assert.match(result.content[0].text, /Failed/);
+});
+
+test("get-workflow-execution-logs reports empty inline level matches", async () => {
+  const handlers = registeredWorkflowTools({
+    getWorkflowExecutionLogs: async () => ({
+      logs: [
+        {
+          severity: "INFO",
+          "short-description": "Started",
+        },
+      ],
+    }),
+  });
+
+  const result = await handlers.get("get-workflow-execution-logs")({
+    workflowId: "workflow-1",
+    executionId: "execution-1",
+    level: "error",
+  });
+
+  assert.equal(result.content[0].text, "No execution logs found.");
+});
+
 test("get-workflow-execution-logs reports empty logs", async () => {
   const handlers = registeredWorkflowTools({
     getWorkflowExecutionLogs: async () => ({ logs: [] }),
@@ -296,6 +370,73 @@ test("get-workflow-execution-logs reports empty logs", async () => {
   });
 
   assert.equal(result.content[0].text, "No execution logs found.");
+});
+
+test("get-workflow-execution-logs exports when fileName is provided", async () => {
+  let exportParams;
+  const handlers = new Map();
+  const configs = new Map();
+  const server = {
+    registerTool(name, config, handler) {
+      configs.set(name, config);
+      handlers.set(name, handler);
+    },
+  };
+  registerWorkflowTools(server, {
+    exportWorkflowExecutionLogs: async (params) => {
+      exportParams = params;
+      return {
+        path: "/tmp/execution-logs/execution-1.json",
+        level: params.level,
+        format: "json",
+        fetchedCount: 3,
+        exportedCount: 2,
+      };
+    },
+  });
+
+  const result = await handlers.get("get-workflow-execution-logs")({
+    workflowId: "workflow-1",
+    executionId: "execution-1",
+    fileName: "execution-1.json",
+    maxResult: 3,
+  });
+
+  assert.equal(
+    configs.get("get-workflow-execution-logs").annotations.readOnlyHint,
+    true,
+  );
+  assert.deepEqual(exportParams, {
+    workflowId: "workflow-1",
+    executionId: "execution-1",
+    fileName: "execution-1.json",
+    maxResult: 3,
+    level: "info",
+    format: undefined,
+    overwrite: false,
+  });
+  assert.equal(result.isError, undefined);
+  assert.match(result.content[0].text, /execution-1\.json/);
+  assert.match(result.content[0].text, /Level: info/);
+  assert.match(result.content[0].text, /Format: json/);
+  assert.match(result.content[0].text, /Exported log count: 2/);
+});
+
+test("get-workflow-execution-logs surfaces export errors", async () => {
+  const handlers = registeredWorkflowTools({
+    exportWorkflowExecutionLogs: async () => {
+      throw new Error("Execution log export file already exists");
+    },
+  });
+
+  const result = await handlers.get("get-workflow-execution-logs")({
+    workflowId: "workflow-1",
+    executionId: "execution-1",
+    fileName: "execution-1.json",
+  });
+
+  assert.equal(result.isError, true);
+  assert.match(result.content[0].text, /already exists/);
 });
 
 test("scaffold-workflow-file returns saved path", async () => {

--- a/test/workflow-tools.test.mjs
+++ b/test/workflow-tools.test.mjs
@@ -251,6 +251,53 @@ test("run-workflow-and-wait reports log fetch warnings", async () => {
   );
 });
 
+test("get-workflow-execution-logs formats execution log entries", async () => {
+  let logRequest;
+  const handlers = registeredWorkflowTools({
+    getWorkflowExecutionLogs: async (workflowId, executionId, options) => {
+      logRequest = { workflowId, executionId, options };
+      return {
+        logs: [
+          {
+            severity: "INFO",
+            origin: "item1",
+            "time-stamp": "2026-05-12T10:00:00Z",
+            "short-description": "Started",
+          },
+        ],
+      };
+    },
+  });
+
+  const result = await handlers.get("get-workflow-execution-logs")({
+    workflowId: "workflow-1",
+    executionId: "execution-1",
+    maxResult: 5,
+  });
+
+  assert.deepEqual(logRequest, {
+    workflowId: "workflow-1",
+    executionId: "execution-1",
+    options: { maxResult: 5 },
+  });
+  assert.equal(result.isError, undefined);
+  assert.match(result.content[0].text, /Found 1 execution log/);
+  assert.match(result.content[0].text, /2026-05-12T10:00:00Z \[INFO\] item1 Started/);
+});
+
+test("get-workflow-execution-logs reports empty logs", async () => {
+  const handlers = registeredWorkflowTools({
+    getWorkflowExecutionLogs: async () => ({ logs: [] }),
+  });
+
+  const result = await handlers.get("get-workflow-execution-logs")({
+    workflowId: "workflow-1",
+    executionId: "execution-1",
+  });
+
+  assert.equal(result.content[0].text, "No execution logs found.");
+});
+
 test("scaffold-workflow-file returns saved path", async () => {
   let scaffoldParams;
   const handlers = registeredWorkflowTools({


### PR DESCRIPTION
## Summary

- Add `VCFA_TARGET_PLATFORM` with `vcfa` as the default and `vra8` as the Basic-auth `/vco/api` compatibility mode.
- Support vRA/vRO 8.12+ read/run workflows by using Basic auth directly for vRO APIs while preserving current VCFA Cloud API session behavior by default.
- Add `get-workflow-execution-logs` as a standalone MCP tool and wire execution-log client support.
- Return clear unsupported-mode errors for Automation-service APIs and vRO write/import paths in `vra8` mode.
- Update README, configuration, troubleshooting, tool reference, examples, and AGENTS.md.

## Validation

- `npm run validate`
- Review pass over staged/unstaged changes

## Notes

Automation-service token auth for vRA 8 catalog, deployments, templates, subscriptions, and event topics remains intentionally deferred for a later phase.