### PR TITLE
[codex] Scope configuration listing by category

### DIFF
--- a/docs/how-tos/configuration-resources.md
+++ b/docs/how-tos/configuration-resources.md
@@ -8,7 +8,7 @@ Recommended sequence:
 
 1. `list-categories(type: "ConfigurationElementCategory", filter: "Integrations")`
 2. `create-configuration(...)`
-3. `list-configurations(filter: "...")`
+3. `list-configurations(categoryId: "...", filter: "...")`
 4. `get-configuration(id: "...")`
 
 Avoid dumping sensitive values in docs, issue comments, or generated context. Prefer redaction when summarizing configuration attributes.
@@ -28,6 +28,6 @@ Recommended sequence:
 
 To rotate a value or replace a shared binary resource:
 
-1. `list-configurations(filter: "...")` or `list-resource-elements(filter: "...")`
+1. `list-configurations(categoryId: "...", filter: "...")` or `list-resource-elements(filter: "...")`
 2. `update-configuration(...)` or `update-resource-element(..., confirm: true)`
 3. Re-read the object to verify the change.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -424,12 +424,13 @@ Delete an action from VCF Automation Orchestrator. This action is irreversible.
 
 ### `list-configurations`
 
-List configuration elements from VCF Automation Orchestrator. Optionally filter by name.
+List configuration elements from VCF Automation Orchestrator. Optionally filter by name or scope to a specific category.
 
 ::: details Parameters
 | Parameter | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `filter` | string | No | - | Filter configuration elements by name using a substring match. |
+| `categoryId` | string | No | - | Filter configuration elements by ConfigurationElementCategory ID. Use `list-categories` with `type ConfigurationElementCategory` to find a category ID. |
 :::
 
 ### `get-configuration`

--- a/src/client/configuration-client.ts
+++ b/src/client/configuration-client.ts
@@ -19,7 +19,13 @@ import { toVroParameters } from "./parameters.js";
 export class ConfigurationClient {
   constructor(private http: VroHttpClient) {}
 
-  async listConfigurations(filter?: string): Promise<ConfigElementList> {
+  async listConfigurations(
+    filter?: string,
+    categoryId?: string,
+  ): Promise<ConfigElementList> {
+    if (categoryId) {
+      return this.listConfigurationsByCategory(categoryId, filter);
+    }
     let path = "/configurations";
     const params: string[] = [];
     if (filter) {
@@ -39,10 +45,45 @@ export class ConfigurationClient {
         name: a["name"] ?? a["@name"],
         description: a["description"],
         version: a["version"],
-        categoryId: a["categoryId"],
+        categoryId: a["categoryId"] ?? a["category-id"] ?? a["categoryid"],
       };
     });
     return { total: raw.total ?? link.length, link };
+  }
+
+  private async listConfigurationsByCategory(
+    categoryId: string,
+    filter?: string,
+  ): Promise<ConfigElementList> {
+    const raw = await this.http.get<{
+      relations?: {
+        link?: {
+          rel?: string;
+          href?: string;
+          attributes?: { name: string; value: string }[];
+        }[];
+      };
+    }>(`/categories/${encodeURIComponent(categoryId)}`);
+    const links = raw.relations?.link ?? [];
+    let link: ConfigElement[] = links.flatMap((l) => {
+      if (l.rel !== "down") return [];
+      const a = parseAttrs(l.attributes);
+      const type = a["type"] ?? a["@type"] ?? a["@fullType"];
+      if (type !== "ConfigurationElement") return [];
+      return [{
+        id: a["id"] ?? a["@id"],
+        name: a["name"] ?? a["@name"],
+        description: a["description"],
+        version: a["version"],
+        categoryId,
+        href: l.href,
+      }];
+    });
+    if (filter) {
+      const lower = filter.toLowerCase();
+      link = link.filter((item) => item.name?.toLowerCase().includes(lower) ?? false);
+    }
+    return { total: link.length, link };
   }
 
   getConfiguration(id: string): Promise<ConfigElement> {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -411,8 +411,11 @@ export class VroClient {
     return this.actions.deleteAction(id);
   }
 
-  listConfigurations(filter?: string): Promise<ConfigElementList> {
-    return this.configurations.listConfigurations(filter);
+  listConfigurations(
+    filter?: string,
+    categoryId?: string,
+  ): Promise<ConfigElementList> {
+    return this.configurations.listConfigurations(filter, categoryId);
   }
 
   getConfiguration(id: string): Promise<ConfigElement> {

--- a/src/tools/config-tools.ts
+++ b/src/tools/config-tools.ts
@@ -13,18 +13,24 @@ export function registerConfigTools(
     {
       title: "List Configuration Elements",
       description:
-        "List configuration elements from VCF Automation Orchestrator. Optionally filter by name.",
+        "List configuration elements from VCF Automation Orchestrator. Optionally filter by name or scope to a specific category.",
       inputSchema: z.object({
         filter: z
           .string()
           .optional()
           .describe("Filter configuration elements by name (substring match)"),
+        categoryId: z
+          .string()
+          .optional()
+          .describe(
+            "Filter configuration elements by ConfigurationElementCategory ID. Use list-categories with type ConfigurationElementCategory to find a category ID.",
+          ),
       }),
       annotations: { readOnlyHint: true },
     },
-    async ({ filter }): Promise<CallToolResult> => {
+    async ({ filter, categoryId }): Promise<CallToolResult> => {
       try {
-        const result = await client.listConfigurations(filter);
+        const result = await client.listConfigurations(filter, categoryId);
         const configs = result.link ?? [];
         if (configs.length === 0) {
           return {

--- a/test/artifact-tools.test.mjs
+++ b/test/artifact-tools.test.mjs
@@ -82,16 +82,20 @@ test("configuration tools format attributes and guard imports and deletes", asyn
   let exported;
   let imported;
   let deletedId;
+  let listSeen;
   const handlers = registeredTools(registerConfigTools, {
-    listConfigurations: async (filter) => ({
-      link: [
-        {
-          id: "config-1",
-          name: `Settings ${filter}`,
-          description: "Runtime settings",
-        },
-      ],
-    }),
+    listConfigurations: async (filter, categoryId) => {
+      listSeen = { filter, categoryId };
+      return {
+        link: [
+          {
+            id: "config-1",
+            name: `Settings ${filter}`,
+            description: "Runtime settings",
+          },
+        ],
+      };
+    },
     getConfiguration: async (id) => ({
       id,
       name: "Settings",
@@ -125,7 +129,11 @@ test("configuration tools format attributes and guard imports and deletes", asyn
     },
   });
 
-  const list = await handlers.get("list-configurations")({ filter: "prod" });
+  const list = await handlers.get("list-configurations")({
+    categoryId: "category-1",
+    filter: "prod",
+  });
+  assert.deepEqual(listSeen, { categoryId: "category-1", filter: "prod" });
   assert.match(list.content[0].text, /Settings prod \(id: config-1\)/);
   assert.match(list.content[0].text, /Runtime settings/);
 

--- a/test/vro-client.test.mjs
+++ b/test/vro-client.test.mjs
@@ -955,6 +955,99 @@ test("category and plugin clients parse attribute links", async () => {
   );
 });
 
+test("listConfigurations with categoryId fetches category relations and filters ConfigurationElements", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    return Response.json({
+      relations: {
+        link: [
+          {
+            rel: "down",
+            href: "https://vcfa.example.test/vco/api/configurations/conf-1",
+            attributes: [
+              { name: "id", value: "conf-1" },
+              { name: "name", value: "Email Configuration" },
+              { name: "type", value: "ConfigurationElement" },
+              { name: "version", value: "1.2.0" },
+            ],
+          },
+          {
+            rel: "down",
+            attributes: [
+              { name: "id", value: "sub-cat" },
+              { name: "name", value: "Sub" },
+              { name: "type", value: "ConfigurationElementCategory" },
+            ],
+          },
+          {
+            rel: "up",
+            attributes: [
+              { name: "id", value: "parent-cat" },
+              { name: "name", value: "Swisscom" },
+              { name: "type", value: "ConfigurationElementCategory" },
+            ],
+          },
+        ],
+      },
+    });
+  };
+
+  const client = new VroClient(config());
+  const result = await client.listConfigurations(undefined, "migration-cat");
+
+  assert.equal(result.total, 1);
+  assert.deepEqual(result.link, [
+    {
+      id: "conf-1",
+      name: "Email Configuration",
+      description: undefined,
+      version: "1.2.0",
+      categoryId: "migration-cat",
+      href: "https://vcfa.example.test/vco/api/configurations/conf-1",
+    },
+  ]);
+  assert.equal(
+    calls[1].url,
+    "https://vcfa.example.test/vco/api/categories/migration-cat",
+  );
+});
+
+test("listConfigurations with categoryId and filter applies name substring match", async () => {
+  globalThis.fetch = async (url) => {
+    if (String(url).includes("/sessions")) return authResponse();
+    return Response.json({
+      relations: {
+        link: [
+          {
+            rel: "down",
+            attributes: [
+              { name: "id", value: "c1" },
+              { name: "name", value: "Email Configuration" },
+              { name: "type", value: "ConfigurationElement" },
+            ],
+          },
+          {
+            rel: "down",
+            attributes: [
+              { name: "id", value: "c2" },
+              { name: "name", value: "Auth Server Settings" },
+              { name: "type", value: "ConfigurationElement" },
+            ],
+          },
+        ],
+      },
+    });
+  };
+
+  const client = new VroClient(config());
+  const result = await client.listConfigurations("email", "cat-id");
+
+  assert.equal(result.total, 1);
+  assert.equal(result.link[0].name, "Email Configuration");
+});
+
 test("listWorkflowsByCategory resolves paths from category details and relations", async () => {
   const calls = [];
   globalThis.fetch = async (url, init) => {


### PR DESCRIPTION
## Summary

Adds category scoping to `list-configurations` so callers can list configuration elements under a specific `ConfigurationElementCategory` while preserving the existing name filter behavior.

## Changes

- Added optional `categoryId` support in the configuration client and MCP tool schema.
- Parses configuration elements from category relation links and applies local name filtering for category-scoped results.
- Updated reference docs and configuration how-to examples to show category-scoped listing.
- Added client and MCP-layer tests for category forwarding and category relation parsing.

## Validation

- `npm run validate:docs`
- `npm run docs:build`
- `npm test`