### PR TITLE
[codex] Add confirmation gates for live operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ Before authoring or importing workflow artifacts, read `docs/vro-artifact-author
 ## Template, Subscription, Catalog, And Deployment Rules
 
 - For Cloud Assembly templates, inspect existing templates with `list-templates` and `get-template` before drafting YAML. Reuse discovered resource types, inputs, image/flavor/network conventions, constraints, and catalog patterns. Do not invent provider-specific YAML.
-- Confirm the target `projectId` and template content before `create-template`.
+- Confirm the target `projectId` and template content before calling `create-template` with `confirm: true`.
 - For catalog work, inspect `list-catalog-items` and `get-catalog-item` before creating deployments.
 - For deployments, inspect `get-deployment` and `list-deployment-actions` before proposing remediation. Do not run `run-deployment-action` until the user confirms the action, inputs, target deployment, and expected impact.
 - For extensibility subscriptions, inspect `list-event-topics`, `list-subscriptions`, and `get-subscription` first. During testing, disabling or updating a subscription may be safer than deleting it.

--- a/docs/how-tos/catalog-deployments.md
+++ b/docs/how-tos/catalog-deployments.md
@@ -12,7 +12,7 @@ Recommended sequence:
 
 1. `list-catalog-items(search: "Ubuntu")`
 2. `get-catalog-item(id: "...")`
-3. `create-deployment(catalogItemId: "...", deploymentName: "...", projectId: "...", inputs: {...})`
+3. `create-deployment(catalogItemId: "...", deploymentName: "...", projectId: "...", inputs: {...}, confirm: true)`
 4. `list-deployments(search: "...", projectId: "...")`
 
 ## Discover And Run Day-2 Actions

--- a/docs/how-tos/configuration-resources.md
+++ b/docs/how-tos/configuration-resources.md
@@ -7,7 +7,7 @@ Use configuration elements for runtime data that workflows should read without h
 Recommended sequence:
 
 1. `list-categories(type: "ConfigurationElementCategory", filter: "Integrations")`
-2. `create-configuration(...)`
+2. `create-configuration(..., confirm: true)`
 3. `list-configurations(categoryId: "...", filter: "...")`
 4. `get-configuration(id: "...")`
 
@@ -29,5 +29,5 @@ Recommended sequence:
 To rotate a value or replace a shared binary resource:
 
 1. `list-configurations(categoryId: "...", filter: "...")` or `list-resource-elements(filter: "...")`
-2. `update-configuration(...)` or `update-resource-element(..., confirm: true)`
+2. `update-configuration(..., confirm: true)` or `update-resource-element(..., confirm: true)`
 3. Re-read the object to verify the change.

--- a/docs/how-tos/templates-subscriptions.md
+++ b/docs/how-tos/templates-subscriptions.md
@@ -13,7 +13,7 @@ Recommended sequence:
 1. `list-templates(search: "Ubuntu")`
 2. `get-template(id: "<ubuntu-template-id>")`
 3. Draft YAML using discovered resource types, inputs, and project conventions.
-4. `create-template(name: "...", projectId: "...", content: "...")`
+4. `create-template(name: "...", projectId: "...", content: "...", confirm: true)`
 5. `get-template(id: "<new-template-id>")`
 
 Do not invent provider-specific YAML properties. If no reliable example or user-provided schema exists, report the missing facts.
@@ -30,11 +30,11 @@ Recommended sequence:
 
 1. `list-event-topics()`
 2. `list-workflows(filter: "Post-Provision Hardening")`
-3. `create-subscription(...)`
+3. `create-subscription(..., confirm: true)`
 4. `list-subscriptions()` or `get-subscription(id: "...")`
 
 If blocking behavior matters, verify the event topic supports it before setting `blocking: true`.
 
 ## Disable Instead Of Delete
 
-For temporary testing, prefer `update-subscription(id: "...", disabled: true)` over `delete-subscription`. Delete only when the hook is no longer needed.
+For temporary testing, prefer `update-subscription(id: "...", disabled: true, confirm: true)` over `delete-subscription`. Delete only when the hook is no longer needed.

--- a/docs/how-tos/workflows.md
+++ b/docs/how-tos/workflows.md
@@ -13,7 +13,7 @@ Recommended tool sequence:
 
 1. `list-workflows(filter: "resize")`
 2. `get-workflow(id: "...")`
-3. `run-workflow-and-wait(...)`
+3. `run-workflow-and-wait(..., confirm: true)`
 
 `run-workflow-and-wait` validates inputs before running and polls until completion. If the workflow fails, the response includes current item details, stack information, log excerpts, and warnings when diagnostics cannot be fetched.
 
@@ -86,7 +86,7 @@ Recommended tool sequence:
 1. `scaffold-workflow-file` with workflow inputs, outputs, tasks, and bindings.
 2. `preflight-workflow-file(fileName: "echo-message.workflow")`.
 3. For a narrow validation run only, `list-categories(type: "WorkflowCategory", filter: "Dev")` and `import-workflow-file(..., confirm: true)`.
-4. Verify the workflow with `list-workflows(filter: "Echo Message")`, `get-workflow`, and `run-workflow-and-wait(...)`.
+4. Verify the workflow with `list-workflows(filter: "Echo Message")`, `get-workflow`, and `run-workflow-and-wait(..., confirm: true)`.
 5. Publish reusable project content through the project package:
    - `ensure-project-package(packageName: "com.example.project")`
    - `add-workflow-to-project-package(packageName: "com.example.project", workflowId: "<workflow-id>", confirm: true)`

--- a/docs/operations/safety.md
+++ b/docs/operations/safety.md
@@ -6,6 +6,8 @@ The server includes read-only discovery tools and write-capable tools. Treat eve
 
 These operations should be performed only after explicit user confirmation:
 
+- creating or updating live workflows, actions, configurations, templates, subscriptions, deployments, or packages
+- running workflows, because workflow execution may change the target environment
 - importing workflows, actions, configurations, packages, or resource elements
 - deleting workflows, actions, configurations, resource elements, packages, templates, deployments, or subscriptions
 - running deployment day-2 actions

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -23,7 +23,7 @@ Use this only when you accept the TLS risk.
 
 ## Workflow Run Failures
 
-Prefer `run-workflow-and-wait` during development. It validates input names and types against `get-workflow`, waits for completion, and returns failure context when available.
+Prefer `run-workflow-and-wait` with `confirm: true` during development after the target workflow and inputs are verified. It validates input names and types against `get-workflow`, waits for completion, and returns failure context when available.
 
 If a workflow was started asynchronously, use:
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -111,6 +111,7 @@ Create a new empty workflow in VCF Automation Orchestrator. Use `list-categories
 | `categoryId` | string | Yes | - | Workflow category ID where the empty workflow is created. |
 | `name` | string | Yes | - | Name for the new workflow. |
 | `description` | string | No | - | Optional workflow description. |
+| `confirm` | boolean | Yes | - | Must be `true` to confirm creation. If `false`, the workflow is not created. |
 :::
 
 ### `delete-workflow`
@@ -133,6 +134,7 @@ Execute a workflow with optional input parameters. Returns the execution ID; use
 | --- | --- | --- | --- | --- |
 | `id` | string | Yes | - | Workflow ID to execute. |
 | `inputs` | array | No | `[]` | Input parameters for the workflow execution. Inspect the workflow with `get-workflow` before running. |
+| `confirm` | boolean | Yes | - | Must be `true` to confirm execution. If `false`, the workflow is not run. |
 
 `inputs` array item:
 
@@ -155,6 +157,7 @@ Validate inputs, execute a workflow, poll until completion, failure, or timeout,
 | `timeoutSeconds` | integer | No | `300` | Maximum time to wait for completion before returning a timeout result. |
 | `pollIntervalSeconds` | integer | No | `2` | Seconds between execution status polls. |
 | `logLimit` | integer | No | `20` | Maximum execution log entries to include on failure or timeout. Set to `0` to suppress log excerpts. |
+| `confirm` | boolean | Yes | - | Must be `true` to confirm execution. If `false`, the workflow is not run. |
 
 `inputs` array item:
 
@@ -347,6 +350,7 @@ Create a new action in VCF Automation Orchestrator.
 | `script` | string | Yes | - | JavaScript or TypeScript script content for the action. |
 | `inputParameters` | array | No | `[]` | Input parameter definitions for the action. |
 | `returnType` | string | No | - | Return type, for example `string`, `void`, or `Array/string`. |
+| `confirm` | boolean | Yes | - | Must be `true` to confirm creation. If `false`, the action is not created. |
 
 `inputParameters` array item:
 
@@ -454,6 +458,7 @@ Create a new configuration element in VCF Automation Orchestrator. Use `list-cat
 | `name` | string | Yes | - | Name for the new configuration element. |
 | `description` | string | No | - | Optional description. |
 | `attributes` | array | No | `[]` | Initial attributes for the configuration element. |
+| `confirm` | boolean | Yes | - | Must be `true` to confirm creation. If `false`, the configuration element is not created. |
 
 `attributes` array item:
 
@@ -475,6 +480,7 @@ Update a configuration element name, description, or attributes. Supplied attrib
 | `name` | string | No | current name | New name for the configuration element. |
 | `description` | string | No | current description | New description. |
 | `attributes` | array | No | current attributes | New attributes to replace the existing set. |
+| `confirm` | boolean | Yes | - | Must be `true` to confirm update. If `false`, the configuration element is not updated. |
 
 `attributes` array item:
 
@@ -662,6 +668,7 @@ Create a new deployment from a catalog item. Use `list-catalog-items` to find th
 | `version` | string | No | latest | Catalog item version to deploy. |
 | `reason` | string | No | - | Reason or comment for the deployment request. |
 | `inputs` | object | No | `{}` | Catalog item input parameters as a key/value object. Use `get-catalog-item` or catalog documentation to verify the expected shape before deploying. |
+| `confirm` | boolean | Yes | - | Must be `true` to confirm deployment creation. If `false`, the deployment request is not submitted. |
 :::
 
 ### `delete-deployment`
@@ -734,6 +741,7 @@ Create a new blueprint template in VCF Automation Cloud Assembly. Use `list-temp
 | `description` | string | No | - | Optional template description. |
 | `content` | string | No | empty template | YAML blueprint content for the template. Treat this as Cloud Assembly blueprint content and verify conventions from existing templates or docs before authoring. |
 | `requestScopeOrg` | boolean | No | `false` | If `true`, the template is available org-wide rather than project-scoped. |
+| `confirm` | boolean | Yes | - | Must be `true` to confirm creation. If `false`, the template is not created. |
 :::
 
 ### `delete-template`
@@ -1019,6 +1027,7 @@ Create a subscription linking an Event Broker topic to a vRO workflow or ABX act
 | `priority` | number | No | - | Subscription priority. Lower number means higher priority. |
 | `timeout` | number | No | - | Timeout in minutes for runnable execution. |
 | `disabled` | boolean | No | `false` | Create the subscription in a disabled state. |
+| `confirm` | boolean | Yes | - | Must be `true` to confirm creation. If `false`, the subscription is not created. |
 :::
 
 ### `update-subscription`
@@ -1037,6 +1046,7 @@ Update a subscription. All fields except `id` are optional; only supplied fields
 | `blocking` | boolean | No | current setting | New blocking setting. |
 | `priority` | number | No | current priority | New subscription priority. Lower number means higher priority. |
 | `timeout` | number | No | current timeout | New timeout in minutes. |
+| `confirm` | boolean | Yes | - | Must be `true` to confirm update. If `false`, the subscription is not updated. |
 :::
 
 ### `delete-subscription`

--- a/docs/vro-artifact-authoring.md
+++ b/docs/vro-artifact-authoring.md
@@ -241,7 +241,7 @@ Useful live MCP sequence:
 2. `import-workflow-file` with `categoryId`, `fileName`, `overwrite: true`, `confirm: true`.
 3. `list-workflows` filtered by workflow name.
 4. `get-workflow` to verify inputs/outputs.
-5. `run-workflow` with inputs.
+5. `run-workflow` with inputs and `confirm: true`.
 6. `get-workflow-execution` to poll status and inspect outputs/errors.
 
 Workflow files are read from the `workflows` subdirectory of `VCFA_ARTIFACT_DIR` (defaults to `artifacts/workflows/` in the MCP server process working directory, typically the open project) unless `VCFA_WORKFLOW_DIR` overrides it.

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,7 +9,7 @@ These examples are current, import-safe patterns for using the MCP tools. They a
 - [Artifact Promotion](./artifact-promotion.md): preflight, diff, optional backup, and import recommendation.
 - [Workflow Execution Logs](./workflow-execution-logs.md): show, filter, and export execution syslogs from workflow runs.
 - [Template, Catalog, And Subscription](./template-catalog-subscription.md): review templates, inspect catalog/deployment behavior, and plan subscriptions.
-- vRA/vRO 8.12+ read/run mode: set `VCFA_TARGET_PLATFORM=vra8`, use vRO list/get tools, run workflows with `run-workflow` or `run-workflow-and-wait`, and inspect/export syslogs with `get-workflow-execution-logs`.
+- vRA/vRO 8.12+ read/run mode: set `VCFA_TARGET_PLATFORM=vra8`, use vRO list/get tools, run workflows with confirmed `run-workflow` or `run-workflow-and-wait` calls, and inspect/export syslogs with `get-workflow-execution-logs`.
 
 ## Safety Defaults
 

--- a/examples/artifact-promotion.md
+++ b/examples/artifact-promotion.md
@@ -24,7 +24,7 @@ Only after reviewing the promotion output and confirming the target:
 ```text
 import-workflow-file(categoryId: "<workflow-category-id>", fileName: "echo-message.workflow", overwrite: true, confirm: true)
 get-workflow(id: "<workflow-id>")
-run-workflow-and-wait(id: "<workflow-id>", inputs: [{ name: "message", value: "post-import check" }], timeoutSeconds: 60)
+run-workflow-and-wait(id: "<workflow-id>", inputs: [{ name: "message", value: "post-import check" }], timeoutSeconds: 60, confirm: true)
 ```
 
 For action replacements, use `preflight-action-file(fileName: "example.action")` and `diff-action-file(base: { source: "live", actionId: "<action-id>" }, compare: { source: "file", fileName: "example.action" })` before importing.

--- a/examples/template-catalog-subscription.md
+++ b/examples/template-catalog-subscription.md
@@ -40,6 +40,6 @@ list-subscriptions(projectId: "<project-id>")
 Create the subscription only after the topic, workflow ID, blocking behavior, and timeout are confirmed:
 
 ```text
-create-subscription(name: "Tag Ubuntu deployments", eventTopicId: "<event-topic-id>", runnableType: "extensibility.vro", runnableId: "<workflow-id>", projectId: "<project-id>", blocking: false, priority: 100, timeout: 10, disabled: true)
+create-subscription(name: "Tag Ubuntu deployments", eventTopicId: "<event-topic-id>", runnableType: "extensibility.vro", runnableId: "<workflow-id>", projectId: "<project-id>", blocking: false, priority: 100, timeout: 10, disabled: true, confirm: true)
 get-subscription(id: "<subscription-id>")
 ```

--- a/examples/workflow-artifact.md
+++ b/examples/workflow-artifact.md
@@ -43,5 +43,5 @@ list-categories(type: "WorkflowCategory", filter: "Development")
 import-workflow-file(categoryId: "<workflow-category-id>", fileName: "echo-message.workflow", overwrite: true, confirm: true)
 list-workflows(filter: "Echo Message")
 get-workflow(id: "<workflow-id>")
-run-workflow-and-wait(id: "<workflow-id>", inputs: [{ name: "message", value: "hello" }], timeoutSeconds: 60, pollIntervalSeconds: 2)
+run-workflow-and-wait(id: "<workflow-id>", inputs: [{ name: "message", value: "hello" }], timeoutSeconds: 60, pollIntervalSeconds: 2, confirm: true)
 ```

--- a/src/client/action-client.ts
+++ b/src/client/action-client.ts
@@ -17,6 +17,13 @@ import {
   resolveFileInDirectory,
 } from "./files.js";
 
+function isNotFoundError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message.includes("404") || error.message.includes("not found"))
+  );
+}
+
 export class ActionClient {
   constructor(private http: VroHttpClient) {}
 
@@ -102,7 +109,8 @@ export class ActionClient {
         return await this.http.get<Action>(
           `/actions/${encodeURIComponent(id)}`,
         );
-      } catch {
+      } catch (error) {
+        if (!isNotFoundError(error)) throw error;
         // Older callers may pass friendly IDs that only resolve via list metadata.
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,9 +85,9 @@ async function main(): Promise<void> {
     {
       instructions: [
         "This server connects to a VCF Automation instance by default, or to vRA/vRO 8.12+ when VCFA_TARGET_PLATFORM is set to vra8.",
-        "Use list-categories before creating workflows, actions, or configuration elements to find the target category ID.",
-        "Use get-workflow to inspect a workflow's input parameters before running it with run-workflow.",
-        "Use run-workflow-and-wait for rapid development loops that validate workflow inputs, wait for completion, and return outputs or diagnostics.",
+        "Use list-categories before creating workflows, actions, or configuration elements to find the target category ID; pass confirm set to true only after the live target and impact are confirmed.",
+        "Use get-workflow to inspect a workflow's input parameters before running it with run-workflow and confirm set to true.",
+        "Use run-workflow-and-wait with confirm set to true for rapid development loops that validate workflow inputs, wait for completion, and return outputs or diagnostics.",
         "After starting a workflow execution with run-workflow, use get-workflow-execution to poll for completion and retrieve outputs; use get-workflow-execution-logs to retrieve execution logs.",
         "Use export-workflow-file to save a workflow artifact under the configured workflow artifact directory; use direct import-workflow-file only for narrow validation or explicitly requested single-artifact tests.",
         "Use scaffold-workflow-file to generate a local .workflow artifact from structured workflow metadata and linear scriptable tasks before publishing or validating it.",
@@ -100,8 +100,8 @@ async function main(): Promise<void> {
         "Use list-event-topics to discover available event topics before creating extensibility subscriptions.",
         "Use list-subscriptions to see existing event-driven triggers.",
         "Use list-catalog-items to browse the Service Broker catalog; use get-catalog-item to inspect a specific item by ID.",
-        "Use list-deployments to see existing deployments; use create-deployment to deploy a catalog item, providing the catalogItemId, deploymentName, and projectId. Use list-deployment-actions to discover available deployment day-2 actions, then run-deployment-action with confirm set to true to submit one.",
-        "Use list-templates to browse blueprint templates; use get-template to inspect a specific template by ID; use create-template to create a new template; use delete-template to remove one.",
+        "Use list-deployments to see existing deployments; use create-deployment with confirm set to true to deploy a catalog item, providing the catalogItemId, deploymentName, and projectId. Use list-deployment-actions to discover available deployment day-2 actions, then run-deployment-action with confirm set to true to submit one.",
+        "Use list-templates to browse blueprint templates; use get-template to inspect a specific template by ID; use create-template with confirm set to true to create a new template; use delete-template to remove one.",
         "Publish reusable vRO content through packages by default: use ensure-project-package, add content to the exact project package, rebuild-project-package, export-project-package, get-project-package-import-details, then import-project-package. Reuse the configured project package from VCFA_PROJECT_PACKAGE_NAME; never create one-off packages unless the user confirms the exact package name.",
         "Use list-resource-elements to browse vRO resource elements; use list-categories with type ResourceElementCategory before importing a resource element; exported and imported resource files are stored under the configured resource artifact directory.",
         "Use list-plugins to see all installed vRO plugins.",

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -281,7 +281,7 @@ export function registerVcfaPrompts(server: McpServer): void {
           "Use list-templates and get-template to find reusable YAML conventions before drafting content.",
           "Use list-catalog-items or list-deployments when the template must align with catalog or deployment behavior.",
           ...discoveryGuardrails(),
-          "Call create-template only after the target projectId and YAML content are confirmed, then verify with get-template.",
+          "Call create-template with confirm set to true only after the target projectId and YAML content are confirmed, then verify with get-template.",
         ]),
       ),
   );
@@ -339,7 +339,7 @@ export function registerVcfaPrompts(server: McpServer): void {
           "Use list-workflows/get-workflow, list-templates/get-template, list-catalog-items/get-catalog-item, list-event-topics, and list-subscriptions to map current state.",
           "Use list-deployments and list-deployment-actions if day-2 behavior matters.",
           ...discoveryGuardrails(),
-          "Recommend create-subscription, update-subscription, template creation, or workflow import only as explicit next steps with required confirmations and risks.",
+          "Recommend create-subscription, update-subscription, template creation, or workflow import only as explicit next steps with required confirm arguments and risks.",
         ]),
       ),
   );

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -97,7 +97,7 @@ Use \`list-templates\` to discover existing Cloud Assembly blueprint templates b
 Template metadata handled by the current tools includes:
 
 - \`id\`, \`name\`, \`description\`, \`status\`, \`projectId\`, \`projectName\`, \`valid\`, \`createdBy\`, \`createdAt\`, \`updatedBy\`, and \`updatedAt\` when returned by the API.
-- \`create-template\` accepts \`name\`, \`projectId\`, optional \`description\`, optional YAML \`content\`, and optional \`requestScopeOrg\`.
+- \`create-template\` accepts \`name\`, \`projectId\`, optional \`description\`, optional YAML \`content\`, optional \`requestScopeOrg\`, and required \`confirm: true\`.
 
 Authoring rules:
 
@@ -183,7 +183,7 @@ Implementation shape:
 
 Validation flow:
 
-- Use \`create-template\` only after the target project and YAML content are confirmed.
+- Use \`create-template\` only after the target project and YAML content are confirmed, then pass \`confirm: true\`.
 - Verify the result with \`get-template\` and inspect \`valid\` or status fields when returned.
 `;
 

--- a/src/tools/action-tools.ts
+++ b/src/tools/action-tools.ts
@@ -153,6 +153,11 @@ export function registerActionTools(
           .string()
           .optional()
           .describe("Return type (e.g. string, void, Array/string)"),
+        confirm: z
+          .boolean()
+          .describe(
+            "Must be set to true to confirm action creation. If false, the action will not be created.",
+          ),
       }),
       annotations: { readOnlyHint: false },
     },
@@ -162,7 +167,19 @@ export function registerActionTools(
       script,
       inputParameters,
       returnType,
+      confirm,
     }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Confirm creation of action ${moduleName}/${name} by setting confirm to true.`,
+            },
+          ],
+        };
+      }
+
       try {
         const action = await client.createAction({
           moduleName,

--- a/src/tools/config-tools.ts
+++ b/src/tools/config-tools.ts
@@ -139,6 +139,11 @@ export function registerConfigTools(
           )
           .optional()
           .describe("Initial attributes for the configuration element"),
+        confirm: z
+          .boolean()
+          .describe(
+            "Must be set to true to confirm configuration element creation. If false, the element will not be created.",
+          ),
       }),
       annotations: { readOnlyHint: false },
     },
@@ -147,7 +152,19 @@ export function registerConfigTools(
       name,
       description,
       attributes,
+      confirm,
     }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Confirm creation of configuration element ${name} in category ${categoryId} by setting confirm to true.`,
+            },
+          ],
+        };
+      }
+
       try {
         const config = await client.createConfiguration(
           categoryId,
@@ -399,10 +416,32 @@ export function registerConfigTools(
           )
           .optional()
           .describe("New attributes (replaces existing ones)"),
+        confirm: z
+          .boolean()
+          .describe(
+            "Must be set to true to confirm configuration element update. If false, the element will not be updated.",
+          ),
       }),
       annotations: { readOnlyHint: false },
     },
-    async ({ id, name, description, attributes }): Promise<CallToolResult> => {
+    async ({
+      id,
+      name,
+      description,
+      attributes,
+      confirm,
+    }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Confirm update of configuration element ${id} by setting confirm to true.`,
+            },
+          ],
+        };
+      }
+
       try {
         await client.updateConfiguration(id, { name, description, attributes });
         return {

--- a/src/tools/deployment-tools.ts
+++ b/src/tools/deployment-tools.ts
@@ -263,6 +263,11 @@ export function registerDeploymentTools(
           .record(z.string(), z.unknown())
           .optional()
           .describe("Catalog item input parameters as a key/value object"),
+        confirm: z
+          .boolean()
+          .describe(
+            "Must be set to true to confirm deployment creation. If false, the deployment request will not be submitted.",
+          ),
       }),
       annotations: { readOnlyHint: false },
     },
@@ -273,7 +278,19 @@ export function registerDeploymentTools(
       version,
       reason,
       inputs,
+      confirm,
     }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Confirm deployment of catalog item ${catalogItemId} as ${deploymentName} in project ${projectId} by setting confirm to true.`,
+            },
+          ],
+        };
+      }
+
       try {
         const deployment = await client.createDeploymentFromCatalogItem({
           catalogItemId,

--- a/src/tools/subscription-tools.ts
+++ b/src/tools/subscription-tools.ts
@@ -191,6 +191,11 @@ export function registerSubscriptionTools(
           .boolean()
           .optional()
           .describe("Create the subscription in disabled state"),
+        confirm: z
+          .boolean()
+          .describe(
+            "Must be set to true to confirm subscription creation. If false, the subscription will not be created.",
+          ),
       }),
       annotations: { readOnlyHint: false },
     },
@@ -205,7 +210,19 @@ export function registerSubscriptionTools(
       priority,
       timeout,
       disabled,
+      confirm,
     }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Confirm creation of subscription ${name} for event topic ${eventTopicId} by setting confirm to true.`,
+            },
+          ],
+        };
+      }
+
       try {
         const sub = await client.createSubscription({
           name,
@@ -266,6 +283,11 @@ export function registerSubscriptionTools(
         blocking: z.boolean().optional().describe("New blocking setting"),
         priority: z.number().optional().describe("New priority"),
         timeout: z.number().optional().describe("New timeout in minutes"),
+        confirm: z
+          .boolean()
+          .describe(
+            "Must be set to true to confirm subscription update. If false, the subscription will not be updated.",
+          ),
       }),
       annotations: { readOnlyHint: false },
     },
@@ -279,7 +301,19 @@ export function registerSubscriptionTools(
       blocking,
       priority,
       timeout,
+      confirm,
     }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Confirm update of subscription ${id} by setting confirm to true.`,
+            },
+          ],
+        };
+      }
+
       try {
         const sub = await client.updateSubscription(id, {
           name,

--- a/src/tools/template-tools.ts
+++ b/src/tools/template-tools.ts
@@ -132,6 +132,11 @@ export function registerTemplateTools(
           .describe(
             "If true, the template is available org-wide rather than project-scoped",
           ),
+        confirm: z
+          .boolean()
+          .describe(
+            "Must be set to true to confirm template creation. If false, the template will not be created.",
+          ),
       }),
       annotations: { readOnlyHint: false },
     },
@@ -141,7 +146,19 @@ export function registerTemplateTools(
       description,
       content,
       requestScopeOrg,
+      confirm,
     }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Confirm creation of template ${name} in project ${projectId} by setting confirm to true.`,
+            },
+          ],
+        };
+      }
+
       try {
         const template = await client.createTemplate({
           name,

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -534,10 +534,31 @@ export function registerWorkflowTools(
           .string()
           .optional()
           .describe("Optional description for the workflow"),
+        confirm: z
+          .boolean()
+          .describe(
+            "Must be set to true to confirm workflow creation. If false, the workflow will not be created.",
+          ),
       }),
       annotations: { readOnlyHint: false },
     },
-    async ({ categoryId, name, description }): Promise<CallToolResult> => {
+    async ({
+      categoryId,
+      name,
+      description,
+      confirm,
+    }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Confirm creation of workflow ${name} in category ${categoryId} by setting confirm to true.`,
+            },
+          ],
+        };
+      }
+
       try {
         const wf = await client.createWorkflow(categoryId, name, description);
         return {
@@ -584,10 +605,26 @@ export function registerWorkflowTools(
           )
           .optional()
           .describe("Input parameters for the workflow execution"),
+        confirm: z
+          .boolean()
+          .describe(
+            "Must be set to true to confirm workflow execution. If false, the workflow will not be run.",
+          ),
       }),
       annotations: { readOnlyHint: false },
     },
-    async ({ id, inputs }): Promise<CallToolResult> => {
+    async ({ id, inputs, confirm }): Promise<CallToolResult> => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Confirm execution of workflow ${id} by setting confirm to true. Workflows may change the target environment.`,
+            },
+          ],
+        };
+      }
+
       try {
         const exec = await client.runWorkflow(id, inputs);
         return {
@@ -655,6 +692,11 @@ export function registerWorkflowTools(
           .describe(
             "Maximum execution log entries to include on failure or timeout (default: 20)",
           ),
+        confirm: z
+          .boolean()
+          .describe(
+            "Must be set to true to confirm workflow execution. If false, the workflow will not be run.",
+          ),
       }),
       annotations: { readOnlyHint: false },
     },
@@ -664,8 +706,20 @@ export function registerWorkflowTools(
       timeoutSeconds,
       pollIntervalSeconds,
       logLimit,
+      confirm,
     }): Promise<CallToolResult> => {
       let startedExecution: WorkflowExecution | undefined;
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Confirm execution of workflow ${id} by setting confirm to true. Workflows may change the target environment.`,
+            },
+          ],
+        };
+      }
+
       try {
         const workflow = await client.getWorkflow(id);
         const validation = validateWorkflowRunInputs(workflow, inputs ?? []);

--- a/test/artifact-tools.test.mjs
+++ b/test/artifact-tools.test.mjs
@@ -65,6 +65,7 @@ test("action tools format detail responses and pass create payloads", async () =
     script: "return vm.ipAddress;",
     inputParameters: [{ name: "vm", type: "VC:VirtualMachine" }],
     returnType: "string",
+    confirm: true,
   });
   assert.deepEqual(createParams, {
     moduleName: "com.example.actions",
@@ -74,6 +75,16 @@ test("action tools format detail responses and pass create payloads", async () =
     returnType: "string",
   });
   assert.match(created.content[0].text, /ID: action-1/);
+
+  createParams = undefined;
+  const refused = await handlers.get("create-action")({
+    moduleName: "com.example.actions",
+    name: "blocked",
+    script: "return null;",
+    confirm: false,
+  });
+  assert.equal(createParams, undefined);
+  assert.match(refused.content[0].text, /setting confirm to true/);
 });
 
 test("configuration tools format attributes and guard imports and deletes", async () => {
@@ -147,6 +158,7 @@ test("configuration tools format attributes and guard imports and deletes", asyn
     name: "Settings",
     description: "Runtime settings",
     attributes: [{ name: "host", type: "string", value: "vcfa.example.test" }],
+    confirm: true,
   });
   assert.deepEqual(created, {
     categoryId: "category-1",
@@ -160,6 +172,7 @@ test("configuration tools format attributes and guard imports and deletes", asyn
     id: "config-1",
     description: "Updated settings",
     attributes: [{ name: "enabled", type: "boolean", value: "true" }],
+    confirm: true,
   });
   assert.deepEqual(updated, {
     id: "config-1",

--- a/test/catalog-template-tools.test.mjs
+++ b/test/catalog-template-tools.test.mjs
@@ -145,6 +145,7 @@ test("template tools create and delete with confirmation", async () => {
     description: "Demo",
     content: "formatVersion: 1",
     requestScopeOrg: true,
+    confirm: true,
   });
   assert.deepEqual(createParams, {
     name: "New VM",

--- a/test/deployment-tools.test.mjs
+++ b/test/deployment-tools.test.mjs
@@ -78,6 +78,7 @@ test("deployment tools list, get, create, and delete with confirmation", async (
     version: "1.0.0",
     reason: "Test deployment",
     inputs: { size: "small" },
+    confirm: true,
   });
   assert.deepEqual(createParams, {
     catalogItemId: "catalog-1",

--- a/test/resources-prompts.test.mjs
+++ b/test/resources-prompts.test.mjs
@@ -343,7 +343,10 @@ test("implementation prompts include discovery-first guardrails", async () => {
     projectHint: "MainPrj",
   });
   assert.match(createTemplate.messages[0].content.text, /list-templates/);
-  assert.match(createTemplate.messages[0].content.text, /create-template only after/);
+  assert.match(
+    createTemplate.messages[0].content.text,
+    /create-template with confirm set to true only after/,
+  );
 
   const reviewTemplate = await prompts.get("vcfa-review-template").handler({
     templateId: "template-1",

--- a/test/subscription-tools.test.mjs
+++ b/test/subscription-tools.test.mjs
@@ -98,6 +98,7 @@ test("subscription tools pass create and update payloads through", async () => {
     priority: 10,
     timeout: 30,
     disabled: true,
+    confirm: true,
   });
   assert.deepEqual(createdParams, {
     name: "Provisioning approval",
@@ -122,6 +123,7 @@ test("subscription tools pass create and update payloads through", async () => {
     blocking: false,
     priority: 20,
     timeout: 45,
+    confirm: true,
   });
   assert.deepEqual(updatedCall, {
     id: "sub-1",

--- a/test/vro-client.test.mjs
+++ b/test/vro-client.test.mjs
@@ -1918,6 +1918,30 @@ test("getAction resolves listed action ids to definition endpoint", async () => 
   assert.equal(action.script, "return vm.ipAddress;");
 });
 
+test("getAction rethrows direct lookup errors that are not not-found responses", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    return new Response("boom", {
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+  };
+
+  const client = new VroClient(config());
+  await assert.rejects(
+    () => client.getAction("action-1"),
+    /500 Internal Server Error/,
+  );
+
+  assert.equal(calls.length, 2);
+  assert.equal(
+    calls[1].url,
+    "https://vcfa.example.test/vco/api/actions/action-1",
+  );
+});
+
 test("getAction accepts opaque action ids directly", async () => {
   const calls = [];
   globalThis.fetch = async (url, init) => {

--- a/test/workflow-tools.test.mjs
+++ b/test/workflow-tools.test.mjs
@@ -180,6 +180,7 @@ test("run-workflow-and-wait rejects strict validation errors before running", as
 
   const result = await handlers.get("run-workflow-and-wait")({
     id: "workflow-1",
+    confirm: true,
     inputs: [
       { name: "projectName", type: "string", value: 123 },
       { name: "projectName", type: "string", value: "duplicate" },
@@ -193,6 +194,30 @@ test("run-workflow-and-wait rejects strict validation errors before running", as
   assert.match(result.content[0].text, /Duplicate input: projectName/);
   assert.match(result.content[0].text, /Unknown input: extra/);
   assert.match(result.content[0].text, /Missing required input: count/);
+});
+
+test("run-workflow-and-wait requires confirmation before discovery or execution", async () => {
+  let getCalls = 0;
+  let runCalls = 0;
+  const handlers = registeredWorkflowTools({
+    getWorkflow: async () => {
+      getCalls += 1;
+      return { id: "workflow-1", name: "Workflow", inputParameters: [] };
+    },
+    runWorkflow: async () => {
+      runCalls += 1;
+      return { id: "execution-1", state: "running" };
+    },
+  });
+
+  const result = await handlers.get("run-workflow-and-wait")({
+    id: "workflow-1",
+    confirm: false,
+  });
+
+  assert.equal(getCalls, 0);
+  assert.equal(runCalls, 0);
+  assert.match(result.content[0].text, /setting confirm to true/);
 });
 
 test("run-workflow-and-wait fills omitted input types and returns outputs", async () => {
@@ -232,6 +257,7 @@ test("run-workflow-and-wait fills omitted input types and returns outputs", asyn
     inputs: [{ name: "name", value: "web-server-01" }],
     timeoutSeconds: 1,
     pollIntervalSeconds: 0,
+    confirm: true,
   });
 
   assert.equal(result.isError, undefined);
@@ -277,6 +303,7 @@ test("run-workflow-and-wait reports failure diagnostics and log excerpts", async
     id: "workflow-1",
     timeoutSeconds: 1,
     pollIntervalSeconds: 0,
+    confirm: true,
   });
 
   assert.equal(result.isError, true);
@@ -309,6 +336,7 @@ test("run-workflow-and-wait times out without canceling the workflow", async () 
     id: "workflow-1",
     timeoutSeconds: 0,
     pollIntervalSeconds: 0,
+    confirm: true,
   });
 
   assert.equal(result.isError, true);
@@ -340,6 +368,7 @@ test("run-workflow-and-wait reports log fetch warnings", async () => {
     id: "workflow-1",
     timeoutSeconds: 1,
     pollIntervalSeconds: 0,
+    confirm: true,
   });
 
   assert.equal(result.isError, true);


### PR DESCRIPTION
## Summary

- Add required `confirm` gates to live create/update operations and workflow execution tools.
- Preserve non-404 errors from direct `getAction` lookups instead of falling back to list resolution for every failure.
- Align safety docs, tool reference, prompts, resources, how-tos, examples, and tests with the new confirmation contract.

## Why

The project safety guidance requires explicit confirmation before live environment changes. Some live mutating tools did not enforce that at the schema/handler level, and `getAction` could hide useful server/auth errors behind the compatibility fallback.

## Validation

- `npm run validate`

Note: local `gh auth status` reports an invalid token, so this PR was opened through the GitHub connector after pushing the branch.