### PR TITLE
[VCFO-040] Correct readOnlyHint annotations for local artifact write tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,6 @@ npm run docs:dev
 
 ## Safety
 
-Use read-only discovery tools before live writes. Import, delete, deployment action, and overwrite operations require explicit confirmation. Local artifact tools only read or write under configured artifact directories and reject unsafe paths.
+Use read-only discovery tools before live writes. Import, delete, deployment action, and run operations require explicit confirmation (`confirm: true`). Local artifact export and snapshot tools write files under configured artifact directories, are not advertised as read-only, and reject unsafe paths. They do not require confirmation; `overwrite` defaults to `false`.
 
 Live VCFA validation should be run separately from local validation. Read-only list/get smoke checks are appropriate for sandbox environments; write, import, delete, and day-2 action tests should use disposable assets and explicit confirmation.

--- a/docs/operations/safety.md
+++ b/docs/operations/safety.md
@@ -1,6 +1,10 @@
 # Safety
 
-The server includes read-only discovery tools and write-capable tools. Treat every live write operation as an environment change.
+Tools fall into three categories:
+
+- **Read-only discovery** (`readOnlyHint: true`): list, get, preflight, and diff tools. They do not write local files or mutate live VCFA/vRO state. `get-workflow-execution-logs` is also read-only by default; it only writes a local file when the optional `fileName` parameter is provided.
+- **Local artifact writes** (`readOnlyHint: false`, no `confirm` required): export, scaffold, and snapshot tools — for example `export-workflow-file`, `export-action-file`, `export-configuration-file`, `export-resource-element`, `export-package`, `export-project-package`, `scaffold-workflow-file`, `collect-context-snapshot`, and `prepare-artifact-promotion`. These write files under configured artifact directories and default `overwrite` to `false`. They do not mutate live VCFA/vRO state.
+- **Live VCFA/vRO mutations** (`readOnlyHint: false`, `confirm: true` required): create, update, import, delete, run, and deployment day-2 action tools. Treat every live write operation as an environment change.
 
 ## Confirmation Required
 
@@ -11,7 +15,6 @@ These operations should be performed only after explicit user confirmation:
 - importing workflows, actions, configurations, packages, or resource elements
 - deleting workflows, actions, configurations, resource elements, packages, templates, deployments, or subscriptions
 - running deployment day-2 actions
-- overwriting local artifact export targets
 
 ## Artifact Path Safety
 

--- a/docs/operations/safety.md
+++ b/docs/operations/safety.md
@@ -27,6 +27,8 @@ Artifact file tools require plain file names under configured artifact directori
 - unsafe symlink export targets
 - existing export targets unless `overwrite: true`
 
+Export and snapshot tools default `overwrite` to `false`. Pass `overwrite: true` explicitly when replacing an existing local artifact.
+
 ## Secrets
 
 Configuration values and workflow/action scripts may contain sensitive information. When summarizing output:

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -1,6 +1,10 @@
 # Tool Reference
 
-Tools are grouped by operating domain. Read-only tools are safe for discovery; write and delete tools can modify live VCFA/vRO state or local artifact files.
+Tools are grouped by operating domain and carry MCP annotation hints:
+
+- **`readOnlyHint: true`** — list, get, preflight, and diff tools. Safe for discovery; do not write local files or mutate live state. (`get-workflow-execution-logs` is read-only by default; it writes a local file only when `fileName` is provided.)
+- **`readOnlyHint: false` (no `confirm`)** — export, scaffold, and snapshot tools. Write files under configured artifact directories; `overwrite` defaults to `false`. Do not mutate live VCFA/vRO state.
+- **`readOnlyHint: false` with `confirm: true`** — create, update, import, run, and delete tools. Mutate live VCFA/vRO state and require explicit confirmation.
 
 Each tool lists its input schema in a collapsible parameters section. Required confirmation fields such as `confirm` must be set to `true` before the tool performs the write or destructive operation.
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -1,10 +1,10 @@
 # Tool Reference
 
-Tools are grouped by operating domain and carry MCP annotation hints:
+Tools are grouped by operating domain. Each tool carries an MCP annotation hint indicating its effect category:
 
-- **`readOnlyHint: true`** — list, get, preflight, and diff tools. Safe for discovery; do not write local files or mutate live state. (`get-workflow-execution-logs` is read-only by default; it writes a local file only when `fileName` is provided.)
-- **`readOnlyHint: false` (no `confirm`)** — export, scaffold, and snapshot tools. Write files under configured artifact directories; `overwrite` defaults to `false`. Do not mutate live VCFA/vRO state.
-- **`readOnlyHint: false` with `confirm: true`** — create, update, import, run, and delete tools. Mutate live VCFA/vRO state and require explicit confirmation.
+- **Read-only discovery** (`readOnlyHint: true`) — list, get, preflight, and diff tools. Safe for discovery; do not write local files or mutate live state. (`get-workflow-execution-logs` is read-only by default; it writes a local file only when the optional `fileName` is provided.)
+- **Local artifact write** (`readOnlyHint: false`, no `confirm`) — export, scaffold, and snapshot tools. Write files under configured artifact directories; `overwrite` defaults to `false`. Do not mutate live VCFA/vRO state.
+- **Live mutation** (`readOnlyHint: false`, `confirm: true`) — create, update, import, run, and delete tools. Mutate live VCFA/vRO state and require explicit confirmation.
 
 Each tool lists its input schema in a collapsible parameters section. Required confirmation fields such as `confirm` must be set to `true` before the tool performs the write or destructive operation.
 

--- a/src/tools/action-tools.ts
+++ b/src/tools/action-tools.ts
@@ -228,7 +228,7 @@ export function registerActionTools(
           .optional()
           .describe("Overwrite the file if it already exists (default: false)"),
       }),
-      annotations: { readOnlyHint: true },
+      annotations: { readOnlyHint: false },
     },
     async ({ id, fileName, overwrite }): Promise<CallToolResult> => {
       try {

--- a/src/tools/config-tools.ts
+++ b/src/tools/config-tools.ts
@@ -263,7 +263,7 @@ export function registerConfigTools(
           .optional()
           .describe("Overwrite the file if it already exists (default: false)"),
       }),
-      annotations: { readOnlyHint: true },
+      annotations: { readOnlyHint: false },
     },
     async ({ id, fileName, overwrite }): Promise<CallToolResult> => {
       try {

--- a/src/tools/context-tools.ts
+++ b/src/tools/context-tools.ts
@@ -65,7 +65,7 @@ export function registerContextTools(
             "Snapshot profile. Use vcfaBuiltIns to collect workflows in subfolders below Library and actions in com.vmware modules.",
           ),
       }),
-      annotations: { readOnlyHint: true },
+      annotations: { readOnlyHint: false },
     },
     async (params): Promise<CallToolResult> => {
       try {

--- a/src/tools/package-tools.ts
+++ b/src/tools/package-tools.ts
@@ -188,7 +188,7 @@ export function registerPackageTools(
           .describe("Overwrite the file if it already exists (default: false)"),
         ...packageExportOptionsSchema,
       }),
-      annotations: { readOnlyHint: true },
+      annotations: { readOnlyHint: false },
     },
     async ({
       name,
@@ -747,7 +747,7 @@ export function registerPackageTools(
         overwrite: z.boolean().optional(),
         ...packageExportOptionsSchema,
       }),
-      annotations: { readOnlyHint: true },
+      annotations: { readOnlyHint: false },
     },
     async ({
       packageName,

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -76,7 +76,7 @@ export function registerResourceTools(
           .optional()
           .describe("Overwrite the file if it already exists (default: false)"),
       }),
-      annotations: { readOnlyHint: true },
+      annotations: { readOnlyHint: false },
     },
     async ({ id, fileName, overwrite }): Promise<CallToolResult> => {
       try {

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -1077,7 +1077,7 @@ export function registerWorkflowTools(
           .optional()
           .describe("Overwrite the file if it already exists (default: false)"),
       }),
-      annotations: { readOnlyHint: true },
+      annotations: { readOnlyHint: false },
     },
     async ({ id, fileName, overwrite }): Promise<CallToolResult> => {
       try {

--- a/test/artifact-tools.test.mjs
+++ b/test/artifact-tools.test.mjs
@@ -412,3 +412,13 @@ test("resource tools format lists and guard updates and deletes", async () => {
   });
   assert.deepEqual(deleted, { id: "resource-1", force: true });
 });
+
+test("export-action-file, export-configuration-file, and export-resource-element are not read-only", () => {
+  const { configs: actionConfigs } = registeredToolsWithConfigs(registerActionTools, {});
+  const { configs: configConfigs } = registeredToolsWithConfigs(registerConfigTools, {});
+  const { configs: resourceConfigs } = registeredToolsWithConfigs(registerResourceTools, {});
+
+  assert.equal(actionConfigs.get("export-action-file").annotations.readOnlyHint, false);
+  assert.equal(configConfigs.get("export-configuration-file").annotations.readOnlyHint, false);
+  assert.equal(resourceConfigs.get("export-resource-element").annotations.readOnlyHint, false);
+});

--- a/test/context-snapshot.test.mjs
+++ b/test/context-snapshot.test.mjs
@@ -549,7 +549,7 @@ test("collect-context-snapshot tool delegates and reports saved paths", async ()
     },
   });
 
-  assert.equal(configs.get("collect-context-snapshot").annotations.readOnlyHint, true);
+  assert.equal(configs.get("collect-context-snapshot").annotations.readOnlyHint, false);
   assert.ok(configs.get("collect-context-snapshot").inputSchema.shape.profile);
   const result = await handlers.get("collect-context-snapshot")({
     domains: ["workflows"],

--- a/test/package-tools.test.mjs
+++ b/test/package-tools.test.mjs
@@ -679,3 +679,10 @@ test("preflight-package formats reports and is read-only", async () => {
   assert.match(result.content[0].text, /preflight passed/);
   assert.match(result.content[0].text, /workflowArtifacts: 0/);
 });
+
+test("export-package and export-project-package are not read-only", () => {
+  const { configs } = registeredPackageToolsWithConfigs({});
+
+  assert.equal(configs.get("export-package").annotations.readOnlyHint, false);
+  assert.equal(configs.get("export-project-package").annotations.readOnlyHint, false);
+});

--- a/test/workflow-tools.test.mjs
+++ b/test/workflow-tools.test.mjs
@@ -529,6 +529,8 @@ test("get-workflow-execution-logs exports when fileName is provided", async () =
     maxResult: 3,
   });
 
+  // readOnlyHint stays true: file write is conditional on the optional fileName
+  // param; the primary function is read-only log retrieval. See VCFO-040.
   assert.equal(
     configs.get("get-workflow-execution-logs").annotations.readOnlyHint,
     true,

--- a/test/workflow-tools.test.mjs
+++ b/test/workflow-tools.test.mjs
@@ -698,3 +698,15 @@ test("diff-workflow-file is read-only and delegates to client", async () => {
   assert.equal(result.isError, undefined);
   assert.match(result.content[0].text, /No meaningful workflow changes/);
 });
+
+test("export-workflow-file is not read-only", () => {
+  const configs = new Map();
+  const server = {
+    registerTool(name, config, _handler) {
+      configs.set(name, config);
+    },
+  };
+  registerWorkflowTools(server, {});
+
+  assert.equal(configs.get("export-workflow-file").annotations.readOnlyHint, false);
+});


### PR DESCRIPTION
## Summary

Fixes #49.

Seven MCP tools that write local files were incorrectly annotated with `readOnlyHint: true`, misleading MCP clients and agents into treating them as pure discovery tools.

## Changes

### Source — annotation corrections (`readOnlyHint: true` → `false`)

| Tool | File |
|------|------|
| `collect-context-snapshot` | `src/tools/context-tools.ts` |
| `export-workflow-file` | `src/tools/workflow-tools.ts` |
| `export-action-file` | `src/tools/action-tools.ts` |
| `export-configuration-file` | `src/tools/config-tools.ts` |
| `export-resource-element` | `src/tools/resource-tools.ts` |
| `export-package` | `src/tools/package-tools.ts` |
| `export-project-package` | `src/tools/package-tools.ts` |

**Kept as-is:** `get-workflow-execution-logs` remains `readOnlyHint: true` — its file write is conditional on the optional `fileName` parameter; the primary function is read-only log retrieval.

**Already correct:** `scaffold-workflow-file` and `prepare-artifact-promotion` were already `readOnlyHint: false`.

### Tests

- Updated existing `collect-context-snapshot` assertion (`true` → `false`) in `test/context-snapshot.test.mjs`
- Added `export-workflow-file` annotation test in `test/workflow-tools.test.mjs`
- Added `export-action-file`, `export-configuration-file`, `export-resource-element` annotation tests in `test/artifact-tools.test.mjs`
- Added `export-package`, `export-project-package` annotation tests in `test/package-tools.test.mjs`

### Docs

Clarified three-tier tool classification across `docs/operations/safety.md`, `docs/reference/tools.md`, and `README.md`:

- **`readOnlyHint: true`** — list, get, preflight, diff (no local writes, no VCFA mutations)
- **`readOnlyHint: false`, no `confirm`** — export, scaffold, snapshot (local writes only, `overwrite` defaults to `false`)
- **`readOnlyHint: false`, `confirm: true`** — create, update, import, delete, run (live VCFA/vRO mutations)

## Verification

- 200/200 tests pass
- Full `npm run validate` gate green (build, tests, coverage, docs drift, docs build, package contents)