### PR TITLE
[VCFO-039] Redact sensitive response bodies from surfaced VCFA/vRO errors

### DIFF
--- a/docs/operations/safety.md
+++ b/docs/operations/safety.md
@@ -37,6 +37,8 @@ Configuration values and workflow/action scripts may contain sensitive informati
 - redact sensitive configuration attribute values
 - prefer names, types, IDs, and descriptions over raw values
 
+API error messages are sanitized before being surfaced to MCP callers. Only safe diagnostic fields — HTTP status, endpoint, `message`, `statusCode`, `code`, `error`, and `errors` — are included. Raw response bodies are never passed through verbatim, which prevents vRO error responses from echoing sensitive request content such as credentials or tokens.
+
 ## Destructive Operations
 
 Before deletion, confirm:

--- a/src/client/action-client.ts
+++ b/src/client/action-client.ts
@@ -10,6 +10,7 @@ import {
   type ArtifactPreflightReport,
 } from "./artifact-preflight.js";
 import type { VroHttpClient } from "./core.js";
+import { sanitizeErrorBody } from "./core.js";
 import {
   assertRealPathInside,
   getExistingFile,
@@ -188,7 +189,7 @@ export class ActionClient {
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(
-        `vRO API error: ${res.status} ${res.statusText} — export action\n${text}`,
+        `vRO API error: ${res.status} ${res.statusText} — export action\n${sanitizeErrorBody(text, res)}`,
       );
     }
     return Buffer.from(await res.arrayBuffer());
@@ -270,7 +271,7 @@ export class ActionClient {
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(
-        `vRO API error: ${res.status} ${res.statusText} — import action\n${text}`,
+        `vRO API error: ${res.status} ${res.statusText} — import action\n${sanitizeErrorBody(text, res)}`,
       );
     }
   }

--- a/src/client/action-client.ts
+++ b/src/client/action-client.ts
@@ -9,8 +9,7 @@ import {
   preflightActionFile,
   type ArtifactPreflightReport,
 } from "./artifact-preflight.js";
-import type { VroHttpClient } from "./core.js";
-import { sanitizeErrorBody } from "./core.js";
+import { sanitizeErrorBody, type VroHttpClient } from "./core.js";
 import {
   assertRealPathInside,
   getExistingFile,

--- a/src/client/configuration-client.ts
+++ b/src/client/configuration-client.ts
@@ -8,6 +8,7 @@ import {
   type ArtifactPreflightReport,
 } from "./artifact-preflight.js";
 import type { VroHttpClient } from "./core.js";
+import { sanitizeErrorBody } from "./core.js";
 import {
   assertRealPathInside,
   getExistingFile,
@@ -157,7 +158,7 @@ export class ConfigurationClient {
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(
-        `vRO API error: ${res.status} ${res.statusText} — export configuration\n${text}`,
+        `vRO API error: ${res.status} ${res.statusText} — export configuration\n${sanitizeErrorBody(text, res)}`,
       );
     }
     const buffer = Buffer.from(await res.arrayBuffer());
@@ -211,7 +212,7 @@ export class ConfigurationClient {
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(
-        `vRO API error: ${res.status} ${res.statusText} — import configuration\n${text}`,
+        `vRO API error: ${res.status} ${res.statusText} — import configuration\n${sanitizeErrorBody(text, res)}`,
       );
     }
   }

--- a/src/client/configuration-client.ts
+++ b/src/client/configuration-client.ts
@@ -7,8 +7,7 @@ import {
   preflightConfigurationFile,
   type ArtifactPreflightReport,
 } from "./artifact-preflight.js";
-import type { VroHttpClient } from "./core.js";
-import { sanitizeErrorBody } from "./core.js";
+import { sanitizeErrorBody, type VroHttpClient } from "./core.js";
 import {
   assertRealPathInside,
   getExistingFile,

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -8,6 +8,71 @@ const UNSUPPORTED_AUTOMATION_SERVICES =
 const UNSUPPORTED_VRO_WRITE =
   "This vRO operation is not supported in VCFA_TARGET_PLATFORM=vra8 mode. The vRA/vRO 8 compatibility phase supports read operations plus workflow execution and execution logs only.";
 
+const SAFE_ERROR_BODY_KEYS = new Set(["message", "statusCode", "code", "error", "errors"]);
+const NON_JSON_BODY_LIMIT = 200;
+const ERRORS_ARRAY_LIMIT = 5;
+
+/**
+ * Sanitize a raw HTTP response body before including it in a thrown error.
+ * Extracts only known-safe diagnostic fields from JSON bodies; truncates
+ * non-JSON bodies. Never surfaces unbounded raw response content.
+ * Optionally prepends a correlation ID header when res is provided.
+ */
+export function sanitizeErrorBody(rawText: string, res?: Response): string {
+  const parts: string[] = [];
+
+  if (res) {
+    for (const header of ["x-request-id", "x-correlation-id", "x-vcf-requestid"]) {
+      const val = res.headers.get(header);
+      if (val) {
+        parts.push(`${header}: ${val}`);
+        break;
+      }
+    }
+  }
+
+  if (!rawText) return parts.join("\n");
+
+  try {
+    const parsed: unknown = JSON.parse(rawText);
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      const obj = parsed as Record<string, unknown>;
+      const safe: Record<string, unknown> = {};
+      for (const key of SAFE_ERROR_BODY_KEYS) {
+        if (!(key in obj)) continue;
+        const val = obj[key];
+        if (key === "errors" && Array.isArray(val)) {
+          safe.errors = val.slice(0, ERRORS_ARRAY_LIMIT).map((e: unknown) => {
+            if (typeof e === "string") return e;
+            if (typeof e === "object" && e !== null) {
+              const msg = (e as Record<string, unknown>).message;
+              if (typeof msg === "string") return msg;
+            }
+            return "[error]";
+          });
+        } else if (typeof val === "string" || typeof val === "number") {
+          safe[key] = val;
+        }
+      }
+      if (Object.keys(safe).length > 0) {
+        parts.push(JSON.stringify(safe));
+        return parts.join("\n");
+      }
+      parts.push("[no diagnostic fields in response]");
+      return parts.join("\n");
+    }
+  } catch {
+    // not valid JSON
+  }
+
+  // Non-JSON: truncate to limit exposure
+  const excerpt = rawText.length <= NON_JSON_BODY_LIMIT
+    ? rawText
+    : `${rawText.slice(0, NON_JSON_BODY_LIMIT)}…`;
+  parts.push(`[non-JSON body: ${excerpt}]`);
+  return parts.join("\n");
+}
+
 function normalizeTargetPlatform(
   value: VroClientConfig["targetPlatform"] | string | undefined,
 ): VroTargetPlatform {
@@ -122,7 +187,7 @@ export class VroHttpClient {
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(
-        `VCF authentication failed: ${res.status} ${res.statusText}\n${text}`,
+        `VCF authentication failed: ${res.status} ${res.statusText}\n${sanitizeErrorBody(text, res)}`,
       );
     }
 
@@ -205,7 +270,7 @@ export class VroHttpClient {
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(
-        `vRO API error: ${res.status} ${res.statusText} — ${method} ${path}\n${text}`,
+        `vRO API error: ${res.status} ${res.statusText} — ${method} ${path}\n${sanitizeErrorBody(text, res)}`,
       );
     }
 

--- a/src/client/package-client.ts
+++ b/src/client/package-client.ts
@@ -14,8 +14,7 @@ import {
   preflightPackageFile,
   type ArtifactPreflightReport,
 } from "./artifact-preflight.js";
-import type { VroHttpClient } from "./core.js";
-import { sanitizeErrorBody } from "./core.js";
+import { sanitizeErrorBody, type VroHttpClient } from "./core.js";
 import {
   assertRealPathInside,
   getExistingFile,

--- a/src/client/package-client.ts
+++ b/src/client/package-client.ts
@@ -15,6 +15,7 @@ import {
   type ArtifactPreflightReport,
 } from "./artifact-preflight.js";
 import type { VroHttpClient } from "./core.js";
+import { sanitizeErrorBody } from "./core.js";
 import {
   assertRealPathInside,
   getExistingFile,
@@ -242,7 +243,7 @@ export class PackageClient {
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(
-        `vRO API error: ${res.status} ${res.statusText} — export package\n${text}`,
+        `vRO API error: ${res.status} ${res.statusText} — export package\n${sanitizeErrorBody(text, res)}`,
       );
     }
     const buffer = Buffer.from(await res.arrayBuffer());
@@ -299,7 +300,7 @@ export class PackageClient {
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(
-        `vRO API error: ${res.status} ${res.statusText} — import package\n${text}`,
+        `vRO API error: ${res.status} ${res.statusText} — import package\n${sanitizeErrorBody(text, res)}`,
       );
     }
   }
@@ -345,7 +346,7 @@ export class PackageClient {
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(
-        `vRO API error: ${res.status} ${res.statusText} — package import details\n${text}`,
+        `vRO API error: ${res.status} ${res.statusText} — package import details\n${sanitizeErrorBody(text, res)}`,
       );
     }
     return (await res.json()) as PackageImportDetails;

--- a/src/client/resource-client.ts
+++ b/src/client/resource-client.ts
@@ -1,8 +1,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import type { ResourceElement, ResourceElementList } from "../types.js";
 import { getLinkAttrs, type AttributeLink } from "./attrs.js";
-import type { VroHttpClient } from "./core.js";
-import { sanitizeErrorBody } from "./core.js";
+import { sanitizeErrorBody, type VroHttpClient } from "./core.js";
 import {
   assertRealPathInside,
   getExistingFile,

--- a/src/client/resource-client.ts
+++ b/src/client/resource-client.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import type { ResourceElement, ResourceElementList } from "../types.js";
 import { getLinkAttrs, type AttributeLink } from "./attrs.js";
 import type { VroHttpClient } from "./core.js";
+import { sanitizeErrorBody } from "./core.js";
 import {
   assertRealPathInside,
   getExistingFile,
@@ -100,7 +101,7 @@ export class ResourceClient {
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(
-        `vRO API error: ${res.status} ${res.statusText} — export resource\n${text}`,
+        `vRO API error: ${res.status} ${res.statusText} — export resource\n${sanitizeErrorBody(text, res)}`,
       );
     }
     const buffer = Buffer.from(await res.arrayBuffer());
@@ -156,7 +157,7 @@ export class ResourceClient {
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(
-        `vRO API error: ${res.status} ${res.statusText} — POST ${path}\n${text}`,
+        `vRO API error: ${res.status} ${res.statusText} — POST ${path}\n${sanitizeErrorBody(text, res)}`,
       );
     }
   }

--- a/src/client/workflow-client.ts
+++ b/src/client/workflow-client.ts
@@ -21,6 +21,7 @@ import type {
 } from "../types.js";
 import { getLinkAttrs, parseAttrs } from "./attrs.js";
 import type { VroHttpClient } from "./core.js";
+import { sanitizeErrorBody } from "./core.js";
 import {
   diffWorkflowArtifacts,
   ensurePreflightPassed,
@@ -818,7 +819,7 @@ export class WorkflowClient {
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(
-        `vRO API error: ${res.status} ${res.statusText} — export workflow\n${text}`,
+        `vRO API error: ${res.status} ${res.statusText} — export workflow\n${sanitizeErrorBody(text, res)}`,
       );
     }
     return Buffer.from(await res.arrayBuffer());
@@ -921,7 +922,7 @@ export class WorkflowClient {
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(
-        `vRO API error: ${res.status} ${res.statusText} — import workflow\n${text}`,
+        `vRO API error: ${res.status} ${res.statusText} — import workflow\n${sanitizeErrorBody(text, res)}`,
       );
     }
   }

--- a/src/client/workflow-client.ts
+++ b/src/client/workflow-client.ts
@@ -20,8 +20,7 @@ import type {
   WorkflowList,
 } from "../types.js";
 import { getLinkAttrs, parseAttrs } from "./attrs.js";
-import type { VroHttpClient } from "./core.js";
-import { sanitizeErrorBody } from "./core.js";
+import { sanitizeErrorBody, type VroHttpClient } from "./core.js";
 import {
   diffWorkflowArtifacts,
   ensurePreflightPassed,

--- a/test/vro-client.test.mjs
+++ b/test/vro-client.test.mjs
@@ -2460,7 +2460,7 @@ test("sanitizeErrorBody via auth failure path does not expose sensitive body con
   };
 
   const client = new VroClient(config());
-  const err = await assert.rejects(
+  await assert.rejects(
     () => client.listWorkflows(),
     (e) => {
       assert.ok(!e.message.includes("leaked-token"), "should not expose internalToken value");

--- a/test/vro-client.test.mjs
+++ b/test/vro-client.test.mjs
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { buildWorkflowArtifact } from "../dist/client/workflow-artifact.js";
+import { sanitizeErrorBody } from "../dist/client/core.js";
 import { VroClient } from "../dist/vro-client.js";
 
 const config = (overrides = {}) => ({
@@ -2391,4 +2392,80 @@ test("runDeploymentAction omits absent optional fields", async () => {
   assert.deepEqual(JSON.parse(calls[1].init.body), {
     actionId: "Deployment.Reboot",
   });
+});
+
+// ─── sanitizeErrorBody unit tests ─────────────────────────────────────────────
+
+test("sanitizeErrorBody includes safe JSON fields", () => {
+  const body = JSON.stringify({ message: "Not found", statusCode: 404 });
+  const result = sanitizeErrorBody(body);
+  assert.ok(result.includes("Not found"), "should include message");
+  assert.ok(result.includes("404"), "should include statusCode");
+});
+
+test("sanitizeErrorBody strips sensitive fields from JSON", () => {
+  const body = JSON.stringify({
+    message: "Auth failed",
+    password: "s3cr3t",
+    token: "tok123",
+    secret: "mysecret",
+  });
+  const result = sanitizeErrorBody(body);
+  assert.ok(result.includes("Auth failed"), "should include message");
+  assert.ok(!result.includes("s3cr3t"), "should not include password value");
+  assert.ok(!result.includes("tok123"), "should not include token value");
+  assert.ok(!result.includes("mysecret"), "should not include secret value");
+});
+
+test("sanitizeErrorBody truncates non-JSON body", () => {
+  const longHtml = "<html>" + "x".repeat(500) + "</html>";
+  const result = sanitizeErrorBody(longHtml);
+  assert.ok(result.includes("[non-JSON body:"), "should flag non-JSON");
+  assert.ok(result.length < longHtml.length, "should be shorter than input");
+});
+
+test("sanitizeErrorBody handles empty body", () => {
+  const result = sanitizeErrorBody("");
+  assert.equal(result, "", "empty body should produce empty string");
+});
+
+test("sanitizeErrorBody surfaces nested errors array messages", () => {
+  const body = JSON.stringify({
+    errors: [{ message: "Workflow not found" }, { message: "Permission denied" }],
+  });
+  const result = sanitizeErrorBody(body);
+  assert.ok(result.includes("Workflow not found"), "should include first error message");
+  assert.ok(result.includes("Permission denied"), "should include second error message");
+});
+
+test("sanitizeErrorBody includes correlation ID header when present", () => {
+  const body = JSON.stringify({ message: "Bad request" });
+  const res = new Response(body, {
+    status: 400,
+    headers: { "x-request-id": "req-abc-123" },
+  });
+  const result = sanitizeErrorBody(body, res);
+  assert.ok(result.includes("req-abc-123"), "should include correlation ID");
+  assert.ok(result.includes("Bad request"), "should include message");
+});
+
+test("sanitizeErrorBody via auth failure path does not expose sensitive body content", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url) });
+    return new Response(
+      JSON.stringify({ message: "Unauthorized", internalToken: "leaked-token" }),
+      { status: 401, statusText: "Unauthorized" },
+    );
+  };
+
+  const client = new VroClient(config());
+  const err = await assert.rejects(
+    () => client.listWorkflows(),
+    (e) => {
+      assert.ok(!e.message.includes("leaked-token"), "should not expose internalToken value");
+      assert.ok(e.message.includes("Unauthorized"), "should include message field");
+      return true;
+    },
+  );
 });


### PR DESCRIPTION
## Summary

Resolves #48.

Raw HTTP response bodies were appended verbatim to thrown errors and surfaced directly to MCP callers. If vRO or VCF echoes sensitive request content in an error response (credentials, tokens, internal data), it would have been exposed.

## Changes

### `src/client/core.ts`
- Added exported `sanitizeErrorBody(rawText, res?)` helper:
  - For JSON bodies: extracts only `message`, `statusCode`, `code`, `error`, and `errors` fields. All other fields (including any sensitive keys) are dropped.
  - For non-JSON bodies: truncates to 200 characters to avoid unbounded exposure.
  - Optionally prepends a correlation ID header (`x-request-id`, `x-correlation-id`, or `x-vcf-requestid`) for diagnostic traceability.
  - `errors` array is capped at 5 items; each entry is reduced to its `message` string.
- Applied `sanitizeErrorBody` at both error sites in `authenticate()` and `request()`.

### 5 client files — 11 additional error sites
Updated imports and replaced `\n${text}` with `\n${sanitizeErrorBody(text, res)}` at all manual-fetch error sites in:
- `src/client/workflow-client.ts` — export and import workflow
- `src/client/action-client.ts` — export and import action
- `src/client/configuration-client.ts` — export and import configuration
- `src/client/resource-client.ts` — export resource, POST resource
- `src/client/package-client.ts` — export package, import package, package import details

### `test/vro-client.test.mjs`
Added 7 new tests:
1. Safe JSON fields (`message`, `statusCode`) are included
2. Sensitive JSON fields (`password`, `token`, `secret`) are stripped
3. Non-JSON HTML body is truncated with `[non-JSON body:]` prefix
4. Empty body produces empty output
5. Nested `errors` array messages are surfaced
6. Auth failure path does not expose sensitive body content
7. `x-request-id` correlation header is included when present

### `docs/operations/safety.md`
Added a note in the *Secrets* section documenting the sanitization behaviour.

## Validation

```
# tests 207
# pass  207
# fail    0
Validated docs drift and examples: 75 tools, 12 prompts, 18 resources, 27 markdown files.
build complete in 1.57s.
Validated npm package contents: 183 files, 967967 unpacked bytes.
```