### PR TITLE
[VCFO-038] Refresh expired VCFA bearer tokens instead of requiring server restart

### DIFF
--- a/docs/operations/safety.md
+++ b/docs/operations/safety.md
@@ -39,6 +39,10 @@ Configuration values and workflow/action scripts may contain sensitive informati
 
 API error messages are sanitized before being surfaced to MCP callers. Only safe diagnostic fields — HTTP status, endpoint, `message`, `statusCode`, `code`, `error`, and `errors` — are included. Raw response bodies are never passed through verbatim, which prevents vRO error responses from echoing sensitive request content such as credentials or tokens.
 
+## Token Refresh
+
+On the default VCFA platform, if a request receives a `401` or `403` response the server automatically clears the cached bearer token, re-authenticates, and retries the request exactly once. This covers JSON API calls, binary exports, and multipart uploads. A second consecutive failure after re-authentication is surfaced as an error without further retry. The `vra8` Basic-auth platform does not retry because a `401` means the credentials are wrong.
+
 ## Destructive Operations
 
 Before deletion, confirm:

--- a/src/client/action-client.ts
+++ b/src/client/action-client.ts
@@ -166,25 +166,14 @@ export class ActionClient {
   async exportActionBuffer(actionId: string): Promise<Buffer> {
     const path = `/actions/${encodeURIComponent(actionId)}`;
     this.http.assertOperationSupported("GET", path);
-    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] GET ${path}`);
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 60_000);
-    let res: Response;
-    try {
-      res = await fetch(url, {
-        method: "GET",
-        headers: {
-          Authorization: authorization,
-          Accept: "application/zip",
-        },
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeoutId);
-    }
+    const res = await this.http.authenticatedFetch(
+      url,
+      { method: "GET", headers: { Accept: "application/zip" } },
+      { timeout: 60_000 },
+    );
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(
@@ -247,26 +236,14 @@ export class ActionClient {
     form.append("categoryName", categoryName);
 
     this.http.assertOperationSupported("POST", path);
-    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] POST ${path}`);
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 60_000);
-    let res: Response;
-    try {
-      res = await fetch(url, {
-        method: "POST",
-        headers: {
-          Authorization: authorization,
-          Accept: "application/json",
-        },
-        body: form,
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeoutId);
-    }
+    const res = await this.http.authenticatedFetch(
+      url,
+      { method: "POST", headers: { Accept: "application/json" }, body: form },
+      { timeout: 60_000 },
+    );
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(

--- a/src/client/configuration-client.ts
+++ b/src/client/configuration-client.ts
@@ -135,25 +135,14 @@ export class ConfigurationClient {
 
     const path = `/configurations/${encodeURIComponent(id)}`;
     this.http.assertOperationSupported("GET", path);
-    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] GET ${path}`);
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 60_000);
-    let res: Response;
-    try {
-      res = await fetch(url, {
-        method: "GET",
-        headers: {
-          Authorization: authorization,
-          Accept: "application/zip",
-        },
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeoutId);
-    }
+    const res = await this.http.authenticatedFetch(
+      url,
+      { method: "GET", headers: { Accept: "application/zip" } },
+      { timeout: 60_000 },
+    );
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(
@@ -188,26 +177,14 @@ export class ConfigurationClient {
     form.append("categoryId", categoryId);
 
     this.http.assertOperationSupported("POST", path);
-    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] POST ${path}`);
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 60_000);
-    let res: Response;
-    try {
-      res = await fetch(url, {
-        method: "POST",
-        headers: {
-          Authorization: authorization,
-          Accept: "application/json",
-        },
-        body: form,
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeoutId);
-    }
+    const res = await this.http.authenticatedFetch(
+      url,
+      { method: "POST", headers: { Accept: "application/json" }, body: form },
+      { timeout: 60_000 },
+    );
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -244,6 +244,8 @@ export class VroHttpClient {
       (res.status === 401 || res.status === 403) &&
       this.targetPlatform !== "vra8"
     ) {
+      // Drain the rejected response body to release the socket promptly.
+      res.body?.cancel().catch(() => {});
       console.error(
         "[vro-client] Received %d, clearing cached token and re-authenticating…",
         res.status,

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -209,6 +209,54 @@ export class VroHttpClient {
     return `Bearer ${await this.ensureAuthenticated()}`;
   }
 
+  /**
+   * Perform an authenticated fetch with automatic token refresh on 401/403.
+   * On the default `vcfa` platform, if the response status is 401 or 403 the
+   * cached bearer token is cleared, a fresh token is obtained, and the request
+   * is retried exactly once.  The `vra8` Basic-auth platform never retries
+   * because a 401 means the credentials are wrong.
+   *
+   * Callers receive the raw `Response` and are responsible for checking
+   * `res.ok` and reading the body.
+   */
+  async authenticatedFetch(
+    url: string,
+    init: RequestInit & { headers: Record<string, string> },
+    options?: { timeout?: number },
+  ): Promise<Response> {
+    const timeout = options?.timeout ?? 30_000;
+    const authorization = await this.authorizationHeader();
+    init.headers["Authorization"] = authorization;
+
+    const doFetch = async (): Promise<Response> => {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), timeout);
+      try {
+        return await fetch(url, { ...init, signal: controller.signal });
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    };
+
+    const res = await doFetch();
+
+    if (
+      (res.status === 401 || res.status === 403) &&
+      this.targetPlatform !== "vra8"
+    ) {
+      console.error(
+        "[vro-client] Received %d, clearing cached token and re-authenticating…",
+        res.status,
+      );
+      this.token = null;
+      await this.authenticate();
+      init.headers["Authorization"] = await this.authorizationHeader();
+      return doFetch();
+    }
+
+    return res;
+  }
+
   assertOperationSupported(
     method: string,
     path: string,
@@ -239,12 +287,10 @@ export class VroHttpClient {
     overrideBaseUrl?: string,
   ): Promise<T> {
     this.assertOperationSupported(method, path, overrideBaseUrl);
-    const authorization = await this.authorizationHeader();
     const url = `${overrideBaseUrl ?? this.baseUrl}${path}`;
     console.error(`[vro-client] ${method} ${path}`);
 
     const headers: Record<string, string> = {
-      Authorization: authorization,
       Accept: "application/json",
     };
 
@@ -252,20 +298,14 @@ export class VroHttpClient {
       headers["Content-Type"] = "application/json";
     }
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 30_000);
-
-    let res: Response;
-    try {
-      res = await fetch(url, {
+    const res = await this.authenticatedFetch(
+      url,
+      {
         method,
         headers,
         body: body !== undefined ? JSON.stringify(body) : undefined,
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeoutId);
-    }
+      },
+    );
 
     if (!res.ok) {
       const text = await res.text().catch(() => "");

--- a/src/client/package-client.ts
+++ b/src/client/package-client.ts
@@ -220,25 +220,14 @@ export class PackageClient {
     const query = packageExportQuery(options);
     const path = `/content/packages/${encodeURIComponent(name)}${query}`;
     this.http.assertOperationSupported("GET", path);
-    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] GET ${path}`);
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 60_000);
-    let res: Response;
-    try {
-      res = await fetch(url, {
-        method: "GET",
-        headers: {
-          Authorization: authorization,
-          Accept: "application/zip",
-        },
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeoutId);
-    }
+    const res = await this.http.authenticatedFetch(
+      url,
+      { method: "GET", headers: { Accept: "application/zip" } },
+      { timeout: 60_000 },
+    );
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(
@@ -276,26 +265,14 @@ export class PackageClient {
     const form = new FormData();
     form.append("file", new Blob([new Uint8Array(buffer)]), fileName);
     this.http.assertOperationSupported("POST", path);
-    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] POST ${path}`);
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 60_000);
-    let res: Response;
-    try {
-      res = await fetch(url, {
-        method: "POST",
-        headers: {
-          Authorization: authorization,
-          Accept: "application/json",
-        },
-        body: form,
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeoutId);
-    }
+    const res = await this.http.authenticatedFetch(
+      url,
+      { method: "POST", headers: { Accept: "application/json" }, body: form },
+      { timeout: 60_000 },
+    );
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(
@@ -322,26 +299,14 @@ export class PackageClient {
     const form = new FormData();
     form.append("file", new Blob([new Uint8Array(buffer)]), fileName);
     this.http.assertOperationSupported("POST", path);
-    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] POST ${path}`);
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 60_000);
-    let res: Response;
-    try {
-      res = await fetch(url, {
-        method: "POST",
-        headers: {
-          Authorization: authorization,
-          Accept: "application/json",
-        },
-        body: form,
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeoutId);
-    }
+    const res = await this.http.authenticatedFetch(
+      url,
+      { method: "POST", headers: { Accept: "application/json" }, body: form },
+      { timeout: 60_000 },
+    );
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(

--- a/src/client/resource-client.ts
+++ b/src/client/resource-client.ts
@@ -78,25 +78,14 @@ export class ResourceClient {
     }
     const path = `/resources/${encodeURIComponent(id)}`;
     this.http.assertOperationSupported("GET", path);
-    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] GET ${path}`);
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 60_000);
-    let res: Response;
-    try {
-      res = await fetch(url, {
-        method: "GET",
-        headers: {
-          Authorization: authorization,
-          Accept: "*/*",
-        },
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeoutId);
-    }
+    const res = await this.http.authenticatedFetch(
+      url,
+      { method: "GET", headers: { Accept: "*/*" } },
+      { timeout: 60_000 },
+    );
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(
@@ -128,31 +117,21 @@ export class ResourceClient {
     changesetSha?: string,
   ): Promise<void> {
     this.http.assertOperationSupported("POST", path);
-    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] POST ${path}`);
 
     const headers: Record<string, string> = {
-      Authorization: authorization,
       Accept: "application/json",
     };
     if (changesetSha) {
       headers["X-VRO-Changeset-Sha"] = changesetSha;
     }
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 60_000);
-    let res: Response;
-    try {
-      res = await fetch(url, {
-        method: "POST",
-        headers,
-        body: form,
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeoutId);
-    }
+    const res = await this.http.authenticatedFetch(
+      url,
+      { method: "POST", headers, body: form },
+      { timeout: 60_000 },
+    );
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(

--- a/src/client/workflow-client.ts
+++ b/src/client/workflow-client.ts
@@ -796,25 +796,14 @@ export class WorkflowClient {
   async exportWorkflowBuffer(id: string): Promise<Buffer> {
     const path = `/content/workflows/${encodeURIComponent(id)}`;
     this.http.assertOperationSupported("GET", path);
-    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] GET ${path}`);
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 60_000);
-    let res: Response;
-    try {
-      res = await fetch(url, {
-        method: "GET",
-        headers: {
-          Authorization: authorization,
-          Accept: "application/zip",
-        },
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeoutId);
-    }
+    const res = await this.http.authenticatedFetch(
+      url,
+      { method: "GET", headers: { Accept: "application/zip" } },
+      { timeout: 60_000 },
+    );
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(
@@ -898,26 +887,14 @@ export class WorkflowClient {
     form.append("file", new Blob([new Uint8Array(buffer)]), fileName);
 
     this.http.assertOperationSupported("POST", path);
-    const authorization = await this.http.authorizationHeader();
     const url = `${this.http.baseUrl}${path}`;
     console.error(`[vro-client] POST ${path}`);
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 60_000);
-    let res: Response;
-    try {
-      res = await fetch(url, {
-        method: "POST",
-        headers: {
-          Authorization: authorization,
-          Accept: "application/json",
-        },
-        body: form,
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeoutId);
-    }
+    const res = await this.http.authenticatedFetch(
+      url,
+      { method: "POST", headers: { Accept: "application/json" }, body: form },
+      { timeout: 60_000 },
+    );
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(

--- a/test/vro-client.test.mjs
+++ b/test/vro-client.test.mjs
@@ -2469,3 +2469,158 @@ test("sanitizeErrorBody via auth failure path does not expose sensitive body con
     },
   );
 });
+
+// ─── Token refresh tests (VCFO-038) ──────────────────────────────────────────
+
+test("401 after cached token triggers one re-auth and retry then succeeds", async () => {
+  const calls = [];
+  let authCount = 0;
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    // Auth calls → always succeed
+    if (String(url).includes("/cloudapi/1.0.0/sessions")) {
+      authCount++;
+      return new Response("", {
+        status: 200,
+        headers: { "x-vmware-vcloud-access-token": `token-${authCount}` },
+      });
+    }
+    // First API call → 401 (stale token)
+    if (calls.filter((c) => !c.url.includes("/sessions")).length === 1) {
+      return new Response("", { status: 401, statusText: "Unauthorized" });
+    }
+    // Retry → success
+    return Response.json({ link: [], total: 0 });
+  };
+
+  const client = new VroClient(config());
+  const result = await client.listWorkflows();
+
+  assert.equal(result.total, 0);
+  // 1st auth + 1st API call (401) + 2nd auth (refresh) + retry = 4
+  assert.equal(calls.length, 4);
+  assert.equal(authCount, 2, "should have authenticated twice");
+  // The retry should use the refreshed token
+  const retryCall = calls[3];
+  assert.equal(retryCall.init.headers.Authorization, "Bearer token-2");
+});
+
+test("second consecutive 401 after re-auth is surfaced without infinite loop", async () => {
+  let authCount = 0;
+  globalThis.fetch = async (url) => {
+    if (String(url).includes("/cloudapi/1.0.0/sessions")) {
+      authCount++;
+      return new Response("", {
+        status: 200,
+        headers: { "x-vmware-vcloud-access-token": `token-${authCount}` },
+      });
+    }
+    // Always return 401
+    return new Response(JSON.stringify({ message: "Token rejected" }), {
+      status: 401,
+      statusText: "Unauthorized",
+    });
+  };
+
+  const client = new VroClient(config());
+  await assert.rejects(() => client.listWorkflows(), /401 Unauthorized/);
+  assert.equal(authCount, 2, "should authenticate exactly twice (initial + refresh)");
+});
+
+test("403 triggers the same token refresh as 401", async () => {
+  const calls = [];
+  let authCount = 0;
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url) });
+    if (String(url).includes("/cloudapi/1.0.0/sessions")) {
+      authCount++;
+      return new Response("", {
+        status: 200,
+        headers: { "x-vmware-vcloud-access-token": `token-${authCount}` },
+      });
+    }
+    if (calls.filter((c) => !c.url.includes("/sessions")).length === 1) {
+      return new Response("", { status: 403, statusText: "Forbidden" });
+    }
+    return Response.json({ link: [], total: 0 });
+  };
+
+  const client = new VroClient(config());
+  const result = await client.listWorkflows();
+  assert.equal(result.total, 0);
+  assert.equal(authCount, 2, "should re-authenticate on 403");
+});
+
+test("vra8 mode does NOT retry on 401 (Basic auth failure is terminal)", async () => {
+  const calls = [];
+  globalThis.fetch = async (url) => {
+    calls.push({ url: String(url) });
+    return new Response(JSON.stringify({ message: "Bad credentials" }), {
+      status: 401,
+      statusText: "Unauthorized",
+    });
+  };
+
+  const client = new VroClient(config({ targetPlatform: "vra8" }));
+  await assert.rejects(() => client.listWorkflows(), /401 Unauthorized/);
+  // Only one call — no re-auth attempt for vra8
+  assert.equal(calls.length, 1, "vra8 should not retry on 401");
+});
+
+test("manual binary export path retries on 401 with refreshed token", async () => {
+  let authCount = 0;
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (String(url).includes("/cloudapi/1.0.0/sessions")) {
+      authCount++;
+      return new Response("", {
+        status: 200,
+        headers: { "x-vmware-vcloud-access-token": `token-${authCount}` },
+      });
+    }
+    // First content call → 401
+    if (calls.filter((c) => c.url.includes("/content/workflows/")).length === 1) {
+      return new Response("", { status: 401, statusText: "Unauthorized" });
+    }
+    // Retry → return a minimal zip buffer
+    return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
+      status: 200,
+      headers: { "Content-Type": "application/zip" },
+    });
+  };
+
+  const client = new VroClient(config());
+  // exportWorkflowBuffer is the manual-fetch binary path
+  const buffer = await client.exportWorkflowBuffer("wf-1");
+  assert.ok(Buffer.isBuffer(buffer), "should return a Buffer");
+  assert.equal(authCount, 2, "should have re-authenticated for binary export");
+});
+
+test("token refresh does not re-authenticate when authenticate() itself fails", async () => {
+  let authCount = 0;
+  globalThis.fetch = async (url) => {
+    if (String(url).includes("/cloudapi/1.0.0/sessions")) {
+      authCount++;
+      if (authCount === 1) {
+        return new Response("", {
+          status: 200,
+          headers: { "x-vmware-vcloud-access-token": "token-1" },
+        });
+      }
+      // Second auth attempt fails
+      return new Response(JSON.stringify({ message: "Service unavailable" }), {
+        status: 503,
+        statusText: "Service Unavailable",
+      });
+    }
+    return new Response("", { status: 401, statusText: "Unauthorized" });
+  };
+
+  const client = new VroClient(config());
+  await assert.rejects(
+    () => client.listWorkflows(),
+    /VCF authentication failed: 503/,
+  );
+  assert.equal(authCount, 2, "should attempt re-auth once then surface the auth failure");
+});


### PR DESCRIPTION
## Summary

Resolves #47.

The VCFA HTTP client cached the Cloud API bearer token for the lifetime of the MCP server and did not recover when that token expired. In a long-running session, once VCFA started returning `401` or `403`, every subsequent API call failed until the server was restarted.

## Changes

### `src/client/core.ts`
- Added `authenticatedFetch(url, init, options?)` method that:
  - Gets the auth header via `authorizationHeader()`
  - Wraps `fetch()` in an `AbortController` with configurable timeout (default 30s)
  - On `401`/`403` when `targetPlatform !== "vra8"`: clears `this.token`, calls `authenticate()`, and retries exactly once
  - Returns the raw `Response` (caller handles ok/error)
- Refactored `request()` to delegate to `authenticatedFetch()` instead of duplicating the auth+fetch+timeout pattern

### 5 client files — 11 inline fetch sites replaced
Replaced all manual `authorizationHeader() + AbortController + fetch + clearTimeout` boilerplate with `this.http.authenticatedFetch(url, init, { timeout: 60_000 })`:
- `src/client/workflow-client.ts` — export and import workflow
- `src/client/action-client.ts` — export and import action
- `src/client/configuration-client.ts` — export and import configuration
- `src/client/resource-client.ts` — export resource, POST resource
- `src/client/package-client.ts` — export package, import package, package import details

This eliminates ~100 lines of duplicated boilerplate and ensures all code paths (JSON, binary export, multipart upload) share consistent token refresh behavior.

### `test/vro-client.test.mjs`
Added 6 new tests:
1. `401` after cached token → one re-auth + retry → success
2. Second consecutive `401` after re-auth → error surfaced (no infinite loop)
3. `403` triggers the same refresh as `401`
4. vra8 mode does NOT retry on `401` (Basic auth failure is terminal)
5. Manual binary export path retries on `401` with refreshed token
6. Re-auth failure during refresh is propagated cleanly

### `docs/operations/safety.md`
Added *Token Refresh* section documenting the automatic refresh behavior and its bounds.

## Validation

```
# tests 213
# pass  213
# fail    0
Validated docs drift and examples: 75 tools, 12 prompts, 18 resources, 27 markdown files.
build complete in 1.54s.
Validated npm package contents: 183 files, 963334 unpacked bytes.
```