### PR TITLE
[VCFO-047] Validate run-workflow inputs via shared preamble

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -152,13 +152,13 @@ Delete a workflow from VCF Automation Orchestrator. This action is irreversible.
 
 ### `run-workflow`
 
-Execute a workflow with optional input parameters. Returns the execution ID; use `get-workflow-execution` to poll status and retrieve outputs.
+Validate inputs against the workflow definition, then execute the workflow with optional input parameters. Returns the execution ID; use `get-workflow-execution` to poll status and retrieve outputs.
 
 ::: details Parameters
 | Parameter | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `id` | string | Yes | - | Workflow ID to execute. |
-| `inputs` | array | No | `[]` | Input parameters for the workflow execution. Inspect the workflow with `get-workflow` before running. |
+| `inputs` | array | No | `[]` | Input parameters for the workflow execution. Inspect the workflow with `get-workflow` before running. Inputs are validated and type-normalized against the workflow definition before execution. |
 | `expectedWorkflowName` | string | No | - | Expected live workflow name to verify before execution. |
 | `expectedInputNames` | string[] | No | - | Expected workflow input names, in discovered order, to verify before execution. |
 | `confirm` | boolean | Yes | - | Must be `true` to confirm execution. If `false`, the workflow is not run. |
@@ -168,8 +168,8 @@ Execute a workflow with optional input parameters. Returns the execution ID; use
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `name` | string | Yes | Parameter name matching a workflow input parameter. |
-| `type` | string | Yes | vRO parameter type, such as `string`, `number`, `boolean`, `Array/string`, or `Properties`. |
-| `value` | any | Yes | Parameter value compatible with the declared type. |
+| `type` | string | No | Optional vRO parameter type. When omitted, this tool uses the type from `get-workflow`. |
+| `value` | any | Yes | Parameter value compatible with the workflow input type. |
 :::
 
 ### `run-workflow-and-wait`

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -280,6 +280,60 @@ function formatValidationErrors(workflow: Workflow, errors: string[]): string {
   ].join("\n");
 }
 
+type WorkflowRunPreamble =
+  | { error: CallToolResult }
+  | { workflow: Workflow; inputs: SimpleParameter[] };
+
+/**
+ * Shared pre-execution path for run-workflow and run-workflow-and-wait: fetch the
+ * live workflow, apply the optional expected-field guards, then validate and
+ * type-normalize the caller inputs. Returns either a short-circuit error result or
+ * the fetched workflow plus normalized inputs ready for client.runWorkflow.
+ */
+async function prepareWorkflowRun(
+  client: VroClient,
+  id: string,
+  inputs: { name: string; type?: string; value?: unknown }[] | undefined,
+  expectedWorkflowName: string | undefined,
+  expectedInputNames: string[] | undefined,
+): Promise<WorkflowRunPreamble> {
+  const workflow = await client.getWorkflow(id);
+
+  const guard = guardExpectedFields(`workflow ${id}`, [
+    {
+      label: "workflow name",
+      expected: expectedWorkflowName,
+      actual: workflow.name,
+    },
+  ]);
+  if (guard) return { error: guard };
+
+  const inputGuard = guardExpectedStringList(
+    `workflow ${id}`,
+    "input names",
+    expectedInputNames,
+    getWorkflowInputParameters(workflow).map((input) => input.name),
+  );
+  if (inputGuard) return { error: inputGuard };
+
+  const validation = validateWorkflowRunInputs(workflow, inputs ?? []);
+  if (validation.errors.length > 0) {
+    return {
+      error: {
+        content: [
+          {
+            type: "text",
+            text: formatValidationErrors(workflow, validation.errors),
+          },
+        ],
+        isError: true,
+      },
+    };
+  }
+
+  return { workflow, inputs: validation.inputs };
+}
+
 function formatOutputParameters(execution: WorkflowExecution): string {
   const outputs = getExecutionOutputParameters(execution);
   if (outputs.length === 0) {
@@ -642,7 +696,7 @@ export function registerWorkflowTools(
     {
       title: "Run Workflow",
       description:
-        "Execute a workflow. Optionally provide input parameters. Returns the execution ID which can be used with get-workflow-execution to check status.",
+        "Validate inputs against the workflow definition, then execute the workflow. Optionally provide input parameters. Returns the execution ID which can be used with get-workflow-execution to check status.",
       inputSchema: z.object({
         id: z.string().describe("The workflow ID to execute"),
         inputs: z
@@ -651,8 +705,9 @@ export function registerWorkflowTools(
               name: z.string().describe("Parameter name"),
               type: z
                 .string()
+                .optional()
                 .describe(
-                  "Parameter type (e.g. string, number, boolean, Array/string)",
+                  "Optional parameter type. If omitted, the workflow definition type is used.",
                 ),
               value: z.unknown().describe("Parameter value"),
             }),
@@ -698,27 +753,16 @@ export function registerWorkflowTools(
       }
 
       try {
-        if (hasAnyExpectedValue({ expectedWorkflowName, expectedInputNames })) {
-          const workflow = await client.getWorkflow(id);
-          const guard = guardExpectedFields(`workflow ${id}`, [
-            {
-              label: "workflow name",
-              expected: expectedWorkflowName,
-              actual: workflow.name,
-            },
-          ]);
-          if (guard) return guard;
+        const prep = await prepareWorkflowRun(
+          client,
+          id,
+          inputs,
+          expectedWorkflowName,
+          expectedInputNames,
+        );
+        if ("error" in prep) return prep.error;
 
-          const inputGuard = guardExpectedStringList(
-            `workflow ${id}`,
-            "input names",
-            expectedInputNames,
-            getWorkflowInputParameters(workflow).map((input) => input.name),
-          );
-          if (inputGuard) return inputGuard;
-        }
-
-        const exec = await client.runWorkflow(id, inputs);
+        const exec = await client.runWorkflow(id, prep.inputs);
         return {
           content: [
             {
@@ -827,36 +871,15 @@ export function registerWorkflowTools(
       }
 
       try {
-        const workflow = await client.getWorkflow(id);
-        const guard = guardExpectedFields(`workflow ${id}`, [
-          {
-            label: "workflow name",
-            expected: expectedWorkflowName,
-            actual: workflow.name,
-          },
-        ]);
-        if (guard) return guard;
-
-        const inputGuard = guardExpectedStringList(
-          `workflow ${id}`,
-          "input names",
+        const prep = await prepareWorkflowRun(
+          client,
+          id,
+          inputs,
+          expectedWorkflowName,
           expectedInputNames,
-          getWorkflowInputParameters(workflow).map((input) => input.name),
         );
-        if (inputGuard) return inputGuard;
-
-        const validation = validateWorkflowRunInputs(workflow, inputs ?? []);
-        if (validation.errors.length > 0) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: formatValidationErrors(workflow, validation.errors),
-              },
-            ],
-            isError: true,
-          };
-        }
+        if ("error" in prep) return prep.error;
+        const { workflow, inputs: normalizedInputs } = prep;
 
         const timeoutMs = Math.max(
           0,
@@ -871,7 +894,7 @@ export function registerWorkflowTools(
         const waitStartedAt = Date.now();
         const deadline = waitStartedAt + timeoutMs;
 
-        startedExecution = await client.runWorkflow(id, validation.inputs);
+        startedExecution = await client.runWorkflow(id, normalizedInputs);
         if (!startedExecution.id) {
           throw new Error("Workflow execution did not return an execution ID");
         }

--- a/test/workflow-tools.test.mjs
+++ b/test/workflow-tools.test.mjs
@@ -320,6 +320,68 @@ test("run-workflow expected guards stop before execution on mismatch", async () 
   assert.match(result.content[0].text, /workflow name/);
 });
 
+test("run-workflow rejects invalid inputs before running", async () => {
+  let runCalls = 0;
+  const handlers = registeredWorkflowTools({
+    getWorkflow: async () => ({
+      id: "workflow-1",
+      name: "Workflow",
+      inputParameters: [
+        { name: "projectName", type: "string" },
+        { name: "count", type: "number" },
+      ],
+    }),
+    runWorkflow: async () => {
+      runCalls += 1;
+      return { id: "execution-1", state: "running" };
+    },
+  });
+
+  const result = await handlers.get("run-workflow")({
+    id: "workflow-1",
+    confirm: true,
+    inputs: [
+      { name: "projectName", type: "string", value: 123 },
+      { name: "projectName", type: "string", value: "duplicate" },
+      { name: "extra", type: "string", value: "unused" },
+    ],
+  });
+
+  assert.equal(result.isError, true);
+  assert.equal(runCalls, 0);
+  assert.match(result.content[0].text, /Input projectName must be a string/);
+  assert.match(result.content[0].text, /Duplicate input: projectName/);
+  assert.match(result.content[0].text, /Unknown input: extra/);
+  assert.match(result.content[0].text, /Missing required input: count/);
+});
+
+test("run-workflow normalizes input types before execution", async () => {
+  let runInputs;
+  const handlers = registeredWorkflowTools({
+    getWorkflow: async () => ({
+      id: "workflow-1",
+      name: "Workflow",
+      inputParameters: [{ name: "name", type: "string" }],
+    }),
+    runWorkflow: async (_id, inputs) => {
+      runInputs = inputs;
+      return { id: "execution-1", state: "running" };
+    },
+  });
+
+  const result = await handlers.get("run-workflow")({
+    id: "workflow-1",
+    confirm: true,
+    inputs: [{ name: "name", value: "web-server-01" }],
+  });
+
+  assert.equal(result.isError, undefined);
+  assert.deepEqual(runInputs, [
+    { name: "name", type: "string", value: "web-server-01" },
+  ]);
+  assert.match(result.content[0].text, /Workflow execution started/);
+});
+
 test("run-workflow-and-wait verifies expected input names before running", async () => {
   let runCalls = 0;
   const handlers = registeredWorkflowTools({


### PR DESCRIPTION
## Summary

`run-workflow` was the only execution path that POSTed caller-supplied inputs straight to the live workflow without running `validateWorkflowRunInputs`, while its sibling `run-workflow-and-wait` validated and type-normalized the same inputs. The two handlers also duplicated the "fetch workflow → expected-field guards → validate/normalize" preamble and had already drifted (`inputs[].type` was required in one, optional in the other).

## Changes

- Extract a shared `prepareWorkflowRun` helper in `src/tools/workflow-tools.ts` (fetch workflow → expected-field guards → validate/normalize) used by both `run-workflow` and `run-workflow-and-wait`, so the validation/normalization path cannot drift again.
- `run-workflow` now validates inputs and rejects unknown/duplicate/wrong-typed/missing inputs with the same diagnostics as `run-workflow-and-wait`, before execution. Normalized inputs (type resolved from the workflow definition) are passed to `client.runWorkflow`.
- Align `run-workflow`'s `inputs[].type` to optional to match the sibling tool.
- Tests: `run-workflow` rejects invalid inputs without calling `client.runWorkflow`, and normalizes input types on the happy path.
- Update `docs/reference/tools.md`.

## Verification

- `npm run build` — clean
- `npm test` — 239 tests pass
- `npm run test:coverage:check` — gate passes
- `npm run validate:docs` — no drift

## Acceptance criteria

- ✅ `run-workflow` rejects inputs that fail `validateWorkflowRunInputs` with the same diagnostics as `run-workflow-and-wait`
- ✅ Both tools share the validation/normalization path
- ✅ A new test asserts `run-workflow` rejects invalid input without calling `client.runWorkflow`

Closes #72

https://claude.ai/code/session_015itudSkapTSuj3UvLuRsMw

---
_Generated by [Claude Code](https://claude.ai/code/session_015itudSkapTSuj3UvLuRsMw)_