### PR TITLE
[VCFO-048] Redact SecureString attribute values in get-configuration

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -474,7 +474,7 @@ List configuration elements from VCF Automation Orchestrator. Optionally filter 
 
 ### `get-configuration`
 
-Get detailed information about a specific configuration element including its attributes.
+Get detailed information about a specific configuration element including its attributes. Secure-typed attribute values (e.g. `SecureString`) are redacted in the output and shown as `[redacted]`, consistent with the context-snapshot redaction policy.
 
 ::: details Parameters
 | Parameter | Type | Required | Default | Description |

--- a/src/tools/config-tools.ts
+++ b/src/tools/config-tools.ts
@@ -10,6 +10,18 @@ import {
   hasAnyExpectedValue,
 } from "./confirmation-guards.js";
 
+/**
+ * Detects secure/encrypted configuration attribute types whose values must never
+ * be printed (e.g. vRO `SecureString`). The `includes` checks are defensive against
+ * any encrypted/secure variant the API returns. Mirrors the redaction posture of the
+ * context-snapshot path (`src/client/context-snapshot.ts`).
+ */
+function isSecureAttributeType(type: string | undefined): boolean {
+  if (!type) return false;
+  const t = type.toLowerCase();
+  return t === "securestring" || t.includes("secure") || t.includes("encrypted");
+}
+
 export function registerConfigTools(
   server: McpServer,
   client: VroClient,
@@ -97,7 +109,11 @@ export function registerConfigTools(
         if (attrs.length > 0) {
           text += `\nAttributes:\n`;
           for (const a of attrs) {
-            const val = a.value ? JSON.stringify(a.value) : "(no value)";
+            const val = isSecureAttributeType(a.type)
+              ? "[redacted]"
+              : a.value
+                ? JSON.stringify(a.value)
+                : "(no value)";
             text += `  • ${a.name} (${a.type}): ${val}${a.description ? ` — ${a.description}` : ""}\n`;
           }
         } else {

--- a/test/artifact-tools.test.mjs
+++ b/test/artifact-tools.test.mjs
@@ -118,6 +118,12 @@ test("configuration tools format attributes and guard imports and deletes", asyn
           value: { string: { value: "vcfa.example.test" } },
           description: "Host name",
         },
+        {
+          name: "password",
+          type: "SecureString",
+          value: { string: { value: "super-secret" } },
+          description: "Admin password",
+        },
       ],
     }),
     createConfiguration: async (categoryId, name, description, attributes) => {
@@ -151,7 +157,11 @@ test("configuration tools format attributes and guard imports and deletes", asyn
   const detail = await handlers.get("get-configuration")({ id: "config-1" });
   assert.match(detail.content[0].text, /Configuration: Settings/);
   assert.match(detail.content[0].text, /host \(string\):/);
+  assert.match(detail.content[0].text, /vcfa\.example\.test/);
   assert.match(detail.content[0].text, /Host name/);
+  // Secure-typed attribute values must be redacted, never printed in cleartext.
+  assert.match(detail.content[0].text, /password \(SecureString\): \[redacted\]/);
+  assert.doesNotMatch(detail.content[0].text, /super-secret/);
 
   const createResult = await handlers.get("create-configuration")({
     categoryId: "category-1",


### PR DESCRIPTION
get-configuration printed every configuration attribute value verbatim,
leaking SecureString / secret-typed values (passwords, tokens, keys) into
the MCP transcript. This contradicted the project's "never print secrets"
rule and the context-snapshot path, which already redacts the same values.

Mask values for secure-typed attributes (SecureString and any
secure/encrypted variant) by default, showing [redacted] regardless of
whether a value is present. Non-secret values remain visible for debugging.

Adds a test asserting a SecureString value is redacted and never appears in
cleartext, and documents the behavior in docs/reference/tools.md.