### PR TITLE
[VCFO-049] Scope ignoreTls TLS relaxation to client requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@ VCFA_USERNAME=administrator
 VCFA_ORGANIZATION=your-organization-here
 VCFA_PASSWORD=your-password-here
 
-# Set to "true" to allow self-signed TLS certificates (common in lab environments)
+# Set to "true" to allow self-signed TLS certificates for requests to the
+# configured VCFA host only (common in lab environments)
 VCFA_IGNORE_TLS=false
 
 # Optional: override the local root directory for artifact import/export files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Security
+
+- `VCFA_IGNORE_TLS=true` no longer disables TLS certificate verification process-wide via `NODE_TLS_REJECT_UNAUTHORIZED`. TLS relaxation is now scoped to the client's own requests to the configured VCFA host through a dedicated HTTPS agent, so other HTTPS traffic in the same Node process keeps full certificate verification. The minimum supported Node.js version is now 18.17.
+
 ## 2.0.0 - 2026-05-18
 
 This release tightens live-operation safety, improves authentication and error handling, refreshes dependencies and documentation, and adopts Apache License 2.0 with NOTICE attribution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `VCFA_IGNORE_TLS=true` no longer disables TLS certificate verification process-wide via `NODE_TLS_REJECT_UNAUTHORIZED`. TLS relaxation is now scoped to the client's own requests to the configured VCFA host through a dedicated HTTPS agent, so other HTTPS traffic in the same Node process keeps full certificate verification. The minimum supported Node.js version is now 18.17.
 
+### Added
+
+- Added `VroClient.close()` to release the client's network resources (the TLS-relaxed dispatcher); the server now calls it during graceful shutdown.
+
 ## 2.0.0 - 2026-05-18
 
 This release tightens live-operation safety, improves authentication and error handling, refreshes dependencies and documentation, and adopts Apache License 2.0 with NOTICE attribution.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Required at startup (the process exits if any is missing): `VCFA_HOST`, `VCFA_US
 Notable optional variables (see `.env.example` and `README.md` for the full table):
 
 - `VCFA_TARGET_PLATFORM` – `vcfa` (default, VCF Cloud API session flow) or `vra8` (vRA/vRO 8.12+ Basic-auth against `/vco/api`). `vra8` supports only vRO read operations plus workflow execution/logs; Automation-service APIs (catalog, deployments, templates, subscriptions, event topics) are intentionally unsupported in that mode.
-- `VCFA_IGNORE_TLS` – `true` skips TLS verification (lab use only).
+- `VCFA_IGNORE_TLS` – `true` skips TLS verification for the client's VCFA requests only (lab use only).
 - Artifact directories: `VCFA_ARTIFACT_DIR` (root, defaults to `artifacts/` under the process cwd) and per-kind overrides `VCFA_WORKFLOW_DIR`, `VCFA_ACTION_DIR`, `VCFA_CONFIGURATION_DIR`, `VCFA_RESOURCE_DIR`, `VCFA_PACKAGE_DIR`, `VCFA_EXECUTION_LOG_DIR`, `VCFA_CONTEXT_DIR`.
 - Package-first publishing: `VCFA_PROJECT_PACKAGE_NAME` (stable fully-qualified package, e.g. `com.example.project`) and `VCFA_PROJECT_PACKAGE_DESCRIPTION`.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Useful optional variables:
 | Variable | Description |
 | --- | --- |
 | `VCFA_TARGET_PLATFORM` | Target platform mode. Defaults to `vcfa`, which uses the VCF Cloud API session flow. Set to `vra8` for vRA/vRO 8.12+ Basic-auth mode against `/vco/api`; this mode supports vRO read operations plus workflow execution/logs and does not support Automation-service APIs such as catalog, deployments, templates, or subscriptions. |
-| `VCFA_IGNORE_TLS` | Set to `true` to skip TLS certificate verification in lab environments. |
+| `VCFA_IGNORE_TLS` | Set to `true` to skip TLS certificate verification for this server's requests to the VCFA host (lab environments only). |
 | `VCFA_ARTIFACT_DIR` | Root directory for local artifact files. Defaults to `artifacts/` in the MCP server process working directory, typically the open project. |
 | `VCFA_PACKAGE_DIR` | Override package artifact directory. |
 | `VCFA_RESOURCE_DIR` | Override resource artifact directory. |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -26,7 +26,7 @@ For vRA/vRO 8.12+ read/run compatibility, set `VCFA_TARGET_PLATFORM=vra8`. In th
 | Variable | Description |
 | --- | --- |
 | `VCFA_TARGET_PLATFORM` | Target platform mode: `vcfa` (default) or `vra8`. |
-| `VCFA_IGNORE_TLS` | Set to `true` to disable TLS certificate verification for lab environments. |
+| `VCFA_IGNORE_TLS` | Set to `true` to disable TLS certificate verification for this server's requests to the VCFA host (lab environments only). |
 | `VCFA_ARTIFACT_DIR` | Root directory for local artifact import/export files. Defaults to `artifacts/` in the MCP server process working directory, typically the open project. |
 | `VCFA_PACKAGE_DIR` | Override the package artifact directory. |
 | `VCFA_RESOURCE_DIR` | Override the resource element artifact directory. |
@@ -57,4 +57,4 @@ Use the specific directory overrides only when you need different storage locati
 
 ## TLS Warning
 
-`VCFA_IGNORE_TLS=true` sets `NODE_TLS_REJECT_UNAUTHORIZED=0` for the process. Use it only for lab or test environments where the risk is understood.
+`VCFA_IGNORE_TLS=true` disables TLS certificate verification only for this server's requests to the configured VCFA host, using a dedicated HTTPS agent. It does not set `NODE_TLS_REJECT_UNAUTHORIZED` or affect any other HTTPS traffic in the process. Use it only for lab or test environments where the risk is understood.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "fast-xml-parser": "^5.7.2",
         "fflate": "^0.8.2",
+        "undici": "^6.26.0",
         "zod": "^4.4.2"
       },
       "bin": {
@@ -24,7 +25,7 @@
         "vitepress": "^1.6.4"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.17.0"
       },
       "funding": {
         "type": "github",
@@ -3583,6 +3584,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "fast-xml-parser": "^5.7.2",
     "fflate": "^0.8.2",
+    "undici": "^6.26.0",
     "zod": "^4.4.2"
   },
   "devDependencies": {
@@ -68,6 +69,6 @@
     "vite": "6.4.2"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.17.0"
   }
 }

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -1,5 +1,6 @@
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { Agent } from "undici";
 import type { VroClientConfig, VroTargetPlatform } from "../types.js";
 
 const UNSUPPORTED_AUTOMATION_SERVICES =
@@ -110,12 +111,15 @@ export class VroHttpClient {
   private sessionUrl: string;
   private loginHeader: string;
   private token: string | null = null;
+  // Per-client dispatcher so ignoreTls relaxes TLS verification only for
+  // this client's requests, never process-wide (no NODE_TLS_REJECT_UNAUTHORIZED).
+  private readonly dispatcher: Agent | undefined;
 
   constructor(config: VroClientConfig) {
     this.targetPlatform = normalizeTargetPlatform(config.targetPlatform);
-    if (config.ignoreTls) {
-      process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = "0";
-    }
+    this.dispatcher = config.ignoreTls
+      ? new Agent({ connect: { rejectUnauthorized: false } })
+      : undefined;
     this.baseUrl = `https://${config.host}/vco/api`;
     this.eventBrokerBaseUrl = `https://${config.host}/event-broker/api`;
     this.catalogBaseUrl = `https://${config.host}/catalog/api`;
@@ -171,7 +175,7 @@ export class VroHttpClient {
 
     let res: Response;
     try {
-      res = await fetch(this.sessionUrl, {
+      const init: RequestInit & { dispatcher?: Agent } = {
         method: "POST",
         headers: {
           Authorization: this.loginHeader,
@@ -179,7 +183,9 @@ export class VroHttpClient {
           Accept: "application/json;version=9.0.0",
         },
         signal: controller.signal,
-      });
+        dispatcher: this.dispatcher,
+      };
+      res = await fetch(this.sessionUrl, init);
     } finally {
       clearTimeout(timeoutId);
     }
@@ -232,7 +238,12 @@ export class VroHttpClient {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), timeout);
       try {
-        return await fetch(url, { ...init, signal: controller.signal });
+        const fetchInit: RequestInit & { dispatcher?: Agent } = {
+          ...init,
+          signal: controller.signal,
+          dispatcher: this.dispatcher,
+        };
+        return await fetch(url, fetchInit);
       } finally {
         clearTimeout(timeoutId);
       }

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -9,6 +9,10 @@ const UNSUPPORTED_AUTOMATION_SERVICES =
 const UNSUPPORTED_VRO_WRITE =
   "This vRO operation is not supported in VCFA_TARGET_PLATFORM=vra8 mode. The vRA/vRO 8 compatibility phase supports read operations plus workflow execution and execution logs only.";
 
+// The default TypeScript lib's RequestInit lacks undici's dispatcher option,
+// which Node's built-in fetch honors at runtime.
+type DispatchedRequestInit = RequestInit & { dispatcher?: Agent };
+
 const SAFE_ERROR_BODY_KEYS = new Set(["message", "statusCode", "code", "error", "errors"]);
 const NON_JSON_BODY_LIMIT = 200;
 const ERRORS_ARRAY_LIMIT = 5;
@@ -114,6 +118,7 @@ export class VroHttpClient {
   // Per-client dispatcher so ignoreTls relaxes TLS verification only for
   // this client's requests, never process-wide (no NODE_TLS_REJECT_UNAUTHORIZED).
   private readonly dispatcher: Agent | undefined;
+  private dispatcherClosed = false;
 
   constructor(config: VroClientConfig) {
     this.targetPlatform = normalizeTargetPlatform(config.targetPlatform);
@@ -155,6 +160,18 @@ export class VroHttpClient {
       ).toString("base64");
   }
 
+  /**
+   * Release the client's network resources. Closes the TLS-relaxed
+   * dispatcher (if `ignoreTls` was configured) so its keep-alive sockets
+   * do not linger until process exit. Safe to call multiple times.
+   */
+  async close(): Promise<void> {
+    if (this.dispatcher && !this.dispatcherClosed) {
+      this.dispatcherClosed = true;
+      await this.dispatcher.close();
+    }
+  }
+
   async ensureAuthenticated(): Promise<string> {
     if (this.targetPlatform === "vra8") {
       return this.loginHeader;
@@ -175,7 +192,7 @@ export class VroHttpClient {
 
     let res: Response;
     try {
-      const init: RequestInit & { dispatcher?: Agent } = {
+      const init: DispatchedRequestInit = {
         method: "POST",
         headers: {
           Authorization: this.loginHeader,
@@ -238,7 +255,7 @@ export class VroHttpClient {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), timeout);
       try {
-        const fetchInit: RequestInit & { dispatcher?: Agent } = {
+        const fetchInit: DispatchedRequestInit = {
           ...init,
           signal: controller.signal,
           dispatcher: this.dispatcher,

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -99,6 +99,11 @@ export class VroClient {
     this.plugins = new PluginClient(http);
   }
 
+  /** Release network resources (e.g. the TLS-relaxed dispatcher). */
+  close(): Promise<void> {
+    return this.http.close();
+  }
+
   listWorkflows(filter?: string): Promise<WorkflowList> {
     return this.workflows.listWorkflows(filter);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,7 @@ async function main(): Promise<void> {
   process.on("SIGINT", async () => {
     console.error("[vcfa-server] Shutting down...");
     await server.close();
+    await client.close();
     process.exit(0);
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,9 +60,8 @@ async function main(): Promise<void> {
   const contextDir = process.env["VCFA_CONTEXT_DIR"];
 
   if (ignoreTls) {
-    process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = "0";
     console.error(
-      "[vcfa-server] WARNING: TLS certificate verification disabled (VCFA_IGNORE_TLS=true)",
+      "[vcfa-server] WARNING: TLS certificate verification disabled for VCFA requests (VCFA_IGNORE_TLS=true)",
     );
   }
 

--- a/test/vro-client.test.mjs
+++ b/test/vro-client.test.mjs
@@ -1994,13 +1994,13 @@ test("deletePackage sends documented option query", async () => {
   assert.equal(calls[1].init.method, "DELETE");
 });
 
-test("ignoreTls config disables TLS verification for library callers", () => {
+test("ignoreTls config does not mutate NODE_TLS_REJECT_UNAUTHORIZED", () => {
   const previous = process.env["NODE_TLS_REJECT_UNAUTHORIZED"];
 
   try {
     delete process.env["NODE_TLS_REJECT_UNAUTHORIZED"];
     new VroClient(config({ ignoreTls: true }));
-    assert.equal(process.env["NODE_TLS_REJECT_UNAUTHORIZED"], "0");
+    assert.equal(process.env["NODE_TLS_REJECT_UNAUTHORIZED"], undefined);
   } finally {
     if (previous === undefined) {
       delete process.env["NODE_TLS_REJECT_UNAUTHORIZED"];
@@ -2008,6 +2008,46 @@ test("ignoreTls config disables TLS verification for library callers", () => {
       process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = previous;
     }
   }
+});
+
+test("ignoreTls config scopes TLS relaxation to the client's own requests", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    return Response.json({ link: [], total: 0 });
+  };
+
+  const client = new VroClient(config({ ignoreTls: true }));
+  await client.listWorkflows();
+
+  assert.equal(
+    calls[0].url,
+    "https://vcfa.example.test/cloudapi/1.0.0/sessions",
+  );
+  assert.ok(
+    calls[0].init.dispatcher,
+    "session auth call should carry a TLS-relaxed dispatcher",
+  );
+  assert.ok(
+    calls[1].init.dispatcher,
+    "authenticated API call should carry a TLS-relaxed dispatcher",
+  );
+});
+
+test("requests carry no dispatcher when ignoreTls is not set", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    return Response.json({ link: [], total: 0 });
+  };
+
+  const client = new VroClient(config());
+  await client.listWorkflows();
+
+  assert.equal(calls[0].init.dispatcher, undefined);
+  assert.equal(calls[1].init.dispatcher, undefined);
 });
 
 test("workflow import rejects path traversal before network calls", async () => {

--- a/test/vro-client.test.mjs
+++ b/test/vro-client.test.mjs
@@ -2035,6 +2035,15 @@ test("ignoreTls config scopes TLS relaxation to the client's own requests", asyn
   );
 });
 
+test("close releases the TLS-relaxed dispatcher and is idempotent", async () => {
+  const relaxed = new VroClient(config({ ignoreTls: true }));
+  await relaxed.close();
+  await relaxed.close();
+
+  const strict = new VroClient(config());
+  await strict.close();
+});
+
 test("requests carry no dispatcher when ignoreTls is not set", async () => {
   const calls = [];
   globalThis.fetch = async (url, init) => {


### PR DESCRIPTION
## Summary

`VCFA_IGNORE_TLS=true` previously set `process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"` in both the `VroClient` constructor (`src/client/core.ts`) and server startup (`src/index.ts`), disabling TLS certificate verification **process-wide and permanently** — affecting all outbound HTTPS from the Node process, not just requests to the configured VCFA host.

Closes #74

## Changes

- **Scoped dispatcher**: the client now creates a per-instance undici `Agent` with `connect: { rejectUnauthorized: false }` when `ignoreTls` is set, and passes it as the fetch `dispatcher` in both `authenticate()` and `authenticatedFetch()` — the only two fetch call sites in `src/`. All other client modules (including package export/import) route through these, so both `vcfa` and `vra8` platforms are covered.
- **No global mutation**: both `NODE_TLS_REJECT_UNAUTHORIZED` writes are removed; the startup warning is kept (reworded to clarify the scope).
- **Dependency**: added `undici@^6`; bumped `engines.node` to `>=18.17.0` to match undici v6's floor.
- **Tests**: rewrote the old test that asserted the env var was set to `"0"` — it now asserts the env var stays untouched with `ignoreTls: true` — and added tests asserting the dispatcher is threaded into both the session-auth call and authenticated API calls (and absent when `ignoreTls` is not set).
- **Docs**: updated `README.md`, `CLAUDE.md`, `docs/guide/configuration.md` (which explicitly documented the process-wide behavior), `.env.example`, and added a `CHANGELOG.md` Unreleased entry.

## Acceptance criteria (from #74)

- [x] `ignoreTls` no longer mutates `process.env.NODE_TLS_REJECT_UNAUTHORIZED`
- [x] TLS relaxation applies only to requests issued by this client instance
- [x] A test asserts the global env var is untouched when `ignoreTls: true`

## Verification

- `npm run validate` passes: build, all tests, coverage thresholds (91.68% lines / 80.67% branches / 92.40% functions), docs drift, VitePress docs build, and package contents. No live VCFA contact.

https://claude.ai/code/session_018rtrRhGjvSmYdzk1K3RLmE

---
_Generated by [Claude Code](https://claude.ai/code/session_018rtrRhGjvSmYdzk1K3RLmE)_