### PR TITLE
Add Claude Code plugin with vcfa-authoring and vcfa-operations skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "mcp-vcf-orchestrator",
+  "owner": {
+    "name": "mgovedarov",
+    "email": "mgovedarov@evoila.com"
+  },
+  "plugins": [
+    {
+      "name": "vcfa-orchestrator",
+      "source": "./",
+      "description": "Skills for safely working with the VCF Automation Orchestrator MCP server: discovery-first authoring, package-first publishing, and guided troubleshooting.",
+      "version": "2.0.0",
+      "license": "Apache-2.0",
+      "keywords": ["mcp", "vcf", "vro", "orchestrator", "vmware", "automation"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "vcfa-orchestrator",
+  "version": "2.0.0",
+  "description": "Skills that drive the VCF Automation Orchestrator MCP server safely: discovery-first authoring, package-first publishing, and guided troubleshooting via the server's vcfa-* prompts and tools.",
+  "author": {
+    "name": "mgovedarov",
+    "email": "mgovedarov@evoila.com"
+  },
+  "homepage": "https://github.com/mgovedarov/mcp-vcf-orchestrator#readme",
+  "repository": "https://github.com/mgovedarov/mcp-vcf-orchestrator.git",
+  "license": "Apache-2.0",
+  "keywords": [
+    "mcp",
+    "vcf",
+    "vro",
+    "orchestrator",
+    "vmware",
+    "automation",
+    "aria",
+    "extensibility"
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,9 @@ Read the relevant source or docs before changing behavior:
 - Safety guidance: `docs/operations/safety.md`
 - Development and docs process: `docs/operations/contributing.md`
 - Checked examples: `examples/README.md`
+- Claude Code plugin and skills: `.claude-plugin/` and `skills/<name>/SKILL.md`
+
+The Claude Code skills must stay thin: they delegate to the `vcfa-*` prompts, `vcfa://` resources, and tools and must not re-document them. Tool/prompt/resource names referenced in a `SKILL.md` are drift-checked by `npm run validate:docs`; add any legitimate new non-tool kebab term to `KNOWN_NON_REGISTRY_TERMS` in `scripts/validate-docs.mjs`.
 
 If the docs and source disagree, inspect the source, update the docs or examples, and run the docs validation gate.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added a Claude Code plugin (`vcfa-orchestrator`) and marketplace manifest under `.claude-plugin/`, bundling two skills in `skills/`: `vcfa-authoring` (discovery-first artifact lifecycle and package-first publishing) and `vcfa-operations` (running workflows and guided troubleshooting). The skills delegate to the server's existing `vcfa-*` prompts, resources, and tools rather than duplicating them, and `npm run validate:docs` now drift-checks the tool/prompt/resource names they reference.
 - Added `VroClient.close()` to release the client's network resources (the TLS-relaxed dispatcher); the server now calls it during graceful shutdown.
 - Added a local TLS integration test that runs the client against a self-signed HTTPS server, verifying `ignoreTls` completes a real handshake (and that strict mode still rejects) without touching `NODE_TLS_REJECT_UNAUTHORIZED`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Key architectural concepts:
 - **`AGENTS.md` is the deeper operating playbook.** It documents the full current tool/prompt/resource surface, artifact-lifecycle steps, package-first rules, workflow authoring rules, and template/subscription/catalog/deployment rules. Read it before non-trivial behavior changes; this file is the orientation, `AGENTS.md` is the detail.
 - **Do not invent environment-specific values** (vRO IDs, schemas, parameters, action contracts, package/project/category IDs, blueprint YAML). Verify from source, docs, or configured MCP tools, and report a missing fact rather than filling the gap.
 - **Adding a tool**: update the relevant `src/tools/*` module, set accurate read-only/destructive annotations, add tests, and update `docs/reference/tools.md` plus relevant how-tos. For prompts/resources, update `src/prompts/index.ts` or `src/resources/index.ts` and `docs/reference/resources-prompts.md`. For docs sidebar entries, update `docs/.vitepress/config.ts`.
+- **Claude Code plugin/skills**: the plugin lives in `.claude-plugin/` and skills in `skills/<name>/SKILL.md`. Keep skills thin — they delegate to the `vcfa-*` prompts, `vcfa://` resources, and tools and must not re-document them. Tool/prompt/resource names referenced inside a `SKILL.md` are drift-checked by `npm run validate:docs`; add any legitimate new non-tool kebab term to `KNOWN_NON_REGISTRY_TERMS` in `scripts/validate-docs.mjs`.
 - **Issue codes**: use `VCFO-###` (sequential, prefixed in issue titles, e.g. `[VCFO-001] ...`).
 
 ## Testing & Validation

--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ npm install
 npm run build
 ```
 
+## Claude Code Plugin
+
+A [Claude Code](https://claude.ai/code) plugin in this repository bundles two skills (`vcfa-authoring` and `vcfa-operations`) that auto-activate and route to the server's `vcfa-*` prompts and tools with discovery-first, confirm-before-write safety. Install it from a Claude Code session:
+
+```text
+/plugin marketplace add mgovedarov/mcp-vcf-orchestrator
+/plugin install vcfa-orchestrator@mcp-vcf-orchestrator
+```
+
+The plugin contains skills only; configure the MCP server separately. See [docs/guide/claude-code-plugin.md](docs/guide/claude-code-plugin.md).
+
 ## License And Branding
 
 This project is licensed under the [Apache License 2.0](LICENSE). Attribution notices are provided in [NOTICE](NOTICE).

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
           { text: "Installation", link: "/guide/installation" },
           { text: "Configuration", link: "/guide/configuration" },
           { text: "MCP Client Setup", link: "/guide/mcp-clients" },
+          { text: "Claude Code Plugin", link: "/guide/claude-code-plugin" },
         ],
       },
       {

--- a/docs/guide/claude-code-plugin.md
+++ b/docs/guide/claude-code-plugin.md
@@ -1,0 +1,40 @@
+# Claude Code Plugin
+
+This repository ships a [Claude Code](https://claude.ai/code) plugin that bundles
+two **Skills** for working with the VCF Automation Orchestrator MCP server. The
+skills auto-activate from natural intent and route you into the server's existing
+`vcfa-*` prompts and tools, encoding the discovery-first, confirm-before-write
+safety discipline so you do not have to remember tool or prompt names.
+
+The plugin contains skills only. The MCP server itself is configured separately —
+see [Installation](./installation.md) and [Configuration](./configuration.md) for the
+required environment variables (`VCFA_HOST`, `VCFA_USERNAME`, `VCFA_ORGANIZATION`,
+`VCFA_PASSWORD`).
+
+## Skills
+
+- **vcfa-authoring** — fires when you create, update, scaffold, refactor, review,
+  promote, or import a vRO workflow, action, configuration element, resource
+  element, or package, or publish reusable content through the project package.
+  It drives the discovery → export → author → preflight → diff →
+  prepare-promotion → confirm → import → verify lifecycle and the package-first
+  publishing flow.
+- **vcfa-operations** — fires when you run a workflow, troubleshoot a failed
+  execution or a stuck deployment, explore catalog items and deployments, manage
+  day-2 actions, create or review blueprint templates, work with extensibility
+  subscriptions and event topics, or discover what an environment offers.
+
+## Install
+
+From a Claude Code session, add this repository as a marketplace and install the
+plugin:
+
+```text
+/plugin marketplace add mgovedarov/mcp-vcf-orchestrator
+/plugin install vcfa-orchestrator@mcp-vcf-orchestrator
+```
+
+Once installed, the skills activate automatically when your request matches their
+triggers. They prefer the server-provided prompts and read-only discovery tools,
+and they require explicit confirmation before any tool that mutates live VCFA or
+vRO state.

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -165,6 +165,10 @@ function validateReferenceDrift(registry) {
   assertNoDiff("Resources", diff(registry.resources, resourceDocs));
 }
 
+function skillFiles() {
+  return walk("skills", (path) => extname(path) === ".md");
+}
+
 function markdownFiles() {
   return [
     "README.md",
@@ -172,6 +176,7 @@ function markdownFiles() {
     "CLAUDE.md",
     ...walk("docs", (path) => extname(path) === ".md"),
     ...walk("examples", (path) => extname(path) === ".md"),
+    ...skillFiles(),
   ].filter((path) => existsSync(join(root, path)));
 }
 
@@ -298,13 +303,64 @@ function validateExampleToolCalls(files, registry) {
   assert.deepEqual(failures, [], "Documented examples must reference current tools and arguments");
 }
 
+// Legitimate kebab-case tokens used in skill prose that are not registered tool,
+// prompt, or resource names: plugin/skill/marketplace identifiers and the
+// workflow/template/subscription pattern slugs. A renamed tool still referenced
+// in a SKILL.md fails the check below; a genuinely new non-tool term is a
+// one-line addition here.
+const KNOWN_NON_REGISTRY_TERMS = new Set([
+  "vcfa-orchestrator",
+  "vcfa-authoring",
+  "vcfa-operations",
+  "mcp-vcf-orchestrator",
+  "basic-scriptable-task",
+  "action-wrapper",
+  "small-vm",
+  "catalog-ready",
+  "event-driven",
+]);
+
+const TOOL_TOKEN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)+$/;
+
+function validateSkillReferences(registry, skills) {
+  const failures = [];
+  for (const file of skills) {
+    const text = read(file);
+    for (const match of text.matchAll(/`([^`]+)`/g)) {
+      const token = match[1].trim();
+      if (token.startsWith("vcfa://")) {
+        if (!registry.resources.has(token)) {
+          failures.push(`${file}: unknown resource reference ${token}`);
+        }
+        continue;
+      }
+      if (!TOOL_TOKEN.test(token)) continue;
+      if (
+        registry.tools.has(token) ||
+        registry.prompts.has(token) ||
+        KNOWN_NON_REGISTRY_TERMS.has(token)
+      ) {
+        continue;
+      }
+      failures.push(`${file}: unknown tool/prompt reference ${token}`);
+    }
+  }
+  assert.deepEqual(
+    failures,
+    [],
+    "Skill files must reference current tools, prompts, and resources",
+  );
+}
+
 const registry = collectRegistry();
 const files = markdownFiles();
+const skills = skillFiles();
 
 validateReferenceDrift(registry);
 validateMarkdownLinks(files);
 validateExampleToolCalls(files, registry);
+validateSkillReferences(registry, skills);
 
 console.log(
-  `Validated docs drift and examples: ${registry.tools.size} tools, ${registry.prompts.size} prompts, ${registry.resources.size} resources, ${files.length} markdown files.`,
+  `Validated docs drift and examples: ${registry.tools.size} tools, ${registry.prompts.size} prompts, ${registry.resources.size} resources, ${files.length} markdown files (${skills.length} skill files).`,
 );

--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -53,6 +53,8 @@ try {
     /^node_modules\//,
     /^coverage\//,
     /^docs\/\.vitepress\//,
+    /^skills\//,
+    /^\.claude-plugin\//,
     /^\.env$/,
     /^\.env\.example$/,
     /^\.npmrc$/,

--- a/skills/vcfa-authoring/SKILL.md
+++ b/skills/vcfa-authoring/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: vcfa-authoring
+description: >-
+  Author and promote VCF Automation Orchestrator (vRO) content safely through
+  the mcp-vcf-orchestrator MCP server. Use when the user wants to create,
+  update, scaffold, refactor, review, promote, or import a vRO workflow,
+  action, configuration element, resource element, or package, or to publish
+  reusable content through the project package. Encodes the server's
+  discovery-first, confirm-before-write lifecycle and routes to the matching
+  vcfa-* prompts. Does not invent vRO IDs, schemas, or contracts.
+---
+
+# VCFA Authoring
+
+Drive the VCF Automation Orchestrator MCP server when authoring or promoting vRO
+artifacts. Stay discovery-first and conservative with the live environment. This
+skill orchestrates the server's own prompts, resources, and tools — it does not
+replace them.
+
+## Core principles
+
+- Discover before you write. Start with the `list-*` and `get-*` tools and verify
+  every ID, category, schema, and contract from the live environment, docs, or
+  configured tools. Never invent vRO IDs, parameter schemas, action contracts,
+  package names, or category IDs.
+- Mutating tools require a `confirm: true` argument. That schema flag is not a
+  substitute for real user confirmation — confirm the exact target, expected
+  impact, and rollback or backup plan with the user before any live write.
+- Keep local artifact work inside the configured artifact directories. Pass plain
+  file names, never paths, absolute paths, traversal, or symlinks.
+
+## Prefer the server prompts
+
+Reach for the server-provided prompts first — they encode the full playbooks:
+
+- `vcfa-discover-capabilities` — explore installed plugins, categories, reusable
+  actions, workflows, and gaps before designing anything.
+- `vcfa-collect-context-snapshot` — persist reusable environment context in
+  unfamiliar or large environments.
+- `vcfa-discovery-first-implementation-plan` — produce a phased plan that begins
+  with verified read-only discovery.
+- `vcfa-author-workflow` — plan, scaffold, preflight, and safely import a workflow.
+- `vcfa-build-workflow-from-action` — wrap an existing action's verified contract
+  in a workflow.
+- `vcfa-refactor-workflow` — inspect, export, diff, and plan a safe refactor.
+- `vcfa-review-artifact-import` — review a local artifact before import.
+
+## Artifact lifecycle
+
+Follow this sequence unless the user explicitly asks for a narrower read-only review:
+
+1. Discover the live target and dependencies with `list-*` / `get-*` tools.
+2. Export or snapshot existing live state when replacing content
+   (`export-workflow-file`, `export-action-file`, `export-configuration-file`,
+   `export-resource-element`, `export-package`).
+3. Author or modify the local artifact (`scaffold-workflow-file`,
+   `create-workflow`, `create-action`, `create-configuration`).
+4. Validate with the matching preflight tool (`preflight-workflow-file`,
+   `preflight-action-file`, `preflight-configuration-file`, `preflight-package`).
+5. Diff when replacing a workflow or action (`diff-workflow-file`,
+   `diff-action-file`).
+6. Run `prepare-artifact-promotion` to bundle preflight, optional backup export,
+   and change summaries before a live replacement.
+7. Confirm the exact target and impact with the user.
+8. Import or publish (`import-workflow-file`, `import-action-file`,
+   `import-configuration-file`, `import-resource-element`, `import-package`).
+9. Verify with read-only inspection or a confirmed execution.
+
+## Package-first publishing
+
+Move reusable project content through the stable project package by default. Do
+not create random, timestamped, or task-specific packages.
+
+`ensure-project-package` → `add-workflow-to-project-package` /
+`add-action-to-project-package` / `add-configuration-to-project-package` /
+`add-resource-to-project-package` → `rebuild-project-package` →
+`export-project-package` → `get-project-package-import-details` →
+`import-project-package`.
+
+Use direct `import-*-file` tools only for narrow validation or an explicitly
+requested one-off test.
+
+## Authoring detail lives in the server resources
+
+Do not re-derive authoring rules here. Read the server resources for the current,
+authoritative detail:
+
+- `vcfa://docs/artifact-authoring` — full vRO artifact authoring guide
+  (input forms, native action items, layout, encoding rules).
+- `vcfa://schemas/workflow-scaffold` — the workflow scaffold schema.
+- `vcfa://patterns/workflows/basic-scriptable-task` and
+  `vcfa://patterns/workflows/action-wrapper` — workflow patterns to start from.

--- a/skills/vcfa-operations/SKILL.md
+++ b/skills/vcfa-operations/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: vcfa-operations
+description: >-
+  Run and operate VCF Automation Orchestrator, Service Broker, and Cloud
+  Assembly through the mcp-vcf-orchestrator MCP server. Use when the user wants
+  to run a workflow, troubleshoot a failed workflow execution or a stuck
+  deployment, explore catalog items and deployments, manage day-2 actions,
+  create or review blueprint templates, work with extensibility subscriptions
+  and event topics, or discover what an environment offers. Encodes
+  read-only-first discovery and confirm-before-write safety, and routes to the
+  matching vcfa-* prompts.
+---
+
+# VCFA Operations
+
+Operate and troubleshoot VCF Automation through the MCP server. Start with
+read-only discovery and only mutate after explicit confirmation. This skill
+orchestrates the server's prompts, resources, and tools rather than replacing
+them.
+
+## Core principles
+
+- Inspect before you act. Use the `list-*` and `get-*` tools and the execution
+  log tools to understand state before remediating.
+- The mutating tools — `run-workflow`, `run-workflow-and-wait`,
+  `create-deployment`, `run-deployment-action`, `delete-deployment`,
+  `create-template`, `delete-template`, `create-subscription`,
+  `update-subscription`, `delete-subscription` — require a `confirm: true`
+  argument plus real user confirmation of the exact target and expected impact.
+- Running a workflow or a deployment day-2 action changes the live environment.
+  Treat it like a production operation: confirm target, inputs, and blast radius.
+
+## Prefer the server prompts
+
+- `vcfa-troubleshoot-deployment` — inspect a deployment and its day-2 options
+  before remediation.
+- `vcfa-troubleshoot-workflow-execution` — diagnose a failed execution using
+  logs, stack, and workflow source.
+- `vcfa-discover-capabilities` — explore plugins, categories, workflows, actions,
+  catalog items, deployments, templates, and subscriptions.
+- `vcfa-collect-context-snapshot` — persist reusable environment context.
+- `vcfa-create-template` and `vcfa-review-template` — discover conventions before
+  drafting a blueprint, and review one for catalog readiness.
+- `vcfa-integrate-workflow-template-subscription` — plan workflow, template,
+  catalog, deployment, and subscription integration.
+
+## Tool map by task
+
+- Execution: `run-workflow`, `run-workflow-and-wait`, `get-workflow-execution`,
+  `get-workflow-execution-logs`, `list-workflow-executions`.
+- Deployments: `list-deployments`, `get-deployment`, `list-deployment-actions`,
+  `run-deployment-action`, `create-deployment`, `delete-deployment`.
+- Catalog: `list-catalog-items`, `get-catalog-item`.
+- Templates: `list-templates`, `get-template`, `create-template`,
+  `delete-template`.
+- Subscriptions and events: `list-event-topics`, `list-subscriptions`,
+  `get-subscription`, `create-subscription`, `update-subscription`,
+  `delete-subscription`.
+- Discovery support: `list-workflows`, `list-actions`, `list-categories`,
+  `list-plugins`.
+
+Live objects are also available as read-only resources, e.g.
+`vcfa://deployments/{id}`, `vcfa://workflows/{id}`, and `vcfa://subscriptions/{id}`.
+
+## vra8 mode caveat
+
+When the server runs with `VCFA_TARGET_PLATFORM=vra8` (vRA/vRO 8.12+ Basic auth),
+only vRO read operations plus workflow execution and execution logs are
+supported. Automation-service surfaces — catalog, deployments, templates,
+subscriptions, and event topics — are intentionally unsupported in that mode.


### PR DESCRIPTION
Bundle a Claude Code plugin (vcfa-orchestrator) and marketplace manifest
under .claude-plugin/, with two thin skills in skills/ that auto-activate
and route to the server's existing vcfa-* prompts, vcfa:// resources, and
tools rather than duplicating them:

- vcfa-authoring: discovery-first artifact lifecycle and package-first
  publishing for workflows, actions, configurations, resources, packages.
- vcfa-operations: running workflows and guided troubleshooting of
  executions, deployments, catalog, templates, and subscriptions.

Extend validate-docs.mjs to drift-check every tool/prompt/resource name
referenced in a SKILL.md against the live registry (with a small
KNOWN_NON_REGISTRY_TERMS allowlist for plugin/skill/pattern names), and
include skill markdown in the existing link and example checks. Add
defensive forbidden patterns to validate-package.mjs so skills/ and
.claude-plugin/ never ship in the npm tarball.

Add a docs/guide page (wired into the VitePress sidebar), a README
section, a CHANGELOG entry, and convention notes in CLAUDE.md/AGENTS.md.

https://claude.ai/code/session_019N1sUiAYts9VhUXUJxqo6a