### PR TITLE
[VCFO-050] Scope formatQuery $/~ un-encoding to OData system keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Added `VroClient.close()` to release the client's network resources (the TLS-relaxed dispatcher); the server now calls it during graceful shutdown.
 - Added a local TLS integration test that runs the client against a self-signed HTTPS server, verifying `ignoreTls` completes a real handshake (and that strict mode still rejects) without touching `NODE_TLS_REJECT_UNAUTHORIZED`.
 
+### Fixed
+
+- Query parameter values containing `$` or `~` are no longer un-encoded by the pagination query serializer; the literal-`$` exemption now applies only to OData system query keys such as `$filter` and `$search` (VCFO-050).
+
 ## 2.0.0 - 2026-05-18
 
 This release tightens live-operation safety, improves authentication and error handling, refreshes dependencies and documentation, and adopts Apache License 2.0 with NOTICE attribution.

--- a/src/client/pagination.ts
+++ b/src/client/pagination.ts
@@ -41,7 +41,9 @@ function isQueryCountUnsupported(error: unknown): boolean {
 
 function encodeQueryComponent(value: string): string {
   // RFC 3986-strict variant of encodeURIComponent (also encodes ! ' ( ) *).
-  // ~ is unreserved and stays literal; $ is encoded as %24.
+  // ~ is unreserved and stays literal; $ is encoded as %24. Unlike
+  // URLSearchParams.toString(), * serializes as %2A (wire-equivalent after
+  // server-side decoding).
   return encodeURIComponent(value).replace(
     /[!'()*]/g,
     (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
@@ -59,6 +61,11 @@ export function formatQuery(params: URLSearchParams): string {
     parts.push(`${encodedKey}=${encodeQueryComponent(value)}`);
   }
   return parts.join("&");
+}
+
+function withQuery(path: string, params: URLSearchParams): string {
+  const query = formatQuery(params);
+  return query ? `${path}?${query}` : path;
 }
 
 export async function getAllVroPages<T>(
@@ -81,7 +88,7 @@ export async function getAllVroPages<T>(
       pageParams.set("maxResult", String(pageSize));
       pageParams.set("startIndex", String(start));
       if (includeQueryCount) pageParams.set("queryCount", "true");
-      return `${path}?${formatQuery(pageParams)}`;
+      return withQuery(path, pageParams);
     };
 
     let page: VroPage<T>;
@@ -141,7 +148,7 @@ export async function getAllAutomationPages<T>(
     pageParams.set("size", String(pageSize));
 
     const page = await http.get<AutomationPage<T>>(
-      `${path}?${formatQuery(pageParams)}`,
+      withQuery(path, pageParams),
       baseUrl,
     );
     const items = page.content ?? [];

--- a/src/client/pagination.ts
+++ b/src/client/pagination.ts
@@ -39,12 +39,26 @@ function isQueryCountUnsupported(error: unknown): boolean {
   );
 }
 
+function encodeQueryComponent(value: string): string {
+  // RFC 3986-strict variant of encodeURIComponent (also encodes ! ' ( ) *).
+  // ~ is unreserved and stays literal; $ is encoded as %24.
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
 export function formatQuery(params: URLSearchParams): string {
-  return params
-    .toString()
-    .replace(/\+/g, "%20")
-    .replace(/%24/g, "$")
-    .replace(/%7E/gi, "~");
+  const parts: string[] = [];
+  for (const [key, value] of params) {
+    // OData system query keys ($filter, $search, $top, ...) must keep a
+    // literal $ in the key; some VMware Automation endpoints reject %24filter.
+    const encodedKey = /^\$[A-Za-z]+$/.test(key)
+      ? key
+      : encodeQueryComponent(key);
+    parts.push(`${encodedKey}=${encodeQueryComponent(value)}`);
+  }
+  return parts.join("&");
 }
 
 export async function getAllVroPages<T>(

--- a/test/vro-client.test.mjs
+++ b/test/vro-client.test.mjs
@@ -13,6 +13,7 @@ import { join } from "node:path";
 import test from "node:test";
 import { buildWorkflowArtifact } from "../dist/client/workflow-artifact.js";
 import { sanitizeErrorBody } from "../dist/client/core.js";
+import { formatQuery } from "../dist/client/pagination.js";
 import { VroClient } from "../dist/vro-client.js";
 
 const config = (overrides = {}) => ({
@@ -184,6 +185,55 @@ test("vRO list clients aggregate multiple startIndex pages and preserve filters"
   assert.equal(
     calls[2].url,
     "https://vcfa.example.test/vco/api/actions?conditions=name~deploy%20vm&maxResult=100&startIndex=100&queryCount=true",
+  );
+});
+
+test("formatQuery preserves $ and ~ in values while keeping OData $-keys literal", () => {
+  assert.equal(
+    formatQuery(new URLSearchParams({ $filter: "projectId eq 'a$b~c'" })),
+    "$filter=projectId%20eq%20%27a%24b~c%27",
+  );
+  assert.equal(
+    formatQuery(new URLSearchParams({ conditions: "name~cost$center" })),
+    "conditions=name~cost%24center",
+  );
+  assert.equal(
+    formatQuery(new URLSearchParams({ conditions: "a&b=c%d+e" })),
+    "conditions=a%26b%3Dc%25d%2Be",
+  );
+});
+
+test("vRO conditions values containing $ are percent-encoded", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    return Response.json({ start: 0, total: 0, link: [] });
+  };
+
+  const client = new VroClient(config());
+  await client.listActions("cost$center ~v2");
+
+  assert.equal(
+    calls[1].url,
+    "https://vcfa.example.test/vco/api/actions?conditions=name~cost%24center%20~v2&maxResult=100&startIndex=0&queryCount=true",
+  );
+});
+
+test("$search values containing $ keep the key literal and encode the value", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    return Response.json({ totalElements: 0, content: [] });
+  };
+
+  const client = new VroClient(config());
+  await client.listCatalogItems("price $100");
+
+  assert.equal(
+    calls[1].url,
+    "https://vcfa.example.test/catalog/api/items?$search=price%20%24100&page=0&size=100",
   );
 });
 


### PR DESCRIPTION
## Summary

Fixes #75.

`formatQuery` in `src/client/pagination.ts` reverted `%24`→`$` and `%7E`→`~` across the **entire** serialized query string, so percent-encoded operand values that legitimately contained `$` or `~` were silently un-encoded before being sent to the server — a `$` in a filter value could then be reinterpreted as OData syntax by strict servers/gateways.

## Changes

- **`src/client/pagination.ts`**: replace the blanket post-hoc regexes with per-pair serialization. Keys matching the OData system-key shape (`^\$[A-Za-z]+$`, e.g. `$filter`, `$search`) are emitted with a literal `$`; all values and ordinary keys go through an RFC 3986-strict `encodeURIComponent` (also encodes `! ' ( ) *`). `~` is unreserved and stays a literal byte, so vRO `conditions=name~...` output is byte-identical to before; `$` in a value now stays `%24`.
- **`test/vro-client.test.mjs`**: three new tests — a direct `formatQuery` unit test (`$`/`~` in values, hostile `&`/`=`/`%`/`+` value), a vRO `conditions` client-level test with `$` in the filter, and a `$search` test proving the key stays literal while the value's `$` is encoded. All pre-existing exact-URL assertions pass unchanged.
- **`CHANGELOG.md`**: `### Fixed` entry under Unreleased.

No change needed in `subscription-client.ts` — its `''` escaping is correct OData literal escaping, and a `$` inside the quoted literal now travels safely as `%24`.

## Acceptance criteria (from #75)

- [x] A param value containing `$`/`~` is transmitted with those bytes preserved/encoded, not reinterpreted as OData syntax.
- [x] Existing OData `$filter`/`$search` usage still works (existing exact-URL test assertions unchanged).
- [x] Tests cover values containing `$` and `~`.

## Verification

- `npm run build && node --test test/vro-client.test.mjs` — 100/100 pass.
- `npm run validate` — full local gate passes (tests, coverage 91.74% lines / 80.85% branches / 92.50% functions, docs drift, VitePress build, package contents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)