### PR TITLE
[VCFO-051] Add destructiveHint:true to overwriting import/run/update tools

### DIFF
--- a/docs/operations/contributing.md
+++ b/docs/operations/contributing.md
@@ -19,7 +19,7 @@ When adding a new MCP tool:
 
 1. Add the tool in the relevant `src/tools/*` module.
 2. Use existing client modules before introducing new API logic.
-3. Mark read-only and destructive annotations accurately.
+3. Mark read-only and destructive annotations accurately. Tools that overwrite or delete live state must use the shared `DESTRUCTIVE_LIVE_WRITE` constant from `src/tools/annotations.ts`; `test/tool-annotations.test.mjs` fails if a new `import-`/`delete-`/`update-`/`run-` tool is not annotated and listed there.
 4. Add tests for success, error, confirmation, and formatting behavior.
 5. Update the tool reference with a collapsible parameters section directly under the tool, and update relevant how-to docs.
 

--- a/docs/operations/safety.md
+++ b/docs/operations/safety.md
@@ -4,7 +4,7 @@ Tools fall into three categories:
 
 - **Read-only discovery** (`readOnlyHint: true`): list, get, preflight, and diff tools. They do not write local files or mutate live VCFA/vRO state. `get-workflow-execution-logs` is also read-only by default; it only writes a local file when the optional `fileName` parameter is provided.
 - **Local artifact writes** (`readOnlyHint: false`, no `confirm` required): export, scaffold, and snapshot tools — for example `export-workflow-file`, `export-action-file`, `export-configuration-file`, `export-resource-element`, `export-package`, `export-project-package`, `scaffold-workflow-file`, `collect-context-snapshot`, and `prepare-artifact-promotion`. These write files under configured artifact directories and default `overwrite` to `false`. They do not mutate live VCFA/vRO state.
-- **Live VCFA/vRO mutations** (`readOnlyHint: false`, `confirm: true` required): create, update, import, delete, run, and deployment day-2 action tools. Treat every live write operation as an environment change.
+- **Live VCFA/vRO mutations** (`readOnlyHint: false`, `confirm: true` required): create, update, import, delete, run, and deployment day-2 action tools. Treat every live write operation as an environment change. Tools that overwrite or delete live state — import, update, run, and delete tools, plus `rebuild-project-package` — additionally set `destructiveHint: true` so hosts can require heightened approval; additive creates and `add-*-to-project-package` tools do not.
 
 ## Confirmation Required
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -4,7 +4,7 @@ Tools are grouped by operating domain. Each tool carries an MCP annotation hint 
 
 - **Read-only discovery** (`readOnlyHint: true`) — list, get, preflight, and diff tools. Safe for discovery; do not write local files or mutate live state. (`get-workflow-execution-logs` is read-only by default; it writes a local file only when the optional `fileName` is provided.)
 - **Local artifact write** (`readOnlyHint: false`, no `confirm`) — export, scaffold, and snapshot tools. Write files under configured artifact directories; `overwrite` defaults to `false`. Do not mutate live VCFA/vRO state.
-- **Live mutation** (`readOnlyHint: false`, `confirm: true`) — create, update, import, run, and delete tools. Mutate live VCFA/vRO state and require explicit confirmation.
+- **Live mutation** (`readOnlyHint: false`, `confirm: true`) — create, update, import, run, and delete tools. Mutate live VCFA/vRO state and require explicit confirmation. Tools that overwrite or delete live state — import, update, run, and delete tools, plus `rebuild-project-package` — additionally set `destructiveHint: true` so hosts can require heightened approval; additive creates and `add-*-to-project-package` tools do not.
 
 Each tool lists its input schema in a collapsible parameters section. Required confirmation fields such as `confirm` must be set to `true` before the tool performs the write or destructive operation.
 

--- a/src/tools/action-tools.ts
+++ b/src/tools/action-tools.ts
@@ -3,6 +3,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { formatPreflightReport } from "../client/artifact-preflight.js";
 import type { VroClient } from "../vro-client.js";
+import { DESTRUCTIVE_LIVE_WRITE } from "./annotations.js";
 import {
   appendGuardGuidance,
   guardExpectedFields,
@@ -361,7 +362,7 @@ export function registerActionTools(
             "Must be set to true to confirm import. If false, the import will not proceed.",
           ),
       }),
-      annotations: { readOnlyHint: false },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({
       categoryName,
@@ -465,7 +466,7 @@ export function registerActionTools(
             "Must be set to true to confirm deletion. If false, the deletion will not proceed.",
           ),
       }),
-      annotations: { readOnlyHint: false, destructiveHint: true },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({
       id,

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared MCP tool annotation for operations that overwrite or delete live
+ * VCFA/vRO state (imports with overwrite semantics, updates, deletes, and
+ * workflow/deployment-action executions). Hosts may use `destructiveHint`
+ * to require heightened confirmation before invoking these tools.
+ */
+export const DESTRUCTIVE_LIVE_WRITE = {
+  readOnlyHint: false,
+  destructiveHint: true,
+} as const;

--- a/src/tools/config-tools.ts
+++ b/src/tools/config-tools.ts
@@ -3,6 +3,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { formatPreflightReport } from "../client/artifact-preflight.js";
 import type { VroClient } from "../vro-client.js";
+import { DESTRUCTIVE_LIVE_WRITE } from "./annotations.js";
 import {
   appendGuardGuidance,
   guardExpectedCategory,
@@ -236,7 +237,7 @@ export function registerConfigTools(
             "Must be set to true to confirm deletion. If false, the deletion will not proceed.",
           ),
       }),
-      annotations: { readOnlyHint: false, destructiveHint: true },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({ id, expectedName, confirm }): Promise<CallToolResult> => {
       if (!confirm) {
@@ -403,7 +404,7 @@ export function registerConfigTools(
             "Must be set to true to confirm import. If false, the import will not proceed.",
           ),
       }),
-      annotations: { readOnlyHint: false },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({
       categoryId,
@@ -511,7 +512,7 @@ export function registerConfigTools(
             "Must be set to true to confirm configuration element update. If false, the element will not be updated.",
           ),
       }),
-      annotations: { readOnlyHint: false },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({
       id,

--- a/src/tools/deployment-tools.ts
+++ b/src/tools/deployment-tools.ts
@@ -7,6 +7,7 @@ import type {
   DeploymentRequest,
 } from "../types.js";
 import type { VroClient } from "../vro-client.js";
+import { DESTRUCTIVE_LIVE_WRITE } from "./annotations.js";
 import {
   guardExpectedFields,
   hasAnyExpectedValue,
@@ -233,7 +234,7 @@ export function registerDeploymentTools(
             "Must be set to true to confirm deletion. If false, the deletion will not proceed.",
           ),
       }),
-      annotations: { readOnlyHint: false, destructiveHint: true },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({
       id,
@@ -478,7 +479,7 @@ export function registerDeploymentTools(
             "Must be set to true to confirm the day-2 action request. If false, the request will not be submitted.",
           ),
       }),
-      annotations: { readOnlyHint: false, destructiveHint: true },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({
       deploymentId,

--- a/src/tools/package-tools.ts
+++ b/src/tools/package-tools.ts
@@ -3,6 +3,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { formatPreflightReport } from "../client/artifact-preflight.js";
 import type { VroClient } from "../vro-client.js";
+import { DESTRUCTIVE_LIVE_WRITE } from "./annotations.js";
 import {
   appendGuardGuidance,
   guardExpectedFields,
@@ -305,7 +306,7 @@ export function registerPackageTools(
           ),
         ...packageImportOptionsSchema,
       }),
-      annotations: { readOnlyHint: false },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({
       fileName,
@@ -509,7 +510,7 @@ export function registerPackageTools(
         packageName: z.string().optional().describe("Exact package name"),
         confirm: z.boolean().describe("Must be true to rebuild the package."),
       }),
-      annotations: { readOnlyHint: false },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({ packageName, confirm }): Promise<CallToolResult> => {
       if (!confirm) {
@@ -877,7 +878,7 @@ export function registerPackageTools(
         confirm: z.boolean().describe("Must be true to import the package."),
         ...packageImportOptionsSchema,
       }),
-      annotations: { readOnlyHint: false },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({
       packageName,
@@ -973,7 +974,7 @@ export function registerPackageTools(
             "Must be set to true to confirm deletion. If false, the deletion will not proceed.",
           ),
       }),
-      annotations: { readOnlyHint: false, destructiveHint: true },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({
       name,

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { VroClient } from "../vro-client.js";
+import { DESTRUCTIVE_LIVE_WRITE } from "./annotations.js";
 import {
   appendGuardGuidance,
   guardExpectedCategory,
@@ -144,7 +145,7 @@ export function registerResourceTools(
             "Must be set to true to confirm import. If false, the import will not proceed.",
           ),
       }),
-      annotations: { readOnlyHint: false },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({
       categoryId,
@@ -249,7 +250,7 @@ export function registerResourceTools(
             "Must be set to true to confirm update. If false, the update will not proceed.",
           ),
       }),
-      annotations: { readOnlyHint: false },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({
       id,
@@ -342,7 +343,7 @@ export function registerResourceTools(
             "Must be set to true to confirm deletion. If false, the deletion will not proceed.",
           ),
       }),
-      annotations: { readOnlyHint: false, destructiveHint: true },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({
       id,

--- a/src/tools/subscription-tools.ts
+++ b/src/tools/subscription-tools.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { VroClient } from "../vro-client.js";
+import { DESTRUCTIVE_LIVE_WRITE } from "./annotations.js";
 import {
   guardExpectedFields,
   hasAnyExpectedValue,
@@ -309,7 +310,7 @@ export function registerSubscriptionTools(
             "Must be set to true to confirm subscription update. If false, the subscription will not be updated.",
           ),
       }),
-      annotations: { readOnlyHint: false },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({
       id,
@@ -430,7 +431,7 @@ export function registerSubscriptionTools(
             "Must be set to true to confirm deletion. If false, the deletion will not proceed.",
           ),
       }),
-      annotations: { readOnlyHint: false, destructiveHint: true },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({
       id,

--- a/src/tools/template-tools.ts
+++ b/src/tools/template-tools.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { VroClient } from "../vro-client.js";
+import { DESTRUCTIVE_LIVE_WRITE } from "./annotations.js";
 import {
   guardExpectedFields,
   hasAnyExpectedValue,
@@ -224,7 +225,7 @@ export function registerTemplateTools(
             "Must be set to true to confirm deletion. If false, the deletion will not proceed.",
           ),
       }),
-      annotations: { readOnlyHint: false, destructiveHint: true },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({
       id,

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -16,6 +16,7 @@ import {
   formatWorkflowExecutionLogEntry,
   normalizeWorkflowExecutionLog,
 } from "../client/workflow-client.js";
+import { DESTRUCTIVE_LIVE_WRITE } from "./annotations.js";
 import {
   appendGuardGuidance,
   guardExpectedCategory,
@@ -732,7 +733,7 @@ export function registerWorkflowTools(
             "Must be set to true to confirm workflow execution. If false, the workflow will not be run.",
           ),
       }),
-      annotations: { readOnlyHint: false },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({
       id,
@@ -846,7 +847,7 @@ export function registerWorkflowTools(
             "Must be set to true to confirm workflow execution. If false, the workflow will not be run.",
           ),
       }),
-      annotations: { readOnlyHint: false },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({
       id,
@@ -1369,7 +1370,7 @@ export function registerWorkflowTools(
             "Must be set to true to confirm import. If false, the import will not proceed.",
           ),
       }),
-      annotations: { readOnlyHint: false },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({
       categoryId,
@@ -1592,7 +1593,7 @@ export function registerWorkflowTools(
             "Must be set to true to confirm deletion. If false, the deletion will not proceed.",
           ),
       }),
-      annotations: { readOnlyHint: false, destructiveHint: true },
+      annotations: DESTRUCTIVE_LIVE_WRITE,
     },
     async ({ id, expectedName, confirm }): Promise<CallToolResult> => {
       if (!confirm) {

--- a/test/tool-annotations.test.mjs
+++ b/test/tool-annotations.test.mjs
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { registerActionTools } from "../dist/tools/action-tools.js";
+import { registerCatalogTools } from "../dist/tools/catalog-tools.js";
+import { registerCategoryTools } from "../dist/tools/category-tools.js";
+import { registerConfigTools } from "../dist/tools/config-tools.js";
+import { registerContextTools } from "../dist/tools/context-tools.js";
+import { registerDeploymentTools } from "../dist/tools/deployment-tools.js";
+import { registerPackageTools } from "../dist/tools/package-tools.js";
+import { registerPluginTools } from "../dist/tools/plugin-tools.js";
+import { registerPromotionTools } from "../dist/tools/promotion-tools.js";
+import { registerResourceTools } from "../dist/tools/resource-tools.js";
+import { registerSubscriptionTools } from "../dist/tools/subscription-tools.js";
+import { registerTemplateTools } from "../dist/tools/template-tools.js";
+import { registerWorkflowTools } from "../dist/tools/workflow-tools.js";
+
+// Every tool that overwrites or deletes live VCFA/vRO state must advertise
+// destructiveHint: true so MCP hosts can gate elevated approval (VCFO-051).
+// Additive live writes (create-*, ensure-*, add-*-to-project-package) and
+// local-only artifact writes (export-*, scaffold-*, snapshot/promotion tools)
+// are deliberately excluded.
+const DESTRUCTIVE_TOOLS = new Set([
+  "delete-action",
+  "delete-configuration",
+  "delete-deployment",
+  "delete-package",
+  "delete-resource-element",
+  "delete-subscription",
+  "delete-template",
+  "delete-workflow",
+  "import-action-file",
+  "import-configuration-file",
+  "import-package",
+  "import-project-package",
+  "import-resource-element",
+  "import-workflow-file",
+  "rebuild-project-package",
+  "run-deployment-action",
+  "run-workflow",
+  "run-workflow-and-wait",
+  "update-configuration",
+  "update-resource-element",
+  "update-subscription",
+]);
+
+// Name prefixes that signal a live overwrite/delete/execute; any newly added
+// tool matching these must be listed in DESTRUCTIVE_TOOLS (and annotated) or
+// this test fails, keeping annotations from drifting again.
+const DESTRUCTIVE_NAME_PATTERN = /^(import-|delete-|update-|run-)/;
+
+// Registers every tool module; keep the call list in sync with the
+// register* calls in src/index.ts so no module escapes these checks.
+function registerAllToolConfigs() {
+  const configs = new Map();
+  const server = {
+    registerTool(name, config) {
+      assert.equal(configs.has(name), false, `duplicate tool name: ${name}`);
+      configs.set(name, config);
+    },
+    sendResourceListChanged() {},
+  };
+  const client = {};
+  registerWorkflowTools(server, client);
+  registerActionTools(server, client);
+  registerConfigTools(server, client);
+  registerCategoryTools(server, client);
+  registerSubscriptionTools(server, client);
+  registerCatalogTools(server, client);
+  registerDeploymentTools(server, client);
+  registerTemplateTools(server, client);
+  registerPackageTools(server, client);
+  registerPromotionTools(server, client);
+  registerContextTools(server, client);
+  registerResourceTools(server, client);
+  registerPluginTools(server, client);
+  return configs;
+}
+
+test("every registered tool declares a boolean readOnlyHint annotation", () => {
+  const configs = registerAllToolConfigs();
+  assert.ok(configs.size > 0);
+  for (const [name, config] of configs) {
+    assert.equal(
+      typeof config.annotations?.readOnlyHint,
+      "boolean",
+      `${name} must declare annotations.readOnlyHint`,
+    );
+  }
+});
+
+test("all tools that overwrite or delete live state set destructiveHint: true", () => {
+  const configs = registerAllToolConfigs();
+  for (const name of DESTRUCTIVE_TOOLS) {
+    const config = configs.get(name);
+    assert.ok(config, `expected destructive tool to be registered: ${name}`);
+    assert.equal(
+      config.annotations?.readOnlyHint,
+      false,
+      `${name} must set readOnlyHint: false`,
+    );
+    assert.equal(
+      config.annotations?.destructiveHint,
+      true,
+      `${name} must set destructiveHint: true`,
+    );
+  }
+});
+
+test("tools with destructive name prefixes are tracked as destructive", () => {
+  const configs = registerAllToolConfigs();
+  for (const name of configs.keys()) {
+    if (DESTRUCTIVE_NAME_PATTERN.test(name)) {
+      assert.ok(
+        DESTRUCTIVE_TOOLS.has(name),
+        `${name} matches a destructive name prefix; add destructiveHint: true and list it in DESTRUCTIVE_TOOLS`,
+      );
+    }
+  }
+});
+
+test("read-only tools never carry destructiveHint: true", () => {
+  const configs = registerAllToolConfigs();
+  for (const [name, config] of configs) {
+    if (config.annotations?.readOnlyHint === true) {
+      assert.notEqual(
+        config.annotations?.destructiveHint,
+        true,
+        `${name} is read-only and must not set destructiveHint: true`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Import tools default `overwrite` to `true` and `run-workflow`/`run-workflow-and-wait` can change the target environment, but they were annotated only `{ readOnlyHint: false }` — so an MCP host that gates elevated approval on `destructiveHint` treated them as non-destructive, while `delete-*` tools correctly carried the flag.

Closes #76

## Changes

- **New shared constant** `DESTRUCTIVE_LIVE_WRITE = { readOnlyHint: false, destructiveHint: true }` in `src/tools/annotations.ts`, used at all 21 destructive sites.
- **12 tools gain `destructiveHint: true`**: `import-workflow-file`, `import-action-file`, `import-configuration-file`, `import-package`, `import-project-package`, `import-resource-element`, `run-workflow`, `run-workflow-and-wait`, `update-configuration`, `update-subscription`, `update-resource-element`, `rebuild-project-package`.
- **9 tools converted to the constant with no behavior change**: the eight `delete-*` tools and `run-deployment-action`.
- **New consistency test** `test/tool-annotations.test.mjs`: registers every tool module and asserts (1) all overwrite/delete tools set `destructiveHint: true`, (2) any tool matching `import-`/`delete-`/`update-`/`run-` prefixes must be annotated and listed — so future tools can't drift, (3) every tool declares a boolean `readOnlyHint`, (4) no read-only tool sets `destructiveHint`.
- **Docs**: annotation-category intros updated in `docs/reference/tools.md` and `docs/operations/safety.md`; `docs/operations/contributing.md` now points contributors at the constant and the consistency test.

## Deliberately unchanged

- Additive live writes (`create-*`, `ensure-project-package`, `add-*-to-project-package`) — nothing overwritten or lost.
- Local-only writers (`export-*`, `scaffold-workflow-file`, `collect-context-snapshot`, `prepare-artifact-promotion`) — `overwrite` defaults to `false`. Re the issue's aside on `collect-context-snapshot`: its `readOnlyHint: false` is accurate since it does write local snapshot files, so it stays as-is.
- No client-layer changes; `overwrite` defaults are untouched — this is annotations-only.

## Verification

- `npm run validate` passes end-to-end: build, full test suite (including the 4 new tests), coverage thresholds (91.8% lines / 80.9% branches), docs drift check (75 tools, 31 markdown files), VitePress docs build, and npm package contents. No live VCFA contact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)