### PR TITLE
[VCFO-052] Scope synthetic execution shape to explicit startExecution path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - Query parameter values containing `$` or `~` are no longer un-encoded by the pagination query serializer; the literal-`$` exemption now applies only to OData system query keys such as `$filter` and `$search` (VCFO-050).
+- Empty-body 2xx responses with a `Location` header no longer masquerade as a running workflow execution for non-execution endpoints; the synthetic `{ id, state: "running" }` shape is now scoped to the explicit workflow-execution start path (`startExecution`), and generic empty 2xx responses return `{}` (VCFO-052).
 
 ## 2.0.0 - 2026-05-18
 

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -310,12 +310,12 @@ export class VroHttpClient {
     throw new Error(UNSUPPORTED_VRO_WRITE);
   }
 
-  async request<T>(
+  private async send(
     method: string,
     path: string,
     body?: unknown,
     overrideBaseUrl?: string,
-  ): Promise<T> {
+  ): Promise<{ res: Response; text: string }> {
     this.assertOperationSupported(method, path, overrideBaseUrl);
     const url = `${overrideBaseUrl ?? this.baseUrl}${path}`;
     console.error(`[vro-client] ${method} ${path}`);
@@ -344,7 +344,29 @@ export class VroHttpClient {
       );
     }
 
-    const text = await res.text();
+    return { res, text: await res.text() };
+  }
+
+  async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    overrideBaseUrl?: string,
+  ): Promise<T> {
+    const { text } = await this.send(method, path, body, overrideBaseUrl);
+    if (!text) return {} as T;
+    return JSON.parse(text) as T;
+  }
+
+  /**
+   * POST an execution-style request where the API may answer 202 with an
+   * empty body and a Location header pointing at the created execution.
+   * Synthesizes { id, state: "running" } from the Location header in that
+   * case; generic empty 2xx responses elsewhere must use request/post and
+   * receive {} instead.
+   */
+  async startExecution<T>(path: string, body?: unknown): Promise<T> {
+    const { res, text } = await this.send("POST", path, body);
     if (!text) {
       const location = res.headers.get("location");
       if (location) {
@@ -353,7 +375,6 @@ export class VroHttpClient {
       }
       return {} as T;
     }
-
     return JSON.parse(text) as T;
   }
 

--- a/src/client/workflow-client.ts
+++ b/src/client/workflow-client.ts
@@ -641,7 +641,7 @@ export class WorkflowClient {
         value: { [p.type]: { value: p.value } },
       }));
     }
-    return this.http.post<WorkflowExecution>(
+    return this.http.startExecution<WorkflowExecution>(
       `/workflows/${encodeURIComponent(id)}/executions`,
       body,
     );

--- a/test/vro-client.test.mjs
+++ b/test/vro-client.test.mjs
@@ -12,7 +12,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { buildWorkflowArtifact } from "../dist/client/workflow-artifact.js";
-import { sanitizeErrorBody } from "../dist/client/core.js";
+import { sanitizeErrorBody, VroHttpClient } from "../dist/client/core.js";
 import { formatQuery } from "../dist/client/pagination.js";
 import { VroClient } from "../dist/vro-client.js";
 
@@ -697,6 +697,42 @@ test("bodyless 202 responses with Location return an execution id", async () => 
   assert.equal(execution.id, "execution-123");
   assert.equal(execution.state, "running");
   assert.equal(calls.length, 2);
+});
+
+test("generic bodyless 2xx responses with a Location header do not synthesize an execution", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    return new Response("", {
+      status: 202,
+      headers: {
+        location: "https://vcfa.example.test/vco/api/things/thing-9",
+      },
+    });
+  };
+
+  const http = new VroHttpClient(config());
+  const result = await http.post("/things/thing-9/promote");
+
+  assert.deepEqual(result, {});
+  assert.equal(result.state, undefined);
+  assert.equal(calls.length, 2);
+});
+
+test("startExecution parses a JSON 2xx body", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    return Response.json({ id: "execution-9", state: "completed" });
+  };
+
+  const http = new VroHttpClient(config());
+  const execution = await http.startExecution("/workflows/wf-1/executions", {});
+
+  assert.equal(execution.id, "execution-9");
+  assert.equal(execution.state, "completed");
 });
 
 test("getWorkflowExecution can request detailed execution data", async () => {


### PR DESCRIPTION
## Summary

`request<T>` synthesized `{ id, state: "running" }` for **any** empty-body 2xx response with a `Location` header — so a 204 from a delete/update with an unrelated `Location` header could masquerade as a running async execution.

- Extracted the shared HTTP plumbing of `request<T>` into a private `send()` helper (auth assert, URL build, headers, fetch, non-2xx error throw).
- `request<T>` now returns `{}` for any empty-body 2xx — no Location sniffing.
- Added explicit `VroHttpClient.startExecution<T>(path, body?)` that preserves the 202+Location → `{ id, state: "running" }` synthesis for execution-start POSTs only.
- `WorkflowClient.runWorkflow` (the only call site relying on the synthetic shape) now uses `startExecution`.

## Tests

- Existing regression anchor "bodyless 202 responses with Location return an execution id" passes unchanged via `runWorkflow`.
- New: generic bodyless 2xx with Location via `http.post()` returns `{}` with no `state`.
- New: `startExecution` parses a JSON 2xx body.
- `npm run validate` passes (102 tests, coverage 91.8% lines / 80.9% branches).

Fixes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)