### PR TITLE
[VCFO-053] Contextualize non-JSON 2xx response parse failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Query parameter values containing `$` or `~` are no longer un-encoded by the pagination query serializer; the literal-`$` exemption now applies only to OData system query keys such as `$filter` and `$search` (VCFO-050).
 - Empty-body 2xx responses with a `Location` header no longer masquerade as a running workflow execution for non-execution endpoints; the synthetic `{ id, state: "running" }` shape is now scoped to the explicit workflow-execution start path (`startExecution`), and generic empty 2xx responses return `{}` (VCFO-052).
+- A 2xx response with a non-JSON body (for example an HTML error page from a load balancer or SSO interstitial) now throws a sanitized, contextualized error naming the method, path, and correlation ID instead of a bare `SyntaxError: Unexpected token` (VCFO-053).
 
 ## 2.0.0 - 2026-05-18
 

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -347,15 +347,30 @@ export class VroHttpClient {
     return { res, text: await res.text() };
   }
 
+  private parseJsonBody<T>(
+    text: string,
+    res: Response,
+    method: string,
+    path: string,
+  ): T {
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      throw new Error(
+        `vRO API error: non-JSON response body (${res.status} ${res.statusText}) — ${method} ${path}\n${sanitizeErrorBody(text, res)}`,
+      );
+    }
+  }
+
   async request<T>(
     method: string,
     path: string,
     body?: unknown,
     overrideBaseUrl?: string,
   ): Promise<T> {
-    const { text } = await this.send(method, path, body, overrideBaseUrl);
+    const { res, text } = await this.send(method, path, body, overrideBaseUrl);
     if (!text) return {} as T;
-    return JSON.parse(text) as T;
+    return this.parseJsonBody<T>(text, res, method, path);
   }
 
   /**
@@ -375,7 +390,7 @@ export class VroHttpClient {
       }
       return {} as T;
     }
-    return JSON.parse(text) as T;
+    return this.parseJsonBody<T>(text, res, "POST", path);
   }
 
   get<T>(path: string, overrideBaseUrl?: string): Promise<T> {

--- a/test/vro-client.test.mjs
+++ b/test/vro-client.test.mjs
@@ -720,6 +720,47 @@ test("generic bodyless 2xx responses with a Location header do not synthesize an
   assert.equal(calls.length, 2);
 });
 
+test("non-JSON 2xx responses throw a contextualized error", async () => {
+  const htmlBody = "<html><body>Maintenance</body></html>" + "x".repeat(300);
+  globalThis.fetch = async (url, init) => {
+    if (String(url).includes("/sessions")) return authResponse();
+    return new Response(htmlBody, {
+      status: 200,
+      headers: { "content-type": "text/html", "x-request-id": "req-42" },
+    });
+  };
+
+  const client = new VroClient(config());
+  await assert.rejects(
+    () => client.getWorkflow("workflow-1"),
+    (error) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /non-JSON response body \(200/);
+      assert.match(error.message, /GET \/workflows\/workflow-1/);
+      assert.match(error.message, /x-request-id: req-42/);
+      assert.ok(error.message.includes("…"), "excerpt should be truncated");
+      assert.ok(
+        !error.message.includes("x".repeat(250)),
+        "raw body tail must not leak into the error",
+      );
+      return true;
+    },
+  );
+});
+
+test("whitespace-only 2xx responses throw a contextualized error", async () => {
+  globalThis.fetch = async (url) => {
+    if (String(url).includes("/sessions")) return authResponse();
+    return new Response("   ", { status: 200 });
+  };
+
+  const client = new VroClient(config());
+  await assert.rejects(
+    () => client.getWorkflow("workflow-1"),
+    /non-JSON response body .*GET \/workflows\/workflow-1/s,
+  );
+});
+
 test("startExecution parses a JSON 2xx body", async () => {
   const calls = [];
   globalThis.fetch = async (url, init) => {


### PR DESCRIPTION
## Summary

A non-JSON 2xx body (e.g. an HTML maintenance page from a load balancer or SSO interstitial) previously escaped as a bare `SyntaxError: Unexpected token '<'` with no method, path, or correlation ID — unlike the carefully sanitized non-2xx error path.

- New private `parseJsonBody<T>` helper in `VroHttpClient` wraps `JSON.parse` and throws `vRO API error: non-JSON response body (<status>) — METHOD path` followed by the `sanitizeErrorBody` output (correlation-ID header + truncated, non-leaking excerpt).
- Used from both `request<T>` and `startExecution<T>`.

## Tests

- 200 with >200-char HTML body + `x-request-id` header → error contains method/path, correlation ID, truncation ellipsis, and provably does NOT contain the body tail.
- Whitespace-only 200 body also rejects contextually.
- `npm run validate` passes (104 tests).

**Stacked on #90** — base is `vcfo-052-scope-synthetic-execution`; GitHub will retarget to `main` when #90 merges.

Fixes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)