### PR TITLE
[VCFO-054] Surface pagination truncation instead of silently returning partial data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - Query parameter values containing `$` or `~` are no longer un-encoded by the pagination query serializer; the literal-`$` exemption now applies only to OData system query keys such as `$filter` and `$search` (VCFO-050).
+- List results that stop at the pagination request cap now carry a `truncated` flag instead of silently returning partial data with the server's full total; list tools append a visible truncation warning and context snapshots record a per-domain warning (VCFO-054).
 
 ## 2.0.0 - 2026-05-18
 

--- a/src/client/action-client.ts
+++ b/src/client/action-client.ts
@@ -46,7 +46,11 @@ export class ActionClient {
         fqn: a["fqn"],
       };
     });
-    return { total: raw.total ?? link.length, link };
+    return {
+      total: raw.total ?? link.length,
+      link,
+      ...(raw.truncated ? { truncated: true } : {}),
+    };
   }
 
   private parseActionReference(

--- a/src/client/category-client.ts
+++ b/src/client/category-client.ts
@@ -47,6 +47,10 @@ export class CategoryClient {
       }
       return category;
     });
-    return { total: raw.total ?? link.length, link };
+    return {
+      total: raw.total ?? link.length,
+      link,
+      ...(raw.truncated ? { truncated: true } : {}),
+    };
   }
 }

--- a/src/client/configuration-client.ts
+++ b/src/client/configuration-client.ts
@@ -44,7 +44,11 @@ export class ConfigurationClient {
         categoryId: a["categoryId"] ?? a["category-id"] ?? a["categoryid"],
       };
     });
-    return { total: raw.total ?? link.length, link };
+    return {
+      total: raw.total ?? link.length,
+      link,
+      ...(raw.truncated ? { truncated: true } : {}),
+    };
   }
 
   private async listConfigurationsByCategory(

--- a/src/client/context-snapshot.ts
+++ b/src/client/context-snapshot.ts
@@ -68,41 +68,66 @@ export interface CollectContextSnapshotResult {
 
 export interface ContextSnapshotClient {
   getContextDirectory(): string;
-  listWorkflows(filter?: string): Promise<{ link: Workflow[]; total?: number }>;
+  listWorkflows(filter?: string): Promise<{
+    link: Workflow[];
+    total?: number;
+    truncated?: boolean;
+  }>;
   getWorkflow(id: string): Promise<Workflow>;
-  listActions(filter?: string): Promise<{ link: Action[]; total?: number }>;
+  listActions(filter?: string): Promise<{
+    link: Action[];
+    total?: number;
+    truncated?: boolean;
+  }>;
   getAction(id: string): Promise<Action>;
   listConfigurations(filter?: string): Promise<{
     link: ConfigElement[];
     total?: number;
+    truncated?: boolean;
   }>;
   getConfiguration(id: string): Promise<ConfigElement>;
   listResources(filter?: string): Promise<{
     link: ResourceElement[];
     total?: number;
+    truncated?: boolean;
   }>;
   listCategories(
     categoryType: string,
     filter?: string,
-  ): Promise<{ link: Category[]; total?: number }>;
+  ): Promise<{ link: Category[]; total?: number; truncated?: boolean }>;
   listTemplates(search?: string, projectId?: string): Promise<{
     content: Template[];
     totalElements?: number;
+    truncated?: boolean;
   }>;
   getTemplate(id: string): Promise<Template>;
   listCatalogItems(search?: string): Promise<{
     content: CatalogItem[];
     totalElements?: number;
+    truncated?: boolean;
   }>;
   getCatalogItem(id: string): Promise<CatalogItem>;
-  listEventTopics(): Promise<{ content: EventTopic[]; totalElements?: number }>;
+  listEventTopics(): Promise<{
+    content: EventTopic[];
+    totalElements?: number;
+    truncated?: boolean;
+  }>;
   listSubscriptions(projectId?: string): Promise<{
     content: Subscription[];
     totalElements?: number;
+    truncated?: boolean;
   }>;
-  listPackages(filter?: string): Promise<{ link: VroPackage[]; total?: number }>;
+  listPackages(filter?: string): Promise<{
+    link: VroPackage[];
+    total?: number;
+    truncated?: boolean;
+  }>;
   getPackage(name: string): Promise<VroPackage>;
-  listPlugins(filter?: string): Promise<{ link: VroPlugin[]; total?: number }>;
+  listPlugins(filter?: string): Promise<{
+    link: VroPlugin[];
+    total?: number;
+    truncated?: boolean;
+  }>;
 }
 
 interface DomainStats {
@@ -115,6 +140,7 @@ interface ListStatsSource<T> {
   content?: T[];
   total?: number;
   totalElements?: number;
+  truncated?: boolean;
 }
 
 type SnapshotSection = unknown[] | Record<string, unknown[]>;
@@ -247,6 +273,7 @@ async function collectDomain(
       );
     case "resources": {
       const list = await client.listResources();
+      noteListTruncation("resources", list, warnings);
       const items = sortByNameAndId(list.link ?? []).slice(0, maxItems);
       return {
         data: items.map(summarizeResource),
@@ -279,6 +306,7 @@ async function collectDomain(
       );
     case "eventTopics": {
       const list = await client.listEventTopics();
+      noteListTruncation("eventTopics", list, warnings);
       const items = sortByNameAndId(list.content ?? []).slice(0, maxItems);
       return {
         data: items.map(summarizeEventTopic),
@@ -287,6 +315,7 @@ async function collectDomain(
     }
     case "subscriptions": {
       const list = await client.listSubscriptions();
+      noteListTruncation("subscriptions", list, warnings);
       const items = sortByNameAndId(list.content ?? []).slice(0, maxItems);
       return {
         data: items.map(summarizeSubscription),
@@ -305,6 +334,7 @@ async function collectDomain(
       );
     case "plugins": {
       const list = await client.listPlugins();
+      noteListTruncation("plugins", list, warnings);
       const items = sortByNameAndId(list.link ?? []).slice(0, maxItems);
       return {
         data: items.map(summarizePlugin),
@@ -325,6 +355,7 @@ async function collectListWithDetails<TListItem, TDetail>(
   listField: "link" | "content" = "link",
 ): Promise<{ data: unknown[]; stats: DomainStats }> {
   const list = await listFn();
+  noteListTruncation(domain, list, warnings);
   const rawItems = (list[listField] ?? []) as TListItem[];
   const items = sortByNameAndId(rawItems).slice(0, maxItems);
   const data: unknown[] = [];
@@ -355,6 +386,7 @@ async function collectBuiltInWorkflows(
   const libraryCategoryIds =
     await getLibraryWorkflowDescendantCategoryIds(client, warnings);
   const list = await client.listWorkflows();
+  noteListTruncation("workflows", list, warnings);
   const filtered = (list.link ?? []).filter((workflow) =>
     isLibraryWorkflow(workflow, libraryCategoryIds),
   );
@@ -375,6 +407,7 @@ async function collectBuiltInActions(
   warnings: string[],
 ): Promise<{ data: unknown[]; stats: DomainStats }> {
   const list = await client.listActions();
+  noteListTruncation("actions", list, warnings);
   const filtered = (list.link ?? []).filter((action) =>
     isVmwareActionModule(action.module),
   );
@@ -441,6 +474,7 @@ async function collectCategories(
   for (const categoryType of CATEGORY_TYPES) {
     try {
       const list = await client.listCategories(categoryType);
+      noteListTruncation(`categories (${categoryType})`, list, warnings);
       const raw = list.link ?? [];
       data[categoryType] = sortByNameAndId(raw)
         .slice(0, maxItems)
@@ -912,6 +946,17 @@ function boundedStatsFromTotal(
     count,
     skipped: Math.max(0, reportedTotal - count),
   };
+}
+
+function noteListTruncation(
+  domain: string,
+  list: { truncated?: boolean },
+  warnings: string[],
+): void {
+  if (!list.truncated) return;
+  warnings.push(
+    `${domain}: server-side list was truncated by the pagination request limit; counts and skipped totals may be incomplete`,
+  );
 }
 
 function sortByNameAndId<T>(items: T[]): T[] {

--- a/src/client/package-client.ts
+++ b/src/client/package-client.ts
@@ -42,7 +42,11 @@ export class PackageClient {
         version: a["version"],
       };
     });
-    return { total: raw.total ?? link.length, link };
+    return {
+      total: raw.total ?? link.length,
+      link,
+      ...(raw.truncated ? { truncated: true } : {}),
+    };
   }
 
   async getPackage(name: string): Promise<VroPackage> {

--- a/src/client/pagination.ts
+++ b/src/client/pagination.ts
@@ -24,12 +24,16 @@ export interface VroPageResult<T> {
   link: T[];
   start?: number;
   total?: number;
+  /** Present (true) when collection stopped at the page-request cap. */
+  truncated?: boolean;
 }
 
 export interface AutomationPageResult<T> {
   content: T[];
   numberOfElements?: number;
   totalElements?: number;
+  /** Present (true) when collection stopped at the page-request cap. */
+  truncated?: boolean;
 }
 
 function isQueryCountUnsupported(error: unknown): boolean {
@@ -72,9 +76,14 @@ export async function getAllVroPages<T>(
   http: VroHttpClient,
   path: string,
   params: URLSearchParams = new URLSearchParams(),
-  options: { pageSize?: number; queryCount?: boolean } = {},
+  options: {
+    pageSize?: number;
+    queryCount?: boolean;
+    maxPageRequests?: number;
+  } = {},
 ): Promise<VroPageResult<T>> {
   const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE;
+  const maxPageRequests = options.maxPageRequests ?? MAX_PAGE_REQUESTS;
   let queryCount = options.queryCount ?? true;
   const link: T[] = [];
   let start = 0;
@@ -82,7 +91,8 @@ export async function getAllVroPages<T>(
   let reportedTotal: number | undefined;
   const seenPageSignatures = new Set<string>();
 
-  for (let requestCount = 0; requestCount < MAX_PAGE_REQUESTS; requestCount += 1) {
+  let requestCount = 0;
+  for (; requestCount < maxPageRequests; requestCount += 1) {
     const buildPagePath = (includeQueryCount: boolean): string => {
       const pageParams = new URLSearchParams(params);
       pageParams.set("maxResult", String(pageSize));
@@ -123,10 +133,12 @@ export async function getAllVroPages<T>(
     start += items.length;
   }
 
+  const truncated = requestCount >= maxPageRequests;
   return {
     link,
     ...(firstStart !== undefined ? { start: firstStart } : {}),
     total: reportedTotal ?? link.length,
+    ...(truncated ? { truncated } : {}),
   };
 }
 
@@ -135,14 +147,16 @@ export async function getAllAutomationPages<T>(
   path: string,
   baseUrl: string,
   params: URLSearchParams = new URLSearchParams(),
-  options: { pageSize?: number } = {},
+  options: { pageSize?: number; maxPageRequests?: number } = {},
 ): Promise<AutomationPageResult<T>> {
   const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE;
+  const maxPageRequests = options.maxPageRequests ?? MAX_PAGE_REQUESTS;
   const content: T[] = [];
   let reportedTotal: number | undefined;
   let totalPages: number | undefined;
 
-  for (let pageNumber = 0; pageNumber < MAX_PAGE_REQUESTS; pageNumber += 1) {
+  let pageNumber = 0;
+  for (; pageNumber < maxPageRequests; pageNumber += 1) {
     const pageParams = new URLSearchParams(params);
     pageParams.set("page", String(pageNumber));
     pageParams.set("size", String(pageSize));
@@ -170,9 +184,11 @@ export async function getAllAutomationPages<T>(
     }
   }
 
+  const truncated = pageNumber >= maxPageRequests;
   return {
     content,
     numberOfElements: content.length,
     totalElements: reportedTotal ?? content.length,
+    ...(truncated ? { truncated } : {}),
   };
 }

--- a/src/client/plugin-client.ts
+++ b/src/client/plugin-client.ts
@@ -24,6 +24,10 @@ export class PluginClient {
         type: a["type"],
       };
     });
-    return { total: raw.total ?? link.length, link };
+    return {
+      total: raw.total ?? link.length,
+      link,
+      ...(raw.truncated ? { truncated: true } : {}),
+    };
   }
 }

--- a/src/client/resource-client.ts
+++ b/src/client/resource-client.ts
@@ -37,7 +37,12 @@ export class ResourceClient {
         href: item.href,
       };
     });
-    return { total: raw.total ?? link.length, start: raw.start, link };
+    return {
+      total: raw.total ?? link.length,
+      start: raw.start,
+      link,
+      ...(raw.truncated ? { truncated: true } : {}),
+    };
   }
 
   async getResourceElement(id: string): Promise<ResourceElement> {

--- a/src/client/workflow-client.ts
+++ b/src/client/workflow-client.ts
@@ -528,7 +528,11 @@ export class WorkflowClient {
     const link = [...workflowsById.values()].sort((a, b) =>
       a.name.localeCompare(b.name),
     );
-    return { total: link.length, link };
+    return {
+      total: link.length,
+      link,
+      ...(rawCategories.truncated ? { truncated: true } : {}),
+    };
   }
 
   async listWorkflows(filter?: string): Promise<WorkflowList> {
@@ -539,6 +543,7 @@ export class WorkflowClient {
     let raw: {
       link: { attributes?: { name: string; value: string }[] }[];
       total?: number;
+      truncated?: boolean;
     };
     try {
       raw = await getAllVroPages<{
@@ -559,7 +564,11 @@ export class WorkflowClient {
         categoryName: a["categoryName"] ?? a["category-name"],
       };
     });
-    return { total: raw.total ?? link.length, link };
+    return {
+      total: raw.total ?? link.length,
+      link,
+      ...(raw.truncated ? { truncated: true } : {}),
+    };
   }
 
   async listWorkflowsByCategory(

--- a/src/tools/action-tools.ts
+++ b/src/tools/action-tools.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { formatPreflightReport } from "../client/artifact-preflight.js";
 import type { VroClient } from "../vro-client.js";
 import { DESTRUCTIVE_LIVE_WRITE } from "./annotations.js";
+import { truncationNote } from "./truncation.js";
 import {
   appendGuardGuidance,
   guardExpectedFields,
@@ -58,7 +59,7 @@ export function registerActionTools(
           content: [
             {
               type: "text",
-              text: `Found ${actions.length} action(s):\n\n${lines.join("\n")}`,
+              text: `Found ${actions.length} action(s):\n\n${lines.join("\n")}${truncationNote(result, actions.length, result.total)}`,
             },
           ],
         };

--- a/src/tools/catalog-tools.ts
+++ b/src/tools/catalog-tools.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { VroClient } from "../vro-client.js";
+import { truncationNote } from "./truncation.js";
 
 export function registerCatalogTools(
   server: McpServer,
@@ -41,7 +42,7 @@ export function registerCatalogTools(
           content: [
             {
               type: "text",
-              text: `Found ${total} catalog item(s):\n\n${lines.join("\n")}`,
+              text: `Found ${total} catalog item(s):\n\n${lines.join("\n")}${truncationNote(result, items.length, result.totalElements)}`,
             },
           ],
         };

--- a/src/tools/category-tools.ts
+++ b/src/tools/category-tools.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { VroClient } from "../vro-client.js";
+import { truncationNote } from "./truncation.js";
 
 export function registerCategoryTools(
   server: McpServer,
@@ -46,7 +47,7 @@ export function registerCategoryTools(
           content: [
             {
               type: "text",
-              text: `Found ${categories.length} ${type} category(ies):\n\n${lines.join("\n")}`,
+              text: `Found ${categories.length} ${type} category(ies):\n\n${lines.join("\n")}${truncationNote(result, categories.length, result.total)}`,
             },
           ],
         };

--- a/src/tools/config-tools.ts
+++ b/src/tools/config-tools.ts
@@ -3,6 +3,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { formatPreflightReport } from "../client/artifact-preflight.js";
 import type { VroClient } from "../vro-client.js";
+import { truncationNote } from "./truncation.js";
 import { DESTRUCTIVE_LIVE_WRITE } from "./annotations.js";
 import {
   appendGuardGuidance,
@@ -69,7 +70,7 @@ export function registerConfigTools(
           content: [
             {
               type: "text",
-              text: `Found ${configs.length} configuration element(s):\n\n${lines.join("\n")}`,
+              text: `Found ${configs.length} configuration element(s):\n\n${lines.join("\n")}${truncationNote(result, configs.length, result.total)}`,
             },
           ],
         };

--- a/src/tools/deployment-tools.ts
+++ b/src/tools/deployment-tools.ts
@@ -7,6 +7,7 @@ import type {
   DeploymentRequest,
 } from "../types.js";
 import type { VroClient } from "../vro-client.js";
+import { truncationNote } from "./truncation.js";
 import { DESTRUCTIVE_LIVE_WRITE } from "./annotations.js";
 import {
   guardExpectedFields,
@@ -136,7 +137,7 @@ export function registerDeploymentTools(
           content: [
             {
               type: "text",
-              text: `Found ${total} deployment(s):\n\n${lines.join("\n")}`,
+              text: `Found ${total} deployment(s):\n\n${lines.join("\n")}${truncationNote(result, items.length, result.totalElements)}`,
             },
           ],
         };

--- a/src/tools/package-tools.ts
+++ b/src/tools/package-tools.ts
@@ -3,6 +3,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { formatPreflightReport } from "../client/artifact-preflight.js";
 import type { VroClient } from "../vro-client.js";
+import { truncationNote } from "./truncation.js";
 import { DESTRUCTIVE_LIVE_WRITE } from "./annotations.js";
 import {
   appendGuardGuidance,
@@ -115,7 +116,7 @@ export function registerPackageTools(
           content: [
             {
               type: "text",
-              text: `Found ${packages.length} package(s):\n\n${lines.join("\n")}`,
+              text: `Found ${packages.length} package(s):\n\n${lines.join("\n")}${truncationNote(result, packages.length, result.total)}`,
             },
           ],
         };

--- a/src/tools/plugin-tools.ts
+++ b/src/tools/plugin-tools.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { VroClient } from "../vro-client.js";
+import { truncationNote } from "./truncation.js";
 
 export function registerPluginTools(
   server: McpServer,
@@ -42,7 +43,7 @@ export function registerPluginTools(
           content: [
             {
               type: "text",
-              text: `Found ${plugins.length} plugin(s):\n\n${lines.join("\n")}`,
+              text: `Found ${plugins.length} plugin(s):\n\n${lines.join("\n")}${truncationNote(result, plugins.length, result.total)}`,
             },
           ],
         };

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { VroClient } from "../vro-client.js";
+import { truncationNote } from "./truncation.js";
 import { DESTRUCTIVE_LIVE_WRITE } from "./annotations.js";
 import {
   appendGuardGuidance,
@@ -49,7 +50,7 @@ export function registerResourceTools(
           content: [
             {
               type: "text",
-              text: `Found ${resources.length} resource element(s):\n\n${lines.join("\n")}`,
+              text: `Found ${resources.length} resource element(s):\n\n${lines.join("\n")}${truncationNote(result, resources.length, result.total)}`,
             },
           ],
         };

--- a/src/tools/subscription-tools.ts
+++ b/src/tools/subscription-tools.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { VroClient } from "../vro-client.js";
+import { truncationNote } from "./truncation.js";
 import { DESTRUCTIVE_LIVE_WRITE } from "./annotations.js";
 import {
   guardExpectedFields,
@@ -40,7 +41,7 @@ export function registerSubscriptionTools(
           content: [
             {
               type: "text",
-              text: `Found ${topics.length} event topic(s):\n\n${lines.join("\n")}`,
+              text: `Found ${topics.length} event topic(s):\n\n${lines.join("\n")}${truncationNote(result, topics.length, result.totalElements)}`,
             },
           ],
         };
@@ -91,7 +92,7 @@ export function registerSubscriptionTools(
           content: [
             {
               type: "text",
-              text: `Found ${subs.length} subscription(s):\n\n${lines.join("\n")}`,
+              text: `Found ${subs.length} subscription(s):\n\n${lines.join("\n")}${truncationNote(result, subs.length, result.totalElements)}`,
             },
           ],
         };

--- a/src/tools/template-tools.ts
+++ b/src/tools/template-tools.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { VroClient } from "../vro-client.js";
+import { truncationNote } from "./truncation.js";
 import { DESTRUCTIVE_LIVE_WRITE } from "./annotations.js";
 import {
   guardExpectedFields,
@@ -52,7 +53,7 @@ export function registerTemplateTools(
           content: [
             {
               type: "text",
-              text: `Found ${total} template(s):\n\n${lines.join("\n")}`,
+              text: `Found ${total} template(s):\n\n${lines.join("\n")}${truncationNote(result, items.length, result.totalElements)}`,
             },
           ],
         };

--- a/src/tools/truncation.ts
+++ b/src/tools/truncation.ts
@@ -1,0 +1,15 @@
+/**
+ * Renders a warning for list results whose server-side pagination stopped at
+ * the page-request cap, so callers never mistake a partial list for the
+ * complete inventory. Returns an empty string for complete results.
+ */
+export function truncationNote(
+  list: { truncated?: boolean },
+  collected: number,
+  total?: number,
+): string {
+  if (!list.truncated) return "";
+  const ofTotal =
+    total !== undefined && total > collected ? ` of ~${total}` : "";
+  return `\n\n⚠️ Results truncated: the pagination request limit was reached after collecting ${collected}${ofTotal} item(s). Narrow the query with a filter to retrieve the rest.`;
+}

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -25,6 +25,7 @@ import {
   hasAnyExpectedValue,
 } from "./confirmation-guards.js";
 import type { VroClient } from "../vro-client.js";
+import { truncationNote } from "./truncation.js";
 
 const DEFAULT_WORKFLOW_WAIT_TIMEOUT_SECONDS = 300;
 const DEFAULT_WORKFLOW_POLL_INTERVAL_SECONDS = 2;
@@ -500,11 +501,12 @@ export function registerWorkflowTools(
           content: [
             {
               type: "text",
-              text: `Found ${workflows.length} workflow(s):\n\n${lines.join("\n")}`,
+              text: `Found ${workflows.length} workflow(s):\n\n${lines.join("\n")}${truncationNote(result, workflows.length, result.total)}`,
             },
           ],
           structuredContent: {
             workflows: workflows.map(structuredWorkflow),
+            ...(result.truncated ? { truncated: true } : {}),
           },
         };
       } catch (error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,8 @@ export interface WorkflowList {
   total?: number;
   start?: number;
   link: Workflow[];
+  /** Present (true) when server-side pagination stopped at the page-request cap. */
+  truncated?: boolean;
 }
 
 export interface ListWorkflowsByCategoryParams {
@@ -227,6 +229,8 @@ export interface ActionList {
   total?: number;
   start?: number;
   link: Action[];
+  /** Present (true) when server-side pagination stopped at the page-request cap. */
+  truncated?: boolean;
 }
 
 export type ActionDiffSource =
@@ -297,6 +301,8 @@ export interface ConfigElementList {
   total?: number;
   start?: number;
   link: ConfigElement[];
+  /** Present (true) when server-side pagination stopped at the page-request cap. */
+  truncated?: boolean;
 }
 
 // --- Categories ---
@@ -317,6 +323,8 @@ export interface CategoryList {
   total?: number;
   start?: number;
   link: Category[];
+  /** Present (true) when server-side pagination stopped at the page-request cap. */
+  truncated?: boolean;
 }
 
 // --- Extensibility Subscriptions (Event Broker) ---
@@ -343,6 +351,8 @@ export interface SubscriptionList {
   content: Subscription[];
   totalElements?: number;
   numberOfElements?: number;
+  /** Present (true) when server-side pagination stopped at the page-request cap. */
+  truncated?: boolean;
 }
 
 // --- Event Topics (Event Broker) ---
@@ -359,6 +369,8 @@ export interface EventTopicList {
   content: EventTopic[];
   totalElements?: number;
   numberOfElements?: number;
+  /** Present (true) when server-side pagination stopped at the page-request cap. */
+  truncated?: boolean;
 }
 
 // --- Catalog Items (Service Broker) ---
@@ -389,6 +401,8 @@ export interface CatalogItemList {
   content: CatalogItem[];
   totalElements?: number;
   numberOfElements?: number;
+  /** Present (true) when server-side pagination stopped at the page-request cap. */
+  truncated?: boolean;
 }
 
 // --- Deployments ---
@@ -413,6 +427,8 @@ export interface DeploymentList {
   content: Deployment[];
   totalElements?: number;
   numberOfElements?: number;
+  /** Present (true) when server-side pagination stopped at the page-request cap. */
+  truncated?: boolean;
 }
 
 export interface DeploymentActionInput {
@@ -496,6 +512,8 @@ export interface TemplateList {
   content: Template[];
   totalElements?: number;
   numberOfElements?: number;
+  /** Present (true) when server-side pagination stopped at the page-request cap. */
+  truncated?: boolean;
 }
 
 // --- vRO Packages ---
@@ -515,6 +533,8 @@ export interface VroPackage {
 export interface VroPackageList {
   total?: number;
   link: VroPackage[];
+  /** Present (true) when server-side pagination stopped at the page-request cap. */
+  truncated?: boolean;
 }
 
 export interface ProjectPackageResult {
@@ -568,6 +588,8 @@ export interface ResourceElementList {
   total?: number;
   start?: number;
   link: ResourceElement[];
+  /** Present (true) when server-side pagination stopped at the page-request cap. */
+  truncated?: boolean;
 }
 
 // --- vRO Plugins ---
@@ -583,6 +605,8 @@ export interface VroPlugin {
 export interface VroPluginList {
   total?: number;
   link: VroPlugin[];
+  /** Present (true) when server-side pagination stopped at the page-request cap. */
+  truncated?: boolean;
 }
 
 // --- Client config ---

--- a/test/context-snapshot.test.mjs
+++ b/test/context-snapshot.test.mjs
@@ -726,6 +726,48 @@ test("collectContextSnapshot skipped counts use reported list totals", async () 
   }
 });
 
+test("collectContextSnapshot warns when a domain list is truncated", async () => {
+  const contextDir = await mkdtemp(join(tmpdir(), "vcfa-context-"));
+  try {
+    const client = {
+      ...baseClient(contextDir),
+      listWorkflows: async () => ({
+        total: 50,
+        truncated: true,
+        link: [
+          { id: "wf-1", name: "Alpha" },
+          { id: "wf-2", name: "Beta" },
+        ],
+      }),
+      getWorkflow: async (id) => ({
+        id,
+        name: id,
+        description: "",
+        version: "1.0.0",
+        categoryName: "VCFA",
+        inputParameters: [],
+        outputParameters: [],
+      }),
+    };
+
+    const result = await collectContextSnapshot(client, {
+      fileBaseName: "truncated-list-check",
+      domains: ["workflows"],
+      maxItemsPerDomain: 10,
+    });
+
+    assert.ok(
+      result.warnings.some((warning) =>
+        /workflows: .*truncated by the pagination request limit/.test(warning),
+      ),
+    );
+    assert.equal(result.counts.workflows, 2);
+    assert.equal(result.skipped.workflows, 48);
+  } finally {
+    await rm(contextDir, { recursive: true, force: true });
+  }
+});
+
 test("collectContextSnapshot workflow items contain actionable metadata for next steps", async () => {
   const contextDir = await mkdtemp(join(tmpdir(), "vcfa-context-"));
   try {

--- a/test/deployment-tools.test.mjs
+++ b/test/deployment-tools.test.mjs
@@ -28,6 +28,23 @@ test("list-deployment-actions reports empty action lists", async () => {
   );
 });
 
+test("list-deployments surfaces a pagination truncation warning", async () => {
+  const handlers = registeredDeploymentTools({
+    listDeployments: async () => ({
+      totalElements: 50,
+      truncated: true,
+      content: [
+        { id: "deployment-1", name: "VM 1", status: "CREATE_SUCCESSFUL" },
+      ],
+    }),
+  });
+
+  const result = await handlers.get("list-deployments")({});
+
+  assert.match(result.content[0].text, /Results truncated/);
+  assert.match(result.content[0].text, /collecting 1 of ~50 item\(s\)/);
+});
+
 test("deployment tools list, get, create, and delete with confirmation", async () => {
   let createParams;
   let deletedId;

--- a/test/pagination.test.mjs
+++ b/test/pagination.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getAllAutomationPages,
+  getAllVroPages,
+} from "../dist/client/pagination.js";
+
+function vroHttpStub(total) {
+  return {
+    get: async (path) => {
+      const startIndex = Number(
+        new URL(`https://example.test${path}`).searchParams.get("startIndex"),
+      );
+      return {
+        link: startIndex < total ? [{ id: `item-${startIndex}` }] : [],
+        start: startIndex,
+        total,
+      };
+    },
+  };
+}
+
+function automationHttpStub(total) {
+  return {
+    get: async (path) => {
+      const page = Number(
+        new URL(`https://example.test${path}`).searchParams.get("page"),
+      );
+      return {
+        content: page < total ? [{ id: `item-${page}` }] : [],
+        totalElements: total,
+        last: page + 1 >= total,
+      };
+    },
+  };
+}
+
+test("getAllVroPages flags truncation when the page request cap is reached", async () => {
+  const result = await getAllVroPages(vroHttpStub(5), "/things", undefined, {
+    pageSize: 1,
+    maxPageRequests: 2,
+  });
+
+  assert.equal(result.link.length, 2);
+  assert.equal(result.total, 5);
+  assert.equal(result.truncated, true);
+});
+
+test("getAllVroPages omits truncated when pagination completes", async () => {
+  const result = await getAllVroPages(vroHttpStub(3), "/things", undefined, {
+    pageSize: 1,
+  });
+
+  assert.equal(result.link.length, 3);
+  assert.equal(result.total, 3);
+  assert.ok(!("truncated" in result));
+});
+
+test("getAllAutomationPages flags truncation when the page request cap is reached", async () => {
+  const result = await getAllAutomationPages(
+    automationHttpStub(5),
+    "/things",
+    "https://example.test",
+    undefined,
+    { pageSize: 1, maxPageRequests: 2 },
+  );
+
+  assert.equal(result.content.length, 2);
+  assert.equal(result.numberOfElements, 2);
+  assert.equal(result.totalElements, 5);
+  assert.equal(result.truncated, true);
+});
+
+test("getAllAutomationPages omits truncated when the server reports the last page", async () => {
+  const result = await getAllAutomationPages(
+    automationHttpStub(3),
+    "/things",
+    "https://example.test",
+    undefined,
+    { pageSize: 1 },
+  );
+
+  assert.equal(result.content.length, 3);
+  assert.equal(result.totalElements, 3);
+  assert.ok(!("truncated" in result));
+});

--- a/test/workflow-tools.test.mjs
+++ b/test/workflow-tools.test.mjs
@@ -165,6 +165,25 @@ test("list-workflows returns structured workflow summaries", async () => {
   });
 });
 
+test("list-workflows surfaces a pagination truncation warning", async () => {
+  const handlers = registeredWorkflowTools({
+    listWorkflows: async () => ({
+      link: [
+        { id: "workflow-1", name: "Create Org" },
+        { id: "workflow-2", name: "Delete Org" },
+      ],
+      total: 100,
+      truncated: true,
+    }),
+  });
+
+  const result = await handlers.get("list-workflows")({});
+
+  assert.match(result.content[0].text, /Results truncated/);
+  assert.match(result.content[0].text, /collecting 2 of ~100 item\(s\)/);
+  assert.equal(result.structuredContent.truncated, true);
+});
+
 test("list-workflows-by-category shows truncation warning", async () => {
   const handlers = registeredWorkflowTools({
     listWorkflowsByCategory: async () => ({


### PR DESCRIPTION
## Summary

Both paginators cap at `MAX_PAGE_REQUESTS` (1000) and silently returned partial lists with the server's full `total`/`totalElements`, so snapshot/diff/import logic could operate on incomplete data with no signal.

Design: `total`/`totalElements` keep reporting the **server total** (so the snapshot's `skipped = total - count` math stays correct), and a `truncated: true` flag is added **only when the cap exit fired** — zero shape change in the common case.

- `src/client/pagination.ts`: `truncated` on both result types, `maxPageRequests` option (test hook), counters hoisted to detect the cap exit.
- vRO list clients (`action/category/resource/package/plugin/configuration/workflow`) propagate the flag; Automation clients pass the paginator result through, and the 12 `*List` interfaces in `types.ts` declare the field. The inline `raw` annotation in `WorkflowClient.listWorkflows` was widened so it doesn't erase the flag.
- New `src/tools/truncation.ts` → `truncationNote()`; appended in all 12 list-tool outputs ("⚠️ Results truncated: … collecting N of ~T item(s) …"); `list-workflows` also sets `structuredContent.truncated`.
- Context snapshot: `noteListTruncation()` pushes a per-domain warning from `collectListWithDetails`, the direct domain branches, the built-ins collectors, and per-category lookups.

## Tests

- New `test/pagination.test.mjs`: cap-hit → flag set + server total preserved; clean completion → flag omitted (both paginators).
- `list-workflows` / `list-deployments` truncation-warning tool tests.
- `collectContextSnapshot` truncated-domain warning test (skipped still uses server total).
- `npm run validate` passes (258 tests, coverage 91.9% lines / 80.9% branches).

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)