### PR TITLE
chore: prepare 2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,24 @@
 ### Security
 
 - `VCFA_IGNORE_TLS=true` no longer disables TLS certificate verification process-wide via `NODE_TLS_REJECT_UNAUTHORIZED`. TLS relaxation is now scoped to the client's own requests to the configured VCFA host through a dedicated HTTPS agent, so other HTTPS traffic in the same Node process keeps full certificate verification. The minimum supported Node.js version is now 18.17.
+- `get-configuration` now redacts `SecureString` attribute values instead of returning them in plain text (VCFO-048).
 
 ### Added
 
 - Added a Claude Code plugin (`vcfa-orchestrator`) and marketplace manifest under `.claude-plugin/`, bundling two skills in `skills/`: `vcfa-authoring` (discovery-first artifact lifecycle and package-first publishing) and `vcfa-operations` (running workflows and guided troubleshooting). The skills delegate to the server's existing `vcfa-*` prompts, resources, and tools rather than duplicating them, and `npm run validate:docs` now drift-checks the tool/prompt/resource names they reference.
 - Added `VroClient.close()` to release the client's network resources (the TLS-relaxed dispatcher); the server now calls it during graceful shutdown.
 - Added a local TLS integration test that runs the client against a self-signed HTTPS server, verifying `ignoreTls` completes a real handshake (and that strict mode still rejects) without touching `NODE_TLS_REJECT_UNAUTHORIZED`.
+- Added optional two-phase confirmation fields to high-risk live mutation tools: when expected target fields such as `expectedName`, `expectedCategoryId`/`expectedCategoryName`, `expectedPackageName`, `expectedWorkflowName`/`expectedInputNames`, or `expectedDeploymentName`/`expectedActionName` are supplied, the handler performs read-only discovery first and refuses to mutate if the live target does not match. Omitted fields keep existing `confirm: true` behavior unchanged.
+- Workflow tools now return `structuredContent` (structured workflow, execution, and execution-log shapes) alongside their text output.
 
 ### Changed
 
 - `get-template`, `get-action`, and `get-subscription` now summarize bulky content (blueprint YAML, action script, constraints JSON) as a sha256 + length line by default, consistent with context-snapshot redaction; the new `includeContent`, `includeScript`, and `includeConstraints` flags restore the full output (VCFO-055).
+- Tools that overwrite or delete live state — import, update, run, and delete tools, plus `rebuild-project-package` — now advertise `destructiveHint: true` in their MCP annotations so hosts can require heightened approval; additive creates and `add-*-to-project-package` tools do not (VCFO-051).
 
 ### Fixed
 
+- `run-workflow` now validates and type-normalizes caller-supplied inputs through the same shared preamble as `run-workflow-and-wait` instead of POSTing them to the live workflow unvalidated; the two handlers' drifted input schemas (`inputs[].type` required in one, optional in the other) are reconciled (VCFO-047).
 - Query parameter values containing `$` or `~` are no longer un-encoded by the pagination query serializer; the literal-`$` exemption now applies only to OData system query keys such as `$filter` and `$search` (VCFO-050).
 - Empty-body 2xx responses with a `Location` header no longer masquerade as a running workflow execution for non-execution endpoints; the synthetic `{ id, state: "running" }` shape is now scoped to the explicit workflow-execution start path (`startExecution`), and generic empty 2xx responses return `{}` (VCFO-052).
 - A 2xx response with a non-JSON body (for example an HTML error page from a load balancer or SSO interstitial) now throws a sanitized, contextualized error naming the method, path, and correlation ID instead of a bare `SyntaxError: Unexpected token` (VCFO-053).

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Node.js 18.0 or higher.
+- Node.js 18.17 or higher.
 - A VCF Automation 9.x or Aria Automation 8.x instance with REST API access.
 - Credentials for the VCF Cloud API.
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -8,7 +8,7 @@ Tools are grouped by operating domain. Each tool carries an MCP annotation hint 
 
 Each tool lists its input schema in a collapsible parameters section. Required confirmation fields such as `confirm` must be set to `true` before the tool performs the write or destructive operation.
 
-Discovery list tools automatically follow server-side pagination for both vRO `/vco/api` list responses and VCF Automation service pages. Tool inputs stay focused on filters and selectors; callers do not need to provide page cursors for normal discovery.
+Discovery list tools automatically follow server-side pagination for both vRO `/vco/api` list responses and VCF Automation service pages. Tool inputs stay focused on filters and selectors; callers do not need to provide page cursors for normal discovery. If a listing stops at the pagination request cap before reaching the server's full total, the result carries a `truncated` flag and the tool output ends with a visible truncation warning (and context snapshots record a per-domain warning) instead of silently returning partial data.
 
 ## Two-Phase Confirmation Fields
 


### PR DESCRIPTION
## Summary
- Backfill missing `Unreleased` changelog entries found in the pre-release consistency review:
  - **Security**: `get-configuration` SecureString redaction (VCFO-048)
  - **Added**: optional two-phase confirmation fields (`expectedName` et al.); `structuredContent` in workflow tools
  - **Changed**: `destructiveHint: true` annotations on overwriting import/run/update/delete tools (VCFO-051)
  - **Fixed**: `run-workflow` input validation via the shared preamble (VCFO-047)
- Fix the installation guide's Node.js prerequisite (18.0 → 18.17) to match the `engines` floor.
- Document the pagination `truncated` flag and truncation warning (VCFO-054) in the tool reference.

## Validation
- `npm run validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)