### PR TITLE
chore: release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## 2.1.0 - 2026-06-12
+
+This release scopes TLS relaxation to the client's own requests, hardens response parsing and artifact preflight, gates bulky tool output behind opt-in flags, adds two-phase confirmation fields for live mutations, and ships a Claude Code plugin with authoring and operations skills.
 
 ### Security
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mgovedarov/mcp-vcf-orchestrator",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mgovedarov/mcp-vcf-orchestrator",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mgovedarov/mcp-vcf-orchestrator",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "MCP server for VCF Automation Orchestrator — manage workflows, actions, configuration elements, and extensibility subscriptions via AI assistants",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump package metadata to 2.1.0.
- Promote the `Unreleased` changelog section to `2.1.0 - 2026-06-12` with a release intro.
- No source change needed for the advertised MCP server version — it is read from `package.json` at runtime.

After merge: tag `v2.1.0` and publish the GitHub Release, which triggers the npm publish workflow.

## Validation
- `npm run validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)