### PR TITLE
[VCFO-057][VCFO-058] VCF 9.1 API version negotiation, provider logins, and canonical vRO type keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,17 @@
 # VCF Automation connection settings
 VCFA_HOST=vcfa.example.com
 VCFA_USERNAME=administrator
+# Organization name (the tenant URL slug, not the display name).
+# Provider/system administrators set "system", which routes the login to
+# /cloudapi/1.0.0/sessions/provider.
 VCFA_ORGANIZATION=your-organization-here
 VCFA_PASSWORD=your-password-here
+
+# Optional: target platform mode. "vcfa" (default) auto-negotiates the VCF
+# Cloud API version (9.1.0 preferred, then 9.0.0) via GET /api/versions.
+# "vcfa9.1" or "vcfa9.0" pin the version and skip the probe. "vra8" targets
+# vRA/vRO 8.12+ Basic-auth mode against /vco/api.
+# VCFA_TARGET_PLATFORM=vcfa
 
 # Set to "true" to allow self-signed TLS certificates for requests to the
 # configured VCFA host only (common in lab environments)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,8 @@ Many write-capable tools require a `confirm: true` argument before they mutate s
 
 In `vra8` mode, support only vRO `/vco/api` read operations plus workflow execution and execution logs. Automation-service APIs such as catalog, deployments, templates, subscriptions, and event topics are intentionally unsupported in Basic-auth mode until token-auth support is added.
 
+On the default `vcfa` platform, the client auto-negotiates the VCF Cloud API version (`9.1.0` preferred, then `9.0.0`) via the unauthenticated `GET /api/versions` discovery document; `VCFA_TARGET_PLATFORM=vcfa9.1` or `vcfa9.0` pins it. Logins with `VCFA_ORGANIZATION=system` (case-insensitive) are routed to `/cloudapi/1.0.0/sessions/provider` for provider/system administrators; tenant logins use `/cloudapi/1.0.0/sessions` with the organization name (URL slug), not its display name.
+
 ## Current MCP Prompts And Resources
 
 Prefer server-provided prompts for larger VCFA/vRO tasks because they encode the repository's discovery and safety playbooks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - VCF Automation 9.1 support: the default `vcfa` platform now auto-negotiates the VCF Cloud API version before authenticating, probing the unauthenticated `GET /api/versions` discovery document and preferring `9.1.0` over `9.0.0`. A probe that fails outright falls back to `9.0.0` for that attempt only and discovery is retried on the next authentication; a probe that succeeds but advertises no known version caches the `9.0.0` fallback. Authentication is single-flighted, so concurrent requests share one probe and one session login. New `VCFA_TARGET_PLATFORM` values `vcfa9.1` and `vcfa9.0` pin the version explicitly and skip the probe (VCFO-057).
 - Provider/system administrator logins: `VCFA_ORGANIZATION=system` (case-insensitive) now routes authentication to `/cloudapi/1.0.0/sessions/provider`; the tenant `/sessions` endpoint rejects provider accounts with 401. Login 401 errors now include a hint distinguishing organization names from display names and pointing provider accounts at `VCFA_ORGANIZATION=system` (VCFO-057).
 
+### Fixed
+
+- Workflow execution and configuration attribute payloads now key parameter values by the canonical lowercase/hyphenated vRO type literal (`secure-string`, `date`, `mime-attachment`, …) instead of the display type from the definition (`SecureString`), which the vRO REST API rejects with a 400. `Array/<type>` inputs are serialized as `{"array": {"elements": [...]}}`, SDK object types (e.g. `VC:VirtualMachine`) as `{"sdk-object": {"id", "type"}}`, and plain-object `Properties` values as `{"properties": {"property": [...]}}` (VCFO-058).
+- `run-workflow` and `run-workflow-and-wait` input validation now rejects non-string values for `SecureString` and `EncryptedString` inputs instead of forwarding them to the vRO API (VCFO-058).
+
 ## 2.1.0 - 2026-06-12
 
 This release scopes TLS relaxation to the client's own requests, hardens response parsing and artifact preflight, gates bulky tool output behind opt-in flags, adds two-phase confirmation fields for live mutations, and ships a Claude Code plugin with authoring and operations skills.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- VCF Automation 9.1 support: the default `vcfa` platform now auto-negotiates the VCF Cloud API version before authenticating, probing the unauthenticated `GET /api/versions` discovery document and preferring `9.1.0` over `9.0.0`. A probe that fails outright falls back to `9.0.0` for that attempt only and discovery is retried on the next authentication; a probe that succeeds but advertises no known version caches the `9.0.0` fallback. Authentication is single-flighted, so concurrent requests share one probe and one session login. New `VCFA_TARGET_PLATFORM` values `vcfa9.1` and `vcfa9.0` pin the version explicitly and skip the probe (VCFO-057).
+- Provider/system administrator logins: `VCFA_ORGANIZATION=system` (case-insensitive) now routes authentication to `/cloudapi/1.0.0/sessions/provider`; the tenant `/sessions` endpoint rejects provider accounts with 401. Login 401 errors now include a hint distinguishing organization names from display names and pointing provider accounts at `VCFA_ORGANIZATION=system` (VCFO-057).
+
 ## 2.1.0 - 2026-06-12
 
 This release scopes TLS relaxation to the client's own requests, hardens response parsing and artifact preflight, gates bulky tool output behind opt-in flags, adds two-phase confirmation fields for live mutations, and ships a Claude Code plugin with authoring and operations skills.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Required at startup (the process exits if any is missing): `VCFA_HOST`, `VCFA_US
 
 Notable optional variables (see `.env.example` and `README.md` for the full table):
 
-- `VCFA_TARGET_PLATFORM` – `vcfa` (default, VCF Cloud API session flow) or `vra8` (vRA/vRO 8.12+ Basic-auth against `/vco/api`). `vra8` supports only vRO read operations plus workflow execution/logs; Automation-service APIs (catalog, deployments, templates, subscriptions, event topics) are intentionally unsupported in that mode.
+- `VCFA_TARGET_PLATFORM` – `vcfa` (default, VCF Cloud API session flow with API version auto-negotiation via `GET /api/versions`, preferring `9.1.0` then `9.0.0`), `vcfa9.1`/`vcfa9.0` (pin the VCF Cloud API version, skipping the probe), or `vra8` (vRA/vRO 8.12+ Basic-auth against `/vco/api`). `vra8` supports only vRO read operations plus workflow execution/logs; Automation-service APIs (catalog, deployments, templates, subscriptions, event topics) are intentionally unsupported in that mode. `VCFA_ORGANIZATION=system` (case-insensitive) routes the login to the provider sessions endpoint for provider/system administrators; tenant users set their org name (URL slug, not display name).
 - `VCFA_IGNORE_TLS` – `true` skips TLS verification for the client's VCFA requests only (lab use only).
 - Artifact directories: `VCFA_ARTIFACT_DIR` (root, defaults to `artifacts/` under the process cwd) and per-kind overrides `VCFA_WORKFLOW_DIR`, `VCFA_ACTION_DIR`, `VCFA_CONFIGURATION_DIR`, `VCFA_RESOURCE_DIR`, `VCFA_PACKAGE_DIR`, `VCFA_EXECUTION_LOG_DIR`, `VCFA_CONTEXT_DIR`.
 - Package-first publishing: `VCFA_PROJECT_PACKAGE_NAME` (stable fully-qualified package, e.g. `com.example.project`) and `VCFA_PROJECT_PACKAGE_DESCRIPTION`.

--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ Required environment variables:
 | --- | --- |
 | `VCFA_HOST` | VCF Automation hostname, for example `vcfa.example.com`. |
 | `VCFA_USERNAME` | Username without organization, for example `admin`. |
-| `VCFA_ORGANIZATION` | Organization or tenant, for example `System` or `vsphere.local`. |
+| `VCFA_ORGANIZATION` | Organization name (the tenant URL slug, not the display name), or `system` for provider/system administrator logins, which are routed to `/cloudapi/1.0.0/sessions/provider`. |
 | `VCFA_PASSWORD` | Password for the VCF Cloud API session, or the vRO Basic-auth password when `VCFA_TARGET_PLATFORM=vra8`. |
 
 Useful optional variables:
 
 | Variable | Description |
 | --- | --- |
-| `VCFA_TARGET_PLATFORM` | Target platform mode. Defaults to `vcfa`, which uses the VCF Cloud API session flow. Set to `vra8` for vRA/vRO 8.12+ Basic-auth mode against `/vco/api`; this mode supports vRO read operations plus workflow execution/logs and does not support Automation-service APIs such as catalog, deployments, templates, or subscriptions. |
+| `VCFA_TARGET_PLATFORM` | Target platform mode. Defaults to `vcfa`, which uses the VCF Cloud API session flow and auto-negotiates the API version (`9.1.0` preferred, then `9.0.0`) via the unauthenticated `GET /api/versions` discovery document. Set to `vcfa9.1` or `vcfa9.0` to pin the VCF Cloud API version and skip the probe. Set to `vra8` for vRA/vRO 8.12+ Basic-auth mode against `/vco/api`; this mode supports vRO read operations plus workflow execution/logs and does not support Automation-service APIs such as catalog, deployments, templates, or subscriptions. |
 | `VCFA_IGNORE_TLS` | Set to `true` to skip TLS certificate verification for this server's requests to the VCFA host (lab environments only). |
 | `VCFA_ARTIFACT_DIR` | Root directory for local artifact files. Defaults to `artifacts/` in the MCP server process working directory, typically the open project. |
 | `VCFA_PACKAGE_DIR` | Override package artifact directory. |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -8,16 +8,26 @@ The server reads all runtime configuration from environment variables.
 | --- | --- | --- |
 | `VCFA_HOST` | Yes | VCF Automation hostname, for example `vcfa.example.com`. |
 | `VCFA_USERNAME` | Yes | Username without organization, for example `admin`. |
-| `VCFA_ORGANIZATION` | Yes | Organization or tenant, for example `System` or `vsphere.local`. |
+| `VCFA_ORGANIZATION` | Yes | Organization name (the tenant URL slug, not the display name), or `system` for provider/system administrator logins. |
 | `VCFA_PASSWORD` | Yes | Password for the VCF Cloud API session, or the vRO Basic-auth password when `VCFA_TARGET_PLATFORM=vra8`. |
 
-The server authenticates by sending Basic Auth as `{VCFA_USERNAME}@{VCFA_ORGANIZATION}:{VCFA_PASSWORD}` to:
+The server authenticates by sending Basic Auth as `{VCFA_USERNAME}@{VCFA_ORGANIZATION}:{VCFA_PASSWORD}` to the VCF Cloud API session endpoint. Tenant logins use:
 
 ```text
 https://{VCFA_HOST}/cloudapi/1.0.0/sessions
 ```
 
+When `VCFA_ORGANIZATION` is `system` (case-insensitive), the login is routed to the dedicated provider endpoint instead — the tenant endpoint rejects provider accounts with 401:
+
+```text
+https://{VCFA_HOST}/cloudapi/1.0.0/sessions/provider
+```
+
 It uses the returned bearer token for later VCF Automation, Service Broker, Cloud Assembly, and vRO API calls.
+
+### VCF Cloud API Version Negotiation
+
+VCF Automation 9.1 introduces API version `9.1.0` alongside `9.0.0`. Before authenticating, the server probes the unauthenticated discovery document at `https://{VCFA_HOST}/api/versions` and selects the newest API version it knows (`9.1.0` preferred, then `9.0.0`) for the session request. If the probe fails or advertises no known version, the server falls back to `9.0.0`, which 9.1 servers still accept. Set `VCFA_TARGET_PLATFORM` to `vcfa9.1` or `vcfa9.0` to pin the version explicitly and skip the probe.
 
 For vRA/vRO 8.12+ read/run compatibility, set `VCFA_TARGET_PLATFORM=vra8`. In that mode, the server skips the VCF Cloud API session endpoint and sends Basic auth directly to `/vco/api`. The vRA/vRO 8 mode supports vRO read operations plus workflow execution and execution logs; Automation-service APIs such as catalog, deployments, templates, subscriptions, and event topics are intentionally unsupported until token-auth support is added.
 
@@ -25,7 +35,7 @@ For vRA/vRO 8.12+ read/run compatibility, set `VCFA_TARGET_PLATFORM=vra8`. In th
 
 | Variable | Description |
 | --- | --- |
-| `VCFA_TARGET_PLATFORM` | Target platform mode: `vcfa` (default) or `vra8`. |
+| `VCFA_TARGET_PLATFORM` | Target platform mode: `vcfa` (default, auto-negotiates the VCF Cloud API version), `vcfa9.1`/`vcfa9.0` (pin the VCF Cloud API version, skipping the `GET /api/versions` probe), or `vra8`. |
 | `VCFA_IGNORE_TLS` | Set to `true` to disable TLS certificate verification for this server's requests to the VCFA host (lab environments only). |
 | `VCFA_ARTIFACT_DIR` | Root directory for local artifact import/export files. Defaults to `artifacts/` in the MCP server process working directory, typically the open project. |
 | `VCFA_PACKAGE_DIR` | Override the package artifact directory. |

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -11,6 +11,14 @@ VCFA_ORGANIZATION=...
 VCFA_PASSWORD=...
 ```
 
+## 401 Unauthorized At Login
+
+The session request sends Basic auth as `{VCFA_USERNAME}@{VCFA_ORGANIZATION}`. If credentials are correct but the login still returns 401:
+
+- `VCFA_ORGANIZATION` must be the organization **name** (the tenant URL slug, for example the `<orgName>` in `https://<host>/tenant/<orgName>`), not its display name.
+- Provider/system administrator accounts must set `VCFA_ORGANIZATION=system`. That routes the login to `/cloudapi/1.0.0/sessions/provider`; the tenant `/sessions` endpoint rejects provider accounts with 401 regardless of password.
+- The server auto-negotiates the VCF Cloud API version (`9.1.0` on VCF Automation 9.1, `9.0.0` otherwise) via `GET /api/versions`. If negotiation misbehaves against an unusual target, pin it with `VCFA_TARGET_PLATFORM=vcfa9.1` or `vcfa9.0`.
+
 ## TLS Errors In Lab Environments
 
 For lab systems with self-signed certificates, set:

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -1,7 +1,11 @@
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { Agent } from "undici";
-import type { VroClientConfig, VroTargetPlatform } from "../types.js";
+import type {
+  VroClientConfig,
+  VroTargetPlatform,
+  VroTargetPlatformInput,
+} from "../types.js";
 
 const UNSUPPORTED_AUTOMATION_SERVICES =
   "Automation-service APIs (catalog, deployments, templates, subscriptions, and event topics) are not supported in VCFA_TARGET_PLATFORM=vra8 Basic-auth mode. This mode supports vRO /vco/api read operations plus workflow execution and execution logs.";
@@ -78,17 +82,65 @@ export function sanitizeErrorBody(rawText: string, res?: Response): string {
   return parts.join("\n");
 }
 
+// Known VCF Cloud API versions this client can speak, newest first. Version
+// negotiation picks the first entry the target server advertises via the
+// unauthenticated GET /api/versions discovery document.
+const VCFA_KNOWN_API_VERSIONS = ["9.1.0", "9.0.0"] as const;
+// Used when discovery fails or advertises no known version. 9.0.0 is the most
+// compatible choice: 9.1 servers still accept it, while 9.0 servers reject
+// 9.1.0 outright.
+const VCFA_FALLBACK_API_VERSION = "9.0.0";
+
 export function normalizeTargetPlatform(
   value: VroClientConfig["targetPlatform"] | string | undefined,
 ): VroTargetPlatform {
   const normalized = value?.toLowerCase();
-  if (normalized === undefined || normalized === "" || normalized === "vcfa") {
+  if (
+    normalized === undefined ||
+    normalized === "" ||
+    normalized === "vcfa" ||
+    normalized === "vcfa9.0" ||
+    normalized === "vcfa9.1"
+  ) {
     return "vcfa";
   }
   if (normalized === "vra8") {
     return "vra8";
   }
-  throw new Error("targetPlatform must be one of: vcfa, vra8.");
+  throw new Error(
+    "targetPlatform must be one of: vcfa, vcfa9.0, vcfa9.1, vra8.",
+  );
+}
+
+/**
+ * Resolve an explicit VCF Cloud API version pin from the target platform
+ * value. `vcfa9.0`/`vcfa9.1` pin the session API version and skip the
+ * GET /api/versions discovery probe; plain `vcfa` (and `vra8`) return
+ * undefined, meaning auto-negotiation.
+ */
+export function resolvePinnedApiVersion(
+  value: VroClientConfig["targetPlatform"] | string | undefined,
+): string | undefined {
+  const normalized = value?.toLowerCase();
+  if (normalized === "vcfa9.0") return "9.0.0";
+  if (normalized === "vcfa9.1") return "9.1.0";
+  return undefined;
+}
+
+/**
+ * Validate a targetPlatform configuration value and return it in canonical
+ * lowercase input form, preserving the `vcfa9.0`/`vcfa9.1` pins that
+ * normalizeTargetPlatform collapses into the `vcfa` platform.
+ */
+export function normalizeTargetPlatformInput(
+  value: VroClientConfig["targetPlatform"] | string | undefined,
+): VroTargetPlatformInput {
+  const platform = normalizeTargetPlatform(value);
+  const normalized = value?.toLowerCase();
+  if (normalized === "vcfa9.0" || normalized === "vcfa9.1") {
+    return normalized;
+  }
+  return platform;
 }
 
 /**
@@ -113,8 +165,15 @@ export class VroHttpClient {
   readonly contextDir: string;
 
   private sessionUrl: string;
+  private versionsUrl: string;
+  private isProviderLogin: boolean;
+  private pinnedApiVersion: string | undefined;
+  private negotiatedApiVersion: string | null = null;
   private loginHeader: string;
   private token: string | null = null;
+  // Shared in-flight authentication so concurrent requests on a fresh or
+  // expired session run one version probe and one session POST, not one each.
+  private authInFlight: Promise<void> | null = null;
   // Per-client dispatcher so ignoreTls relaxes TLS verification only for
   // this client's requests, never process-wide (no NODE_TLS_REJECT_UNAUTHORIZED).
   private readonly dispatcher: Agent | undefined;
@@ -130,7 +189,15 @@ export class VroHttpClient {
     this.catalogBaseUrl = `https://${config.host}/catalog/api`;
     this.deploymentBaseUrl = `https://${config.host}/deployment/api`;
     this.blueprintBaseUrl = `https://${config.host}/blueprint/api`;
-    this.sessionUrl = `https://${config.host}/cloudapi/1.0.0/sessions`;
+    // Provider/system administrators authenticate at the dedicated provider
+    // session endpoint; the tenant endpoint rejects them with 401.
+    this.isProviderLogin =
+      config.organization.trim().toLowerCase() === "system";
+    this.sessionUrl = this.isProviderLogin
+      ? `https://${config.host}/cloudapi/1.0.0/sessions/provider`
+      : `https://${config.host}/cloudapi/1.0.0/sessions`;
+    this.versionsUrl = `https://${config.host}/api/versions`;
+    this.pinnedApiVersion = resolvePinnedApiVersion(config.targetPlatform);
     const artifactDir = resolve(
       config.artifactDir ?? join(tmpdir(), "mcp-vcf-orchestrator"),
     );
@@ -177,7 +244,7 @@ export class VroHttpClient {
       return this.loginHeader;
     }
     if (!this.token) {
-      await this.authenticate();
+      await this.startAuthentication();
     }
     if (!this.token) {
       throw new Error("Authentication did not produce a bearer token");
@@ -185,8 +252,76 @@ export class VroHttpClient {
     return this.token;
   }
 
+  private startAuthentication(): Promise<void> {
+    if (!this.authInFlight) {
+      this.authInFlight = this.authenticate().finally(() => {
+        this.authInFlight = null;
+      });
+    }
+    return this.authInFlight;
+  }
+
+  /**
+   * Determine the VCF Cloud API version to use for the session request.
+   * An explicit `vcfa9.0`/`vcfa9.1` pin wins; otherwise the unauthenticated
+   * GET /api/versions discovery document is probed and the newest mutually
+   * supported version is cached. A probe that completes but advertises no
+   * known version caches the 9.0.0 fallback; a probe that fails outright
+   * (network error, non-2xx, timeout) falls back to 9.0.0 for this attempt
+   * only, so the next authentication retries discovery.
+   */
+  private async negotiateApiVersion(): Promise<string> {
+    if (this.pinnedApiVersion) return this.pinnedApiVersion;
+    if (this.negotiatedApiVersion) return this.negotiatedApiVersion;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 30_000);
+    try {
+      const init: DispatchedRequestInit = {
+        method: "GET",
+        headers: { Accept: "*/*" },
+        signal: controller.signal,
+        dispatcher: this.dispatcher,
+      };
+      const res = await fetch(this.versionsUrl, init);
+      if (!res.ok) {
+        throw new Error(`${res.status} ${res.statusText}`);
+      }
+      const text = await res.text();
+      const advertised = new Set(
+        [...text.matchAll(/<Version>(\d+\.\d+\.\d+)<\/Version>/g)].map(
+          (m) => m[1],
+        ),
+      );
+      const chosen = VCFA_KNOWN_API_VERSIONS.find((v) => advertised.has(v));
+      if (chosen) {
+        console.error(
+          `[vro-client] Negotiated VCF Cloud API version ${chosen} via GET /api/versions`,
+        );
+        this.negotiatedApiVersion = chosen;
+      } else {
+        console.error(
+          `[vro-client] WARNING: GET /api/versions advertised no known API version (known: ${VCFA_KNOWN_API_VERSIONS.join(", ")}); falling back to ${VCFA_FALLBACK_API_VERSION}`,
+        );
+        this.negotiatedApiVersion = VCFA_FALLBACK_API_VERSION;
+      }
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      console.error(
+        `[vro-client] WARNING: VCF Cloud API version discovery failed (${reason}); falling back to ${VCFA_FALLBACK_API_VERSION} for this attempt. Discovery is retried on the next authentication; set VCFA_TARGET_PLATFORM=vcfa9.1 or vcfa9.0 to pin the version explicitly.`,
+      );
+      return VCFA_FALLBACK_API_VERSION;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+    return this.negotiatedApiVersion;
+  }
+
   private async authenticate(): Promise<void> {
-    console.error("[vro-client] Authenticating via VCF Cloud API sessions…");
+    const apiVersion = await this.negotiateApiVersion();
+    console.error(
+      `[vro-client] Authenticating via VCF Cloud API ${this.isProviderLogin ? "provider " : ""}sessions (version ${apiVersion})…`,
+    );
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 30_000);
 
@@ -196,8 +331,8 @@ export class VroHttpClient {
         method: "POST",
         headers: {
           Authorization: this.loginHeader,
-          "Content-Type": "application/json;version=9.0.0",
-          Accept: "application/json;version=9.0.0",
+          "Content-Type": `application/json;version=${apiVersion}`,
+          Accept: `application/json;version=${apiVersion}`,
         },
         signal: controller.signal,
         dispatcher: this.dispatcher,
@@ -209,8 +344,14 @@ export class VroHttpClient {
 
     if (!res.ok) {
       const text = await res.text().catch(() => "");
+      const hint =
+        res.status === 401
+          ? this.isProviderLogin
+            ? "\nHint: provider logins use the system organization — verify the username is a provider/system administrator account and the password is correct."
+            : '\nHint: VCFA_ORGANIZATION must be the organization name (the tenant URL slug), not its display name. Provider/system administrators must set VCFA_ORGANIZATION=system, which routes the login to /cloudapi/1.0.0/sessions/provider.'
+          : "";
       throw new Error(
-        `VCF authentication failed: ${res.status} ${res.statusText}\n${sanitizeErrorBody(text, res)}`,
+        `VCF authentication failed: ${res.status} ${res.statusText}\n${sanitizeErrorBody(text, res)}${hint}`,
       );
     }
 
@@ -279,7 +420,7 @@ export class VroHttpClient {
         res.status,
       );
       this.token = null;
-      await this.authenticate();
+      await this.startAuthentication();
       init.headers["Authorization"] = await this.authorizationHeader();
       return doFetch();
     }

--- a/src/client/parameters.ts
+++ b/src/client/parameters.ts
@@ -1,9 +1,80 @@
+const SDK_OBJECT_KEY = "sdk-object";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * The vRO REST API keys parameter values by the canonical lowercase/hyphenated
+ * type literal ("secure-string", "mime-attachment"), not the display type used
+ * in workflow definitions ("SecureString"). POST /workflows/{id}/executions
+ * rejects display-type keys with a 400 HTML error page, so the workflow's
+ * declared type cannot be used verbatim as the JSON key.
+ */
+function vroValueKey(type: string): string {
+  const lower = type.toLowerCase();
+  // Array and composite checks must precede the SDK-object check: both
+  // "Array/VC:VirtualMachine" and "CompositeType(field:string):Name"
+  // contain ":" without being plain SDK object types.
+  if (lower.startsWith("array/")) return "array";
+  if (lower.startsWith("composite")) return "composite";
+  if (type.includes(":")) return SDK_OBJECT_KEY;
+  return type.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
+}
+
+export function toVroParameterValue(
+  type: string,
+  value: unknown,
+): Record<string, unknown> {
+  const key = vroValueKey(type);
+
+  if (key === SDK_OBJECT_KEY) {
+    return {
+      [SDK_OBJECT_KEY]: isRecord(value) ? value : { id: value, type },
+    };
+  }
+
+  if (key === "array") {
+    const componentType = type.slice(type.indexOf("/") + 1);
+    const elements = (Array.isArray(value) ? value : [value]).map((element) =>
+      toVroParameterValue(componentType, element),
+    );
+    return { array: { elements } };
+  }
+
+  if (key === "properties" && isRecord(value)) {
+    if ("property" in value) {
+      return { properties: value };
+    }
+    return {
+      properties: {
+        property: Object.entries(value).map(([name, entry]) => ({
+          key: name,
+          value: toVroParameterValue(
+            typeof entry === "number" || typeof entry === "boolean"
+              ? typeof entry
+              : "string",
+            entry,
+          ),
+        })),
+      },
+    };
+  }
+
+  if (key === "composite" && isRecord(value)) {
+    return { composite: value };
+  }
+
+  return { [key]: { value } };
+}
+
 export function toVroParameters(
-  params: { name: string; type: string; value?: string }[],
-): { name: string; type: string; value?: Record<string, { value: string }> }[] {
+  params: { name: string; type: string; value?: unknown }[],
+): { name: string; type: string; value?: Record<string, unknown> }[] {
   return params.map((p) => ({
     name: p.name,
     type: p.type,
-    value: p.value !== undefined ? { [p.type]: { value: p.value } } : undefined,
+    value:
+      p.value !== undefined ? toVroParameterValue(p.type, p.value) : undefined,
   }));
 }

--- a/src/client/workflow-client.ts
+++ b/src/client/workflow-client.ts
@@ -35,6 +35,7 @@ import {
   resolveFileInDirectory,
 } from "./files.js";
 import { getAllVroPages } from "./pagination.js";
+import { toVroParameters } from "./parameters.js";
 import { buildWorkflowArtifact } from "./workflow-artifact.js";
 
 const LOG_SEVERITY_RANK: Record<string, number> = {
@@ -644,11 +645,7 @@ export class WorkflowClient {
   ): Promise<WorkflowExecution> {
     const body: Record<string, unknown> = {};
     if (inputs && inputs.length > 0) {
-      body.parameters = inputs.map((p) => ({
-        name: p.name,
-        type: p.type,
-        value: { [p.type]: { value: p.value } },
-      }));
+      body.parameters = toVroParameters(inputs);
     }
     return this.http.startExecution<WorkflowExecution>(
       `/workflows/${encodeURIComponent(id)}/executions`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,8 @@ import { registerResourceTools } from "./tools/resource-tools.js";
 import { registerSubscriptionTools } from "./tools/subscription-tools.js";
 import { registerTemplateTools } from "./tools/template-tools.js";
 import { registerWorkflowTools } from "./tools/workflow-tools.js";
-import { normalizeTargetPlatform as parseTargetPlatform } from "./client/core.js";
+import { normalizeTargetPlatformInput as parseTargetPlatform } from "./client/core.js";
+import type { VroTargetPlatformInput } from "./types.js";
 import { VroClient } from "./vro-client.js";
 import { createRequire } from "node:module";
 import { join, resolve } from "node:path";
@@ -147,12 +148,14 @@ async function main(): Promise<void> {
   });
 }
 
-function normalizeTargetPlatform(value: string | undefined): "vcfa" | "vra8" {
+function normalizeTargetPlatform(
+  value: string | undefined,
+): VroTargetPlatformInput {
   try {
     return parseTargetPlatform(value);
   } catch {
     console.error(
-      `ERROR: ${TARGET_PLATFORM_ENV} must be one of: vcfa, vra8.`,
+      `ERROR: ${TARGET_PLATFORM_ENV} must be one of: vcfa, vcfa9.0, vcfa9.1, vra8.`,
     );
     process.exit(1);
   }

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -203,7 +203,10 @@ function validateParameterValue(type: string, value: unknown): string | null {
   }
 
   const normalizedType = type.toLowerCase();
-  if (normalizedType === "string" && typeof value !== "string") {
+  if (
+    ["string", "securestring", "encryptedstring"].includes(normalizedType) &&
+    typeof value !== "string"
+  ) {
     return `must be a string for type ${type}`;
   }
   if (

--- a/src/types.ts
+++ b/src/types.ts
@@ -613,12 +613,22 @@ export interface VroPluginList {
 
 export type VroTargetPlatform = "vcfa" | "vra8";
 
+/**
+ * Accepted targetPlatform configuration values. `vcfa` auto-negotiates the
+ * VCF Cloud API version (9.1 preferred); `vcfa9.0`/`vcfa9.1` pin it
+ * explicitly. All `vcfa*` values normalize to the `vcfa` platform.
+ */
+export type VroTargetPlatformInput =
+  | VroTargetPlatform
+  | "vcfa9.0"
+  | "vcfa9.1";
+
 export interface VroClientConfig {
   host: string;
   username: string;
   organization: string;
   password: string;
-  targetPlatform?: VroTargetPlatform;
+  targetPlatform?: VroTargetPlatformInput;
   ignoreTls?: boolean;
   artifactDir?: string;
   packageDir?: string;

--- a/test/tls-integration.test.mjs
+++ b/test/tls-integration.test.mjs
@@ -19,6 +19,9 @@ const config = (host, overrides = {}) => ({
   username: "admin",
   organization: "org",
   password: "secret",
+  // Pin the Cloud API version so authentication skips the GET /api/versions
+  // discovery probe; version negotiation is covered in vro-client.test.mjs.
+  targetPlatform: "vcfa9.0",
   ...overrides,
 });
 

--- a/test/vro-client.test.mjs
+++ b/test/vro-client.test.mjs
@@ -18,6 +18,10 @@ import {
   VroHttpClient,
 } from "../dist/client/core.js";
 import { formatQuery } from "../dist/client/pagination.js";
+import {
+  toVroParameters,
+  toVroParameterValue,
+} from "../dist/client/parameters.js";
 import { VroClient } from "../dist/vro-client.js";
 
 const config = (overrides = {}) => ({
@@ -951,6 +955,117 @@ test("bodyless 202 responses with Location return an execution id", async () => 
   assert.equal(execution.id, "execution-123");
   assert.equal(execution.state, "running");
   assert.equal(calls.length, 2);
+});
+
+test("runWorkflow keys execution input values by the canonical vRO type literal", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) return authResponse();
+    return new Response("", {
+      status: 202,
+      headers: {
+        location:
+          "https://vcfa.example.test/vco/api/workflows/wf/executions/execution-123",
+      },
+    });
+  };
+
+  const client = new VroClient(config());
+  await client.runWorkflow("workflow-1", [
+    { name: "username", type: "string", value: "admin" },
+    { name: "password", type: "SecureString", value: "s3cret" },
+    { name: "expiry", type: "Date", value: "2026-06-12T00:00:00Z" },
+  ]);
+
+  const body = JSON.parse(calls[1].init.body);
+  assert.deepEqual(body.parameters, [
+    {
+      name: "username",
+      type: "string",
+      value: { string: { value: "admin" } },
+    },
+    {
+      name: "password",
+      type: "SecureString",
+      value: { "secure-string": { value: "s3cret" } },
+    },
+    {
+      name: "expiry",
+      type: "Date",
+      value: { date: { value: "2026-06-12T00:00:00Z" } },
+    },
+  ]);
+});
+
+test("toVroParameterValue maps display types to canonical value keys and shapes", () => {
+  assert.deepEqual(toVroParameterValue("SecureString", "s3cret"), {
+    "secure-string": { value: "s3cret" },
+  });
+  assert.deepEqual(toVroParameterValue("MimeAttachment", "data"), {
+    "mime-attachment": { value: "data" },
+  });
+  assert.deepEqual(toVroParameterValue("number", 7), {
+    number: { value: 7 },
+  });
+  assert.deepEqual(toVroParameterValue("Array/SecureString", ["a", "b"]), {
+    array: {
+      elements: [
+        { "secure-string": { value: "a" } },
+        { "secure-string": { value: "b" } },
+      ],
+    },
+  });
+  assert.deepEqual(toVroParameterValue("VC:VirtualMachine", "vm-123"), {
+    "sdk-object": { id: "vm-123", type: "VC:VirtualMachine" },
+  });
+  assert.deepEqual(toVroParameterValue("Array/VC:VirtualMachine", ["vm-1"]), {
+    array: {
+      elements: [
+        { "sdk-object": { id: "vm-1", type: "VC:VirtualMachine" } },
+      ],
+    },
+  });
+  assert.deepEqual(
+    toVroParameterValue("CompositeType(name:string,count:number):Pair", {
+      type: "CompositeType(name:string,count:number):Pair",
+      field: [{ name: "name", value: { string: { value: "a" } } }],
+    }),
+    {
+      composite: {
+        type: "CompositeType(name:string,count:number):Pair",
+        field: [{ name: "name", value: { string: { value: "a" } } }],
+      },
+    },
+  );
+  assert.deepEqual(
+    toVroParameterValue("Properties", { color: "blue", count: 2 }),
+    {
+      properties: {
+        property: [
+          { key: "color", value: { string: { value: "blue" } } },
+          { key: "count", value: { number: { value: 2 } } },
+        ],
+      },
+    },
+  );
+});
+
+test("toVroParameters omits the value wrapper for parameters without a value", () => {
+  assert.deepEqual(
+    toVroParameters([
+      { name: "password", type: "SecureString", value: "s3cret" },
+      { name: "optional", type: "string" },
+    ]),
+    [
+      {
+        name: "password",
+        type: "SecureString",
+        value: { "secure-string": { value: "s3cret" } },
+      },
+      { name: "optional", type: "string", value: undefined },
+    ],
+  );
 });
 
 test("generic bodyless 2xx responses with a Location header do not synthesize an execution", async () => {

--- a/test/vro-client.test.mjs
+++ b/test/vro-client.test.mjs
@@ -12,7 +12,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { buildWorkflowArtifact } from "../dist/client/workflow-artifact.js";
-import { sanitizeErrorBody, VroHttpClient } from "../dist/client/core.js";
+import {
+  normalizeTargetPlatformInput,
+  sanitizeErrorBody,
+  VroHttpClient,
+} from "../dist/client/core.js";
 import { formatQuery } from "../dist/client/pagination.js";
 import { VroClient } from "../dist/vro-client.js";
 
@@ -21,6 +25,9 @@ const config = (overrides = {}) => ({
   username: "admin",
   organization: "org",
   password: "secret",
+  // Pin the Cloud API version so authentication skips the GET /api/versions
+  // discovery probe; version negotiation has dedicated tests below.
+  targetPlatform: "vcfa9.0",
   ...overrides,
 });
 
@@ -554,7 +561,254 @@ test("vra8 platform paginates vRO lists with Basic auth", async () => {
 test("client rejects invalid target platform values", () => {
   assert.throws(
     () => new VroClient(config({ targetPlatform: "vro8" })),
-    /targetPlatform must be one of: vcfa, vra8/,
+    /targetPlatform must be one of: vcfa, vcfa9\.0, vcfa9\.1, vra8/,
+  );
+});
+
+// ─── VCF Cloud API version negotiation and login routing (VCFO-057) ─────────
+
+const versionsXml = (versions) =>
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<SupportedVersions xmlns="http://www.vmware.com/vcloud/versions">
+${versions
+  .map(
+    (v) => `    <VersionInfo deprecated="false">
+        <Version>${v}</Version>
+        <LoginUrl>https://vcfa.example.test/cloudapi/1.0.0/sessions</LoginUrl>
+    </VersionInfo>`,
+  )
+  .join("\n")}
+</SupportedVersions>`;
+
+test("vcfa auto-negotiation prefers API version 9.1.0 from GET /api/versions", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (String(url).endsWith("/api/versions")) {
+      return new Response(versionsXml(["40.0", "9.0.0", "9.1.0"]), {
+        status: 200,
+      });
+    }
+    if (String(url).includes("/cloudapi/1.0.0/sessions")) return authResponse();
+    return Response.json({ link: [], total: 0 });
+  };
+
+  const client = new VroClient(config({ targetPlatform: "vcfa" }));
+  await client.listWorkflows();
+
+  assert.equal(calls[0].url, "https://vcfa.example.test/api/versions");
+  assert.equal(
+    calls[1].url,
+    "https://vcfa.example.test/cloudapi/1.0.0/sessions",
+  );
+  assert.equal(
+    calls[1].init.headers.Accept,
+    "application/json;version=9.1.0",
+  );
+  assert.equal(
+    calls[1].init.headers["Content-Type"],
+    "application/json;version=9.1.0",
+  );
+  const probes = calls.filter((c) => c.url.endsWith("/api/versions"));
+  assert.equal(probes.length, 1, "discovery probe should run exactly once");
+});
+
+test("vcfa auto-negotiation falls back to 9.0.0 when no known version is advertised", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (String(url).endsWith("/api/versions")) {
+      return new Response(versionsXml(["8.7.0"]), { status: 200 });
+    }
+    if (String(url).includes("/cloudapi/1.0.0/sessions")) return authResponse();
+    return Response.json({ link: [], total: 0 });
+  };
+
+  const client = new VroClient(config({ targetPlatform: "vcfa" }));
+  await client.listWorkflows();
+
+  assert.equal(
+    calls[1].init.headers.Accept,
+    "application/json;version=9.0.0",
+  );
+});
+
+test("vcfa auto-negotiation falls back to 9.0.0 when the discovery probe fails", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (String(url).endsWith("/api/versions")) {
+      return new Response("not found", { status: 404, statusText: "Not Found" });
+    }
+    if (String(url).includes("/cloudapi/1.0.0/sessions")) return authResponse();
+    return Response.json({ link: [], total: 0 });
+  };
+
+  const client = new VroClient(config({ targetPlatform: "vcfa" }));
+  await client.listWorkflows();
+
+  assert.equal(
+    calls[1].init.headers.Accept,
+    "application/json;version=9.0.0",
+  );
+});
+
+test("a failed discovery probe is retried on the next authentication", async () => {
+  let probeCount = 0;
+  const sessionVersions = [];
+  let workflowCalls = 0;
+  globalThis.fetch = async (url, init) => {
+    if (String(url).endsWith("/api/versions")) {
+      probeCount += 1;
+      if (probeCount === 1) {
+        return new Response("boom", {
+          status: 503,
+          statusText: "Service Unavailable",
+        });
+      }
+      return new Response(versionsXml(["9.1.0", "9.0.0"]), { status: 200 });
+    }
+    if (String(url).includes("/cloudapi/1.0.0/sessions")) {
+      sessionVersions.push(init.headers.Accept);
+      return authResponse();
+    }
+    workflowCalls += 1;
+    // First workflow request gets 401 to force a token refresh + re-auth.
+    if (workflowCalls === 1) {
+      return new Response("", { status: 401, statusText: "Unauthorized" });
+    }
+    return Response.json({ link: [], total: 0 });
+  };
+
+  const client = new VroClient(config({ targetPlatform: "vcfa" }));
+  await client.listWorkflows();
+
+  assert.equal(probeCount, 2, "failed probe must be retried on re-auth");
+  assert.deepEqual(sessionVersions, [
+    "application/json;version=9.0.0",
+    "application/json;version=9.1.0",
+  ]);
+});
+
+test("concurrent first requests share one probe and one session login", async () => {
+  let probeCount = 0;
+  let sessionCount = 0;
+  globalThis.fetch = async (url) => {
+    if (String(url).endsWith("/api/versions")) {
+      probeCount += 1;
+      return new Response(versionsXml(["9.1.0"]), { status: 200 });
+    }
+    if (String(url).includes("/cloudapi/1.0.0/sessions")) {
+      sessionCount += 1;
+      return authResponse();
+    }
+    return Response.json({ link: [], total: 0 });
+  };
+
+  const client = new VroClient(config({ targetPlatform: "vcfa" }));
+  await Promise.all([
+    client.listWorkflows(),
+    client.listWorkflows(),
+    client.listWorkflows(),
+  ]);
+
+  assert.equal(probeCount, 1, "concurrent requests must share one probe");
+  assert.equal(sessionCount, 1, "concurrent requests must share one login");
+});
+
+test("normalizeTargetPlatformInput preserves version pins and validates input", () => {
+  assert.equal(normalizeTargetPlatformInput(undefined), "vcfa");
+  assert.equal(normalizeTargetPlatformInput(""), "vcfa");
+  assert.equal(normalizeTargetPlatformInput("VCFA"), "vcfa");
+  assert.equal(normalizeTargetPlatformInput("VCFA9.1"), "vcfa9.1");
+  assert.equal(normalizeTargetPlatformInput("vcfa9.0"), "vcfa9.0");
+  assert.equal(normalizeTargetPlatformInput("vra8"), "vra8");
+  assert.throws(
+    () => normalizeTargetPlatformInput("vro8"),
+    /targetPlatform must be one of: vcfa, vcfa9\.0, vcfa9\.1, vra8/,
+  );
+});
+
+test("vcfa9.1 pin skips the discovery probe and uses version 9.1.0", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (String(url).includes("/cloudapi/1.0.0/sessions")) return authResponse();
+    return Response.json({ link: [], total: 0 });
+  };
+
+  const client = new VroClient(config({ targetPlatform: "vcfa9.1" }));
+  await client.listWorkflows();
+
+  assert.equal(
+    calls.filter((c) => c.url.endsWith("/api/versions")).length,
+    0,
+    "pinned version must not probe GET /api/versions",
+  );
+  assert.equal(
+    calls[0].url,
+    "https://vcfa.example.test/cloudapi/1.0.0/sessions",
+  );
+  assert.equal(
+    calls[0].init.headers.Accept,
+    "application/json;version=9.1.0",
+  );
+});
+
+test("system organization routes login to the provider sessions endpoint", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (String(url).includes("/cloudapi/1.0.0/sessions")) return authResponse();
+    return Response.json({ link: [], total: 0 });
+  };
+
+  const client = new VroClient(config({ organization: "System" }));
+  await client.listWorkflows();
+
+  assert.equal(
+    calls[0].url,
+    "https://vcfa.example.test/cloudapi/1.0.0/sessions/provider",
+  );
+  assert.equal(
+    calls[0].init.headers.Authorization,
+    "Basic " + Buffer.from("admin@System:secret").toString("base64"),
+  );
+});
+
+test("tenant 401 failure hints at org name vs display name and provider logins", async () => {
+  globalThis.fetch = async (url) => {
+    if (String(url).includes("/cloudapi/1.0.0/sessions")) {
+      return new Response(JSON.stringify({ message: "Unauthorized" }), {
+        status: 401,
+        statusText: "Unauthorized",
+      });
+    }
+    return Response.json({ link: [], total: 0 });
+  };
+
+  const client = new VroClient(config());
+  await assert.rejects(
+    () => client.listWorkflows(),
+    /organization name \(the tenant URL slug\), not its display name[\s\S]*VCFA_ORGANIZATION=system/,
+  );
+});
+
+test("provider 401 failure hints at provider account verification", async () => {
+  globalThis.fetch = async (url) => {
+    if (String(url).includes("/cloudapi/1.0.0/sessions")) {
+      return new Response(JSON.stringify({ message: "Unauthorized" }), {
+        status: 401,
+        statusText: "Unauthorized",
+      });
+    }
+    return Response.json({ link: [], total: 0 });
+  };
+
+  const client = new VroClient(config({ organization: "system" }));
+  await assert.rejects(
+    () => client.listWorkflows(),
+    /provider logins use the system organization/,
   );
 });
 

--- a/test/workflow-tools.test.mjs
+++ b/test/workflow-tools.test.mjs
@@ -241,6 +241,44 @@ test("run-workflow-and-wait rejects strict validation errors before running", as
   assert.match(result.content[0].text, /Missing required input: count/);
 });
 
+test("run-workflow rejects non-string SecureString and EncryptedString values", async () => {
+  let runCalls = 0;
+  const handlers = registeredWorkflowTools({
+    getWorkflow: async () => ({
+      id: "workflow-1",
+      name: "Workflow",
+      inputParameters: [
+        { name: "password", type: "SecureString" },
+        { name: "apiKey", type: "EncryptedString" },
+      ],
+    }),
+    runWorkflow: async () => {
+      runCalls += 1;
+      return { id: "execution-1", state: "running" };
+    },
+  });
+
+  const result = await handlers.get("run-workflow")({
+    id: "workflow-1",
+    confirm: true,
+    inputs: [
+      { name: "password", value: 12345 },
+      { name: "apiKey", value: true },
+    ],
+  });
+
+  assert.equal(result.isError, true);
+  assert.equal(runCalls, 0);
+  assert.match(
+    result.content[0].text,
+    /Input password must be a string for type SecureString/,
+  );
+  assert.match(
+    result.content[0].text,
+    /Input apiKey must be a string for type EncryptedString/,
+  );
+});
+
 test("run-workflow-and-wait requires confirmation before discovery or execution", async () => {
   let getCalls = 0;
   let runCalls = 0;


### PR DESCRIPTION
## Summary

Two changes, one commit each:

### [VCFO-057] VCF 9.1 API version negotiation and provider session logins
- The default `vcfa` platform probes the unauthenticated `GET /api/versions` discovery document before authenticating and selects the newest mutually supported VCF Cloud API version (`9.1.0` preferred, then `9.0.0`). New `VCFA_TARGET_PLATFORM` values `vcfa9.1`/`vcfa9.0` pin the version and skip the probe.
- A probe that fails outright falls back to `9.0.0` for that attempt only and is retried on the next authentication; a successful probe advertising no known version caches the fallback.
- `VCFA_ORGANIZATION=system` (case-insensitive) routes the login to `/cloudapi/1.0.0/sessions/provider` for provider/system administrators; login 401s now include a hint distinguishing organization names (tenant URL slug) from display names.
- Authentication is single-flighted: concurrent requests on a fresh or expired session share one probe and one session POST.
- Docs updated: README, `.env.example`, configuration guide, new troubleshooting section for login 401s, AGENTS.md, CLAUDE.md.

### [VCFO-058] Key workflow execution values by canonical vRO type literal
- `runWorkflow` and the configuration-attribute helper built input values as `{ [p.type]: { value } }`, using the display type (`SecureString`) verbatim as the JSON key — the vRO REST API rejects this with a 400 (HTML error page). Verified against a live VCF Automation 9.1 lab: the API expects the canonical lowercase/hyphenated literal and echoes `secure-string`.
- Payload construction is centralized in `toVroParameterValue`: CamelCase display types map to hyphenated lowercase keys (`secure-string`, `date`, `mime-attachment`), `Array/<type>` serializes as `{"array": {"elements": [...]}}` with recursively keyed elements, SDK object types as `{"sdk-object": {"id", "type"}}`, and plain-object `Properties` values as `{"properties": {"property": [...]}}`. Array/composite checks precede the SDK-object check since both contain `:` in their display form.
- Tool-layer validation now rejects non-string `SecureString`/`EncryptedString` values instead of forwarding them.

## Test plan

- [x] `npm run validate` (build, 279 tests, coverage gate 92.3% lines / 81.9% branches, docs drift, VitePress build, package contents) passes
- [x] New tests: version negotiation (prefer 9.1.0, unknown-version and probe-failure fallbacks, probe retry after failure, pin skips probe, single-flight concurrency), provider-endpoint routing, both 401 hint variants, `normalizeTargetPlatformInput`
- [x] New tests: end-to-end `runWorkflow` POST body with `SecureString`/`Date` inputs, canonical key/shape mapping incl. `Array/VC:VirtualMachine` and composite types, non-string secure-value rejection
- [x] Payload key fix for `SecureString` verified against a live VCF Automation 9.1 lab; array/sdk-object/properties shapes follow the documented vRO REST contract — recommend one disposable `run-workflow-and-wait` lab smoke test for an `Array/string` input before relying on those paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)