### PR TITLE
chore: release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## 2.2.0 - 2026-06-12
+
+This release adds VCF Automation 9.1 support with automatic API version negotiation, provider/system administrator logins, and fixes workflow and configuration parameter payloads to use the canonical vRO type keys the REST API expects.
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mgovedarov/mcp-vcf-orchestrator",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mgovedarov/mcp-vcf-orchestrator",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mgovedarov/mcp-vcf-orchestrator",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "MCP server for VCF Automation Orchestrator — manage workflows, actions, configuration elements, and extensibility subscriptions via AI assistants",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Promotes the `Unreleased` changelog section to `2.2.0 - 2026-06-12` and bumps the package version. No source changes — the server reads its advertised version from package.json at runtime.

Release highlights (from PR #98, VCFO-057/VCFO-058):
- VCF Automation 9.1 support with automatic API version negotiation (`GET /api/versions`, preferring 9.1.0), plus `vcfa9.1`/`vcfa9.0` platform pins
- Provider/system administrator logins via `VCFA_ORGANIZATION=system`
- Canonical vRO type keys in workflow execution and configuration attribute payloads

`npm run validate` passes locally (build, tests, coverage gate, docs drift, VitePress build, package contents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)