### PR TITLE
[VCFO-060][VCFO-061] Make scaffolded workflows import, open, and run in live vRO 9.1

### DIFF
--- a/docs/artifacts/workflow-authoring.md
+++ b/docs/artifacts/workflow-authoring.md
@@ -10,7 +10,7 @@ A `.workflow` file is a ZIP archive containing:
 - `workflow-content`
 - `input_form_` — only when the workflow has UI-startable inputs.
 
-`workflow-content` is XML encoded as **UTF-16BE** with a big-endian BOM (`0xFE 0xFF`). The XML root is a vRO workflow document with metadata such as `id`, `version`, and `api-version`, plus `object-name="workflow:name=generic"` and `editor-version="2.0"`. Do **not** emit `allowed-operations` — it is the read-only marker on Library workflows and blocks the editor from opening an authored workflow. The workflow terminates in an explicit `<workflow-item type="end" end-mode="0">` chained from the last task's `out-name`.
+`workflow-content` is XML encoded as **UTF-16BE** with a big-endian BOM (`0xFE 0xFF`), and its **declaration must be `<?xml version='1.0' encoding='UTF-8'?>`** (single quotes, `UTF-8`) — vRO writes it that way and the VCF 9.x editor 500s on opening a workflow that declares `encoding="UTF-16"` (import/run still work). The XML root carries `id`, `version`, `api-version`, `object-name="workflow:name=generic"`, and `editor-version="2.0"`. Do **not** emit `allowed-operations` — it is the read-only marker on Library workflows and blocks the editor from opening an authored workflow. Params are bare `<param name type/>` (no `<description>` child); each item (start, tasks, end) needs a distinct `<position>`; tasks carry a non-empty `<description>`; and the workflow terminates in an explicit `<workflow-item type="end" end-mode="0">` with an empty `<in-binding/>`, chained from the last task's `out-name`.
 
 Workflow inputs live under `<input>` and outputs under `<output>`. Scriptable task logic lives in `<workflow-item type="task">` nodes.
 

--- a/docs/artifacts/workflow-authoring.md
+++ b/docs/artifacts/workflow-authoring.md
@@ -4,12 +4,13 @@ This page summarizes the repository's practical vRO workflow artifact knowledge.
 
 ## Workflow Artifact Format
 
-A `.workflow` file is a ZIP archive containing at least:
+A `.workflow` file is a ZIP archive containing:
 
-- `workflow-info`
+- `workflow-info` — a Java properties file (not XML) with fixed keys (`type=workflow`, `version=2.0`, `charset=UTF-16`, `unicode=true`, `creator=www.dunes.ch`, `owner=`).
 - `workflow-content`
+- `input_form_` — only when the workflow has UI-startable inputs.
 
-`workflow-content` is XML encoded as UTF-16 with a BOM. The XML root is a vRO workflow document with metadata such as `id`, `version`, and `api-version`.
+`workflow-content` is XML encoded as **UTF-16BE** with a big-endian BOM (`0xFE 0xFF`). The XML root is a vRO workflow document with metadata such as `id`, `version`, and `api-version`, plus `object-name="workflow:name=generic"` and `editor-version="2.0"`. Do **not** emit `allowed-operations` — it is the read-only marker on Library workflows and blocks the editor from opening an authored workflow. The workflow terminates in an explicit `<workflow-item type="end" end-mode="0">` chained from the last task's `out-name`.
 
 Workflow inputs live under `<input>` and outputs under `<output>`. Scriptable task logic lives in `<workflow-item type="task">` nodes.
 
@@ -83,7 +84,7 @@ Keep generated scripts readable because runtime errors often reference workflow 
 ## Common Pitfalls
 
 - `create-workflow` creates only an empty workflow shell; use `import-workflow-file` for real workflow content.
-- `.workflow` content must preserve UTF-16 encoding with BOM.
+- `.workflow` `workflow-content` must be UTF-16BE with a big-endian BOM, `workflow-info` must be the Java properties file, and the workflow must end in an explicit `<workflow-item type="end">`; otherwise live import fails with `400 "Not a valid workflow file"`.
 - Multipart imports break if `Content-Type` is set manually without the boundary.
 - Workflow execution is asynchronous; poll with `get-workflow-execution` or use `run-workflow-and-wait`.
 - Action imports use category/module name, while workflow and configuration imports use category IDs.

--- a/docs/vro-artifact-authoring.md
+++ b/docs/vro-artifact-authoring.md
@@ -10,14 +10,15 @@ These notes capture the practical details learned while adding workflow artifact
   - `workflow-content` — the workflow XML.
   - `input_form_` — only present when the workflow exposes inputs (UI-startable). Inputless workflows omit it and rely on the in-workflow `<presentation>`.
 - `workflow-content` is XML encoded as **UTF-16BE** with a big-endian BOM (`0xFE 0xFF`). A little-endian BOM (`0xFF 0xFE`) is rejected by live import.
-- `input_form_` is JSON encoded as UTF-16BE with a BOM.
+- The `workflow-content` XML **declaration must be `<?xml version='1.0' encoding='UTF-8'?>`** (single quotes, `UTF-8`) — exactly what vRO writes, even though the bytes are UTF-16BE (the BOM drives decoding). The VCF 9.x Orchestrate **editor returns a 500 when opening** a workflow whose declaration says `encoding="UTF-16"`, even though import and execution succeed.
+- `input_form_` is JSON encoded as UTF-16BE with a BOM. It holds both the `layout` (form) and the `schema`; the schema mirrors the workflow inputs, so keep them in sync (the builder generates the schema from the inputs).
 - The XML root looks like:
   - `<workflow xmlns="http://vmware.com/vco/workflow" ... root-name="..." object-name="workflow:name=generic" id="..." version="..." api-version="6.0.0" editor-version="2.0" ...>`
   - Use `editor-version="2.0"` and do **not** emit `allowed-operations` on authored workflows. The value `allowed-operations="vf"` is vRO's read-only marker for locked Library workflows; emitting it makes the Orchestrate editor treat the workflow as locked, so it shows *Details* instead of *Open* and returns a 500 when opened. Set `object-name` to lowercase `workflow:name=generic`; vRO normalizes it on export.
-- User-facing inputs live under `<input>`.
-- Workflow outputs live under `<output>`.
-- Scriptable tasks are `<workflow-item type="task">` nodes with a `<script encoded="false"><![CDATA[...]]></script>` body.
-- Flow is chained via `out-name`: each task points to the next item, and the final task points to an explicit terminal item `<workflow-item name="..." type="end" end-mode="0">`. Do **not** put `end-mode="1"` on a task — live import rejects scaffolds that lack an explicit `type="end"` item.
+- User-facing inputs/outputs are **bare** `<param name="..." type="..."/>` elements (no `<description>` child — descriptions belong in `<presentation>`/`input_form_`; a `<param>` description combined with the workflow `<description>` breaks the editor). Inputs live under `<input>`, outputs under `<output>`.
+- Scriptable tasks are `<workflow-item type="task">` nodes with a non-empty `<description>` and a `<script encoded="false"><![CDATA[...]]></script>` body.
+- Every item — the start node, each task, and the end item — needs a **distinct `<position>`**. If items overlap (all at `0,0`, which happens when positions are omitted) the editor's schema renderer fails. Lay them out left-to-right with increasing `x`.
+- Flow is chained via `out-name`: each task points to the next item, and the final task points to an explicit terminal item `<workflow-item name="..." type="end" end-mode="0">` that carries an empty `<in-binding/>`. Do **not** put `end-mode="1"` on a task — live import rejects scaffolds that lack an explicit `type="end"` item.
 - Prefer native vRO action workflow items when a workflow step only executes one existing action. Avoid wrapping a single action in a scriptable task that only calls `System.getModule(...)`.
 - Use scriptable tasks when the item performs multiple action calls or additional orchestration logic such as validation, branching, input shaping, or result aggregation.
 - Prefer horizontal workflow layouts: arrange sequential items left-to-right with increasing `x` positions and stable `y` positions unless a branch needs vertical separation.

--- a/docs/vro-artifact-authoring.md
+++ b/docs/vro-artifact-authoring.md
@@ -231,7 +231,7 @@ npm test
 
 Before uploading local artifacts, run the matching preflight tool:
 
-- `preflight-workflow-file` checks `.workflow` ZIP structure, the `workflow-info` properties file, UTF-16BE `workflow-content`, an explicit `type="end"` terminal item, UTF-16BE `input_form_` JSON when present, parameters, bindings, task flow, vRO type syntax, action references, and local import path safety.
+- `preflight-workflow-file` checks `.workflow` ZIP structure, the `workflow-info` properties file, UTF-16BE `workflow-content`, an explicit `type="end"` terminal item, UTF-16BE `input_form_` JSON when present, parameters, bindings, task flow, vRO type syntax, action references, and local import path safety. It also emits **warnings** (non-blocking) for shapes that import and run but make the VCF 9.x editor fail to *open* the workflow: an `encoding="UTF-16"` XML declaration, `<param>` `<description>` children, missing/overlapping item `<position>`s, an end item without `<in-binding/>`, and tasks without a `<description>`.
 - `preflight-action-file` checks `.action` ZIP/path safety and parses recognizable XML metadata conservatively.
 - `preflight-configuration-file` checks `.vsoconf` ZIP/path safety and parses recognizable XML metadata conservatively.
 - `preflight-package` checks `.package`/`.zip` import safety, inspects nested `.workflow`, `.action`, and `.vsoconf` artifacts when they are present, and validates package element `input_form_` entries.

--- a/docs/vro-artifact-authoring.md
+++ b/docs/vro-artifact-authoring.md
@@ -5,17 +5,19 @@ These notes capture the practical details learned while adding workflow artifact
 ## Workflow Artifact Format
 
 - A `.workflow` file is a ZIP archive.
-- The archive contains at least:
-  - `workflow-info`
-  - `workflow-content`
-  - `input_form_` for generated artifacts with UI-startable inputs
-- `workflow-content` is XML encoded as UTF-16 with a BOM.
+- The archive contains:
+  - `workflow-info` — a Java **properties** file (not XML). vRO writes the fixed keys `type=workflow`, `version=2.0`, `charset=UTF-16`, `unicode=true`, `creator=www.dunes.ch`, and `owner=`. The workflow's own id/name/version live in `workflow-content`, **not** here.
+  - `workflow-content` — the workflow XML.
+  - `input_form_` — only present when the workflow exposes inputs (UI-startable). Inputless workflows omit it and rely on the in-workflow `<presentation>`.
+- `workflow-content` is XML encoded as **UTF-16BE** with a big-endian BOM (`0xFE 0xFF`). A little-endian BOM (`0xFF 0xFE`) is rejected by live import.
 - `input_form_` is JSON encoded as UTF-16BE with a BOM.
 - The XML root looks like:
-  - `<workflow xmlns="http://vmware.com/vco/workflow" ... id="..." version="..." api-version="6.0.0">`
+  - `<workflow xmlns="http://vmware.com/vco/workflow" ... root-name="..." object-name="workflow:name=generic" id="..." version="..." api-version="6.0.0" editor-version="2.0" ...>`
+  - Use `editor-version="2.0"` and do **not** emit `allowed-operations` on authored workflows. The value `allowed-operations="vf"` is vRO's read-only marker for locked Library workflows; emitting it makes the Orchestrate editor treat the workflow as locked, so it shows *Details* instead of *Open* and returns a 500 when opened. Set `object-name` to lowercase `workflow:name=generic`; vRO normalizes it on export.
 - User-facing inputs live under `<input>`.
 - Workflow outputs live under `<output>`.
 - Scriptable tasks are `<workflow-item type="task">` nodes with a `<script encoded="false"><![CDATA[...]]></script>` body.
+- Flow is chained via `out-name`: each task points to the next item, and the final task points to an explicit terminal item `<workflow-item name="..." type="end" end-mode="0">`. Do **not** put `end-mode="1"` on a task — live import rejects scaffolds that lack an explicit `type="end"` item.
 - Prefer native vRO action workflow items when a workflow step only executes one existing action. Avoid wrapping a single action in a scriptable task that only calls `System.getModule(...)`.
 - Use scriptable tasks when the item performs multiple action calls or additional orchestration logic such as validation, branching, input shaping, or result aggregation.
 - Prefer horizontal workflow layouts: arrange sequential items left-to-right with increasing `x` positions and stable `y` positions unless a branch needs vertical separation.
@@ -228,7 +230,7 @@ npm test
 
 Before uploading local artifacts, run the matching preflight tool:
 
-- `preflight-workflow-file` checks `.workflow` ZIP structure, `workflow-info`, UTF-16 `workflow-content`, UTF-16BE `input_form_` JSON when present, parameters, bindings, task flow, vRO type syntax, action references, and local import path safety.
+- `preflight-workflow-file` checks `.workflow` ZIP structure, the `workflow-info` properties file, UTF-16BE `workflow-content`, an explicit `type="end"` terminal item, UTF-16BE `input_form_` JSON when present, parameters, bindings, task flow, vRO type syntax, action references, and local import path safety.
 - `preflight-action-file` checks `.action` ZIP/path safety and parses recognizable XML metadata conservatively.
 - `preflight-configuration-file` checks `.vsoconf` ZIP/path safety and parses recognizable XML metadata conservatively.
 - `preflight-package` checks `.package`/`.zip` import safety, inspects nested `.workflow`, `.action`, and `.vsoconf` artifacts when they are present, and validates package element `input_form_` entries.
@@ -253,7 +255,7 @@ Workflow files are read from the `workflows` subdirectory of `VCFA_ARTIFACT_DIR`
 - Avoid vertical-only layouts for simple linear workflows; horizontal layouts are easier to scan and match project conventions.
 - Do not omit `input_form_` for workflows with user inputs that should be started from the vRO UI.
 - Do not add `title` to input form sections or unverified properties like `size` to fields; vRO can reject the start page with schema validation errors.
-- `.workflow` content must preserve UTF-16 encoding with BOM.
+- `.workflow` `workflow-content` must be UTF-16BE with a big-endian BOM, `workflow-info` must be the Java properties file (not XML), and the workflow must terminate in an explicit `<workflow-item type="end">`; live import rejects any of these defects with `400 "Not a valid workflow file"`.
 - Multipart imports break if `Content-Type` is set manually without the boundary.
 - `VRA:Machine` inventory and VCFA deployments are not always a one-to-one match.
 - Workflow execution starts asynchronously; always poll `get-workflow-execution`.

--- a/src/client/artifact-preflight.ts
+++ b/src/client/artifact-preflight.ts
@@ -469,18 +469,14 @@ function inspectWorkflowArchiveFiles(
   if (!content) report.errors.push("Missing required workflow-content entry");
   if (!info || !content) return null;
 
-  const infoXml = decodeUtf8Xml(info, "workflow-info", report);
-  if (infoXml) {
-    const parsed = parseXml(infoXml, "workflow-info", report);
-    const workflowInfo = getObject(parsed, "workflow-info");
-    if (workflowInfo) {
-      copyMetadata(workflowInfo, report, ["id", "name", "version"]);
-    } else {
-      report.errors.push("workflow-info does not contain a workflow-info root");
-    }
-  }
+  validateWorkflowInfoProperties(info, report);
 
-  const contentXml = decodeUtf16XmlWithBom(content, "workflow-content", report);
+  const contentXml = decodeUtf16XmlWithBom(
+    content,
+    "workflow-content",
+    report,
+    "be",
+  );
   if (!contentXml) return null;
 
   const model = parseWorkflowContent(contentXml, report);
@@ -488,6 +484,49 @@ function inspectWorkflowArchiveFiles(
 
   validateWorkflowModel(model, report);
   return buildWorkflowInspection(model.root, report.metadata);
+}
+
+/**
+ * vRO writes `workflow-info` as a Java properties file (not XML). The workflow
+ * identity lives in `workflow-content`; this entry carries fixed container
+ * metadata. Reject the legacy XML shape that earlier scaffolds emitted.
+ */
+function validateWorkflowInfoProperties(
+  info: Uint8Array,
+  report: ArtifactPreflightReport,
+): void {
+  const text = decodeUtf8Text(info, "workflow-info", report);
+  if (text === null) return;
+  if (text.trimStart().startsWith("<")) {
+    report.errors.push(
+      "workflow-info must be a Java properties file (type=workflow, charset, unicode, creator), not XML",
+    );
+    return;
+  }
+  const properties = parseJavaProperties(text);
+  if (properties["type"] !== "workflow") {
+    report.errors.push('workflow-info must declare type=workflow');
+  }
+  for (const key of ["charset", "unicode", "creator"]) {
+    if (!(key in properties)) {
+      report.errors.push(`workflow-info is missing required property ${key}`);
+    }
+  }
+}
+
+/** Minimal Java .properties reader: ignores blank/`#`/`!` comment lines. */
+function parseJavaProperties(text: string): Record<string, string> {
+  const properties: Record<string, string> = {};
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "" || line.startsWith("#") || line.startsWith("!")) continue;
+    const separator = line.search(/[=:]/);
+    if (separator === -1) continue;
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim();
+    if (key) properties[key] = value;
+  }
+  return properties;
 }
 
 function validateGenericXmlArchive(
@@ -770,6 +809,10 @@ function parseWorkflowContent(
     "root-name",
     "object-name",
   ]);
+  // The human-readable name lives in workflow-content (workflow-info is now a
+  // fixed properties file), so surface it on the report for consumers.
+  const displayName = textValue(root["display-name"]).trim();
+  if (displayName) report.metadata["display-name"] = displayName;
 
   return { root };
 }
@@ -825,6 +868,8 @@ function validateWorkflowModel(
     report.errors.push(`Workflow root-name references unknown item ${rootName}`);
   }
 
+  validateWorkflowTermination(items, report);
+
   const nativeActionItems: string[] = [];
   for (const item of items) {
     validateWorkflowItemFlow(item, itemNames, report);
@@ -865,6 +910,32 @@ function validateWorkflowModel(
   }
   if (nativeActionItems.length > 0) {
     report.metadata["native-action-items"] = nativeActionItems.join("; ");
+  }
+}
+
+/**
+ * vRO terminates a workflow with an explicit `<workflow-item type="end">`
+ * item. The legacy scaffold instead set `end-mode="1"` on the final task,
+ * which live import rejects. Require the explicit end item and flag the
+ * legacy pattern.
+ */
+function validateWorkflowTermination(
+  items: XmlObject[],
+  report: ArtifactPreflightReport,
+): void {
+  const hasEndItem = items.some((item) => stringValue(item.type) === "end");
+  if (!hasEndItem) {
+    report.errors.push(
+      'workflow-content has no terminal item; expected an explicit <workflow-item type="end" end-mode="0">',
+    );
+  }
+  for (const item of items) {
+    if (stringValue(item.type) === "task" && item["end-mode"] !== undefined) {
+      const itemName = stringValue(item.name) || "(unnamed)";
+      report.errors.push(
+        `Task ${itemName} uses the unsupported end-mode attribute; chain it via out-name to an explicit type="end" item instead`,
+      );
+    }
   }
 }
 
@@ -1182,7 +1253,7 @@ function getScriptText(item: XmlObject): string {
   return "";
 }
 
-function decodeUtf8Xml(
+function decodeUtf8Text(
   content: Uint8Array,
   entryName: string,
   report: ArtifactPreflightReport,
@@ -1190,7 +1261,7 @@ function decodeUtf8Xml(
   try {
     return new TextDecoder("utf-8", { fatal: true }).decode(content);
   } catch (error) {
-    report.errors.push(`${entryName} is not valid UTF-8 XML: ${errorMessage(error)}`);
+    report.errors.push(`${entryName} is not valid UTF-8: ${errorMessage(error)}`);
     return null;
   }
 }
@@ -1199,8 +1270,9 @@ function decodeUtf16XmlWithBom(
   content: Uint8Array,
   entryName: string,
   report: ArtifactPreflightReport,
+  expected: Utf16Endianness = "any",
 ): string | null {
-  return decodeUtf16TextWithBom(content, entryName, "XML", report);
+  return decodeUtf16TextWithBom(content, entryName, "XML", report, expected);
 }
 
 type Utf16Endianness = "le" | "be" | "any";

--- a/src/client/artifact-preflight.ts
+++ b/src/client/artifact-preflight.ts
@@ -994,7 +994,14 @@ function validateBindings(
       report.errors.push(
         `${itemName} ${elementName} bind ${bindingName || "(unnamed)"} references unknown ${referenceLabel} ${exportName}`,
       );
-    } else if (bindingType && declaredType !== bindingType) {
+    } else if (
+      bindingType &&
+      declaredType !== bindingType &&
+      // vRO's generic actions return/accept `Any`, which is compatible with
+      // any concrete parameter type, so it is not a mismatch.
+      bindingType !== "Any" &&
+      declaredType !== "Any"
+    ) {
       report.errors.push(
         `${itemName} ${elementName} bind ${bindingName || "(unnamed)"} type ${bindingType} does not match ${exportName} type ${declaredType}`,
       );
@@ -1002,31 +1009,45 @@ function validateBindings(
   }
 }
 
+/**
+ * Returns the raw parameter nodes for a workflow section. Inputs and outputs
+ * wrap `<param>` children under `<input>`/`<output>`. Attributes have two
+ * shapes: vRO exports use repeated top-level `<attrib name type>` elements,
+ * while the scaffold historically wrapped a `<param>` inside `<attrib>`.
+ */
+function collectWorkflowParamNodes(
+  root: XmlObject,
+  sectionName: "input" | "output" | "attrib",
+): XmlObject[] {
+  if (sectionName === "attrib") {
+    const direct = asArray(root.attrib)
+      .filter(isObject)
+      .filter((node) => node.name !== undefined);
+    if (direct.length > 0) return direct;
+  }
+  const section = getObject(root, sectionName);
+  if (!section) return [];
+  return asArray(section.param).filter(isObject);
+}
+
 function collectWorkflowParams(
   root: XmlObject,
   sectionName: "input" | "output" | "attrib",
 ): ArtifactPreflightParameter[] {
-  const section = getObject(root, sectionName);
-  if (!section) return [];
-  return asArray(section.param)
-    .filter(isObject)
-    .map((param) => ({
-      name: stringValue(param.name),
-      type: stringValue(param.type),
-      scope: sectionName === "attrib" ? "attribute" : sectionName,
-    }));
+  return collectWorkflowParamNodes(root, sectionName).map((param) => ({
+    name: stringValue(param.name),
+    type: stringValue(param.type),
+    scope: sectionName === "attrib" ? "attribute" : sectionName,
+  }));
 }
 
 function collectWorkflowInspectionParams(
   root: XmlObject,
   sectionName: "input" | "output" | "attrib",
 ): WorkflowArtifactInspectionParameter[] {
-  const section = getObject(root, sectionName);
-  if (!section) return [];
   const scope: WorkflowArtifactInspectionParameter["scope"] =
     sectionName === "attrib" ? "attribute" : sectionName;
-  return asArray(section.param)
-    .filter(isObject)
+  return collectWorkflowParamNodes(root, sectionName)
     .map((param) => ({
       name: stringValue(param.name),
       type: stringValue(param.type),

--- a/src/client/artifact-preflight.ts
+++ b/src/client/artifact-preflight.ts
@@ -479,6 +479,17 @@ function inspectWorkflowArchiveFiles(
   );
   if (!contentXml) return null;
 
+  // Editor-compatibility: vRO writes encoding='UTF-8' (the BOM drives
+  // decoding). The VCF 9.x editor fails to OPEN a workflow whose declaration
+  // says encoding="UTF-16", even though import and execution still work.
+  if (/^\s*<\?xml[^>]*encoding\s*=\s*["']UTF-16["']/i.test(contentXml)) {
+    report.warnings.push(
+      'workflow-content XML declaration uses encoding="UTF-16"; vRO writes ' +
+        "encoding='UTF-8' (the UTF-16BE BOM drives decoding) and the VCF 9.x " +
+        "Orchestrate editor returns a 500 when opening a workflow that declares UTF-16",
+    );
+  }
+
   const model = parseWorkflowContent(contentXml, report);
   if (!model) return null;
 
@@ -910,6 +921,71 @@ function validateWorkflowModel(
   }
   if (nativeActionItems.length > 0) {
     report.metadata["native-action-items"] = nativeActionItems.join("; ");
+  }
+
+  warnEditorCompatibility(model.root, items, report);
+}
+
+/**
+ * Surfaces shapes that import and run but make vRO's VCF 9.x editor fail to
+ * OPEN the workflow (warnings, not errors — they don't block import/run).
+ */
+function warnEditorCompatibility(
+  root: XmlObject,
+  items: XmlObject[],
+  report: ArtifactPreflightReport,
+): void {
+  // Parameters should be bare <param/>; a <description> child combined with the
+  // workflow-level <description> makes the editor fail to open the workflow.
+  for (const section of ["input", "output"] as const) {
+    for (const param of collectWorkflowParamNodes(root, section)) {
+      if (param.description !== undefined) {
+        report.warnings.push(
+          `${section} parameter ${stringValue(param.name) || "(unnamed)"} has a <description> child; vRO emits bare <param/> elements (descriptions belong in <presentation>/input_form_) and the editor can fail to open the workflow`,
+        );
+      }
+    }
+  }
+
+  // Every item needs a distinct <position>; missing/overlapping positions
+  // (all at 0,0) break the editor's schema view.
+  const coords: string[] = [];
+  const rootPosition = getObject(root, "position");
+  if (rootPosition) {
+    coords.push(`${stringValue(rootPosition.x)},${stringValue(rootPosition.y)}`);
+  }
+  for (const item of items) {
+    const name = stringValue(item.name) || "(unnamed)";
+    const position = getObject(item, "position");
+    if (!position) {
+      report.warnings.push(
+        `Workflow item ${name} has no <position>; items without positions overlap at 0,0 and break the editor schema view`,
+      );
+    } else {
+      coords.push(`${stringValue(position.x)},${stringValue(position.y)}`);
+    }
+  }
+  if (coords.length > 1 && new Set(coords).size === 1) {
+    report.warnings.push(
+      "All workflow items share the same <position>; give each item distinct coordinates or the editor schema view breaks",
+    );
+  }
+
+  for (const item of items) {
+    const name = stringValue(item.name) || "(unnamed)";
+    const type = stringValue(item.type);
+    // vRO's editor expects an (empty) in-binding on the terminal item.
+    if (type === "end" && item["in-binding"] === undefined) {
+      report.warnings.push(
+        `End item ${name} is missing an <in-binding/>; vRO's editor expects one on the terminal item`,
+      );
+    }
+    // vRO drops empty task descriptions on import; the editor then fails to open.
+    if (type === "task" && !textValue(item.description).trim()) {
+      report.warnings.push(
+        `Task ${name} has no <description>; vRO drops empty descriptions and the editor can fail to open the workflow`,
+      );
+    }
   }
 }
 

--- a/src/client/workflow-artifact.ts
+++ b/src/client/workflow-artifact.ts
@@ -380,7 +380,7 @@ function renderWorkflowContentXml(spec: NormalizedSpec): string {
   const rootTaskName = spec.tasks[0]?.name ?? "item1";
   const taskNames = new Set(spec.tasks.map((task) => task.name));
   const endItemName = uniqueEndItemName(taskNames);
-  return [
+  const lines = [
     '<?xml version="1.0" encoding="UTF-16"?>',
     `<workflow xmlns="http://vmware.com/vco/workflow" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://vmware.com/vco/workflow http://vmware.com/vco/workflow/Workflow-v4.xsd" root-name="${escapeXmlAttribute(rootTaskName)}" object-name="workflow:name=generic" id="${escapeXmlAttribute(spec.id)}" version="${escapeXmlAttribute(spec.version)}" api-version="${escapeXmlAttribute(spec.apiVersion)}" editor-version="2.0" restartMode="1" resumeFromFailedMode="0">`,
     `  <display-name>${cdata(spec.name)}</display-name>`,
@@ -395,8 +395,8 @@ function renderWorkflowContentXml(spec: NormalizedSpec): string {
     renderPresentation(spec.inputs),
     "  <workflow-note />",
     "</workflow>",
-    "",
-  ].join("\n");
+  ].filter((line) => line !== "");
+  return `${lines.join("\n")}\n`;
 }
 
 /** Picks an end-item name that does not collide with any task name. */
@@ -437,18 +437,19 @@ function renderParameterSection(
 }
 
 function renderAttributes(attributes: WorkflowArtifactParameter[]): string {
-  if (attributes.length === 0) {
-    return "  <attrib />";
-  }
-
-  return [
-    "  <attrib>",
-    ...attributes.map(
-      (attribute) =>
-        `    <param name="${escapeXmlAttribute(attribute.name)}" type="${escapeXmlAttribute(attribute.type)}" scope="local"><description>${cdata(attribute.description ?? "")}</description></param>`,
-    ),
-    "  </attrib>",
-  ].join("\n");
+  // vRO exports each attribute as a top-level <attrib name type read-only>
+  // element with a <value> and <description>, not a <param> wrapped in
+  // <attrib>. Omit the section entirely when there are no attributes.
+  return attributes
+    .map((attribute) =>
+      [
+        `  <attrib name="${escapeXmlAttribute(attribute.name)}" type="${escapeXmlAttribute(attribute.type)}" read-only="false">`,
+        `    <value encoded="n">${cdata("__NULL__")}</value>`,
+        `    <description>${cdata(attribute.description ?? "")}</description>`,
+        "  </attrib>",
+      ].join("\n"),
+    )
+    .join("\n");
 }
 
 function renderTask(

--- a/src/client/workflow-artifact.ts
+++ b/src/client/workflow-artifact.ts
@@ -44,15 +44,22 @@ interface InputFormType {
 
 export function buildWorkflowArtifact(spec: WorkflowArtifactSpec): Uint8Array {
   const normalized = normalizeWorkflowArtifactSpec(spec);
-  return zipSync({
-    "workflow-info": utf8Bytes(buildWorkflowInfo(normalized)),
-    "workflow-content": utf16LeWithBom(renderWorkflowContentXml(normalized)),
-    "input_form_": utf16BeWithBom(renderWorkflowInputFormJson(normalized)),
-  });
+  const entries: Record<string, Uint8Array> = {
+    "workflow-info": utf8Bytes(buildWorkflowInfo()),
+    "workflow-content": utf16BeWithBom(renderWorkflowContentXml(normalized)),
+  };
+  // vRO only writes input_form_ for workflows that expose inputs; inputless
+  // workflows rely on the in-workflow <presentation>. Match that shape.
+  if (normalized.inputs.length > 0) {
+    entries["input_form_"] = utf16BeWithBom(
+      renderWorkflowInputFormJson(normalized),
+    );
+  }
+  return zipSync(entries);
 }
 
 export function buildWorkflowContent(spec: WorkflowArtifactSpec): Uint8Array {
-  return utf16LeWithBom(
+  return utf16BeWithBom(
     renderWorkflowContentXml(normalizeWorkflowArtifactSpec(spec)),
   );
 }
@@ -61,13 +68,20 @@ export function buildWorkflowContentXml(spec: WorkflowArtifactSpec): string {
   return renderWorkflowContentXml(normalizeWorkflowArtifactSpec(spec));
 }
 
-export function buildWorkflowInfo(spec: WorkflowArtifactSpec): string {
-  const normalized = normalizeWorkflowArtifactSpec(spec);
+/**
+ * Emits the `workflow-info` entry as the Java properties file vRO writes on
+ * export. The workflow's own identity (id/name/version) lives in
+ * `workflow-content`, not here — these keys are fixed container metadata.
+ */
+export function buildWorkflowInfo(): string {
   return [
-    '<?xml version="1.0" encoding="UTF-8"?>',
-    `<workflow-info id="${escapeXmlAttribute(normalized.id)}" name="${escapeXmlAttribute(
-      normalized.name,
-    )}" version="${escapeXmlAttribute(normalized.version)}" />`,
+    "#",
+    "owner=",
+    "charset=UTF-16",
+    "creator=www.dunes.ch",
+    "unicode=true",
+    "type=workflow",
+    "version=2.0",
     "",
   ].join("\n");
 }
@@ -364,21 +378,43 @@ function validateUniqueNames(
 
 function renderWorkflowContentXml(spec: NormalizedSpec): string {
   const rootTaskName = spec.tasks[0]?.name ?? "item1";
+  const taskNames = new Set(spec.tasks.map((task) => task.name));
+  const endItemName = uniqueEndItemName(taskNames);
   return [
     '<?xml version="1.0" encoding="UTF-16"?>',
-    `<workflow xmlns="http://vmware.com/vco/workflow" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://vmware.com/vco/workflow http://vmware.com/vco/workflow/Workflow-v4.xsd" root-name="${escapeXmlAttribute(rootTaskName)}" object-name="workflow:name=generic" id="${escapeXmlAttribute(spec.id)}" version="${escapeXmlAttribute(spec.version)}" api-version="${escapeXmlAttribute(spec.apiVersion)}" restartMode="1" resumeFromFailedMode="0">`,
+    `<workflow xmlns="http://vmware.com/vco/workflow" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://vmware.com/vco/workflow http://vmware.com/vco/workflow/Workflow-v4.xsd" root-name="${escapeXmlAttribute(rootTaskName)}" object-name="workflow:name=generic" id="${escapeXmlAttribute(spec.id)}" version="${escapeXmlAttribute(spec.version)}" api-version="${escapeXmlAttribute(spec.apiVersion)}" editor-version="2.0" restartMode="1" resumeFromFailedMode="0">`,
     `  <display-name>${cdata(spec.name)}</display-name>`,
     `  <description>${cdata(spec.description)}</description>`,
     renderParameterSection("input", spec.inputs),
     renderParameterSection("output", spec.outputs),
     renderAttributes(spec.attributes),
     ...spec.tasks.map((task, index) =>
-      renderTask(task, spec.tasks[index + 1]?.name),
+      renderTask(task, spec.tasks[index + 1]?.name ?? endItemName),
     ),
+    renderEndItem(endItemName),
     renderPresentation(spec.inputs),
     "  <workflow-note />",
     "</workflow>",
     "",
+  ].join("\n");
+}
+
+/** Picks an end-item name that does not collide with any task name. */
+function uniqueEndItemName(taskNames: Set<string>): string {
+  let candidate = "item_end";
+  let suffix = 0;
+  while (taskNames.has(candidate)) {
+    suffix += 1;
+    candidate = `item_end_${suffix}`;
+  }
+  return candidate;
+}
+
+function renderEndItem(name: string): string {
+  return [
+    `  <workflow-item name="${escapeXmlAttribute(name)}" type="end" end-mode="0">`,
+    '    <position y="0.0" x="0.0" />',
+    "  </workflow-item>",
   ].join("\n");
 }
 
@@ -417,11 +453,9 @@ function renderAttributes(attributes: WorkflowArtifactParameter[]): string {
 
 function renderTask(
   task: NormalizedWorkflowArtifactTask,
-  nextTaskName?: string,
+  nextItemName: string,
 ): string {
-  const flowAttrs = nextTaskName
-    ? ` out-name="${escapeXmlAttribute(nextTaskName)}"`
-    : ' end-mode="1"';
+  const flowAttrs = ` out-name="${escapeXmlAttribute(nextItemName)}"`;
   const scriptModuleAttr = task.scriptModule
     ? ` script-module="${escapeXmlAttribute(task.scriptModule)}"`
     : "";
@@ -568,10 +602,6 @@ function escapeXmlAttribute(value: string): string {
     .replaceAll('"', "&quot;")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;");
-}
-
-function utf16LeWithBom(value: string): Uint8Array {
-  return new Uint8Array([0xff, 0xfe, ...Buffer.from(value, "utf16le")]);
 }
 
 function utf16BeWithBom(value: string): Uint8Array {

--- a/src/client/workflow-artifact.ts
+++ b/src/client/workflow-artifact.ts
@@ -381,22 +381,37 @@ function renderWorkflowContentXml(spec: NormalizedSpec): string {
   const taskNames = new Set(spec.tasks.map((task) => task.name));
   const endItemName = uniqueEndItemName(taskNames);
   const lines = [
-    '<?xml version="1.0" encoding="UTF-16"?>',
+    // vRO writes this exact declaration (encoding='UTF-8' with single quotes)
+    // even though the bytes are UTF-16BE — the BOM drives decoding. The v2
+    // editor refuses to open a workflow whose declaration says encoding="UTF-16".
+    "<?xml version='1.0' encoding='UTF-8'?>",
     `<workflow xmlns="http://vmware.com/vco/workflow" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://vmware.com/vco/workflow http://vmware.com/vco/workflow/Workflow-v4.xsd" root-name="${escapeXmlAttribute(rootTaskName)}" object-name="workflow:name=generic" id="${escapeXmlAttribute(spec.id)}" version="${escapeXmlAttribute(spec.version)}" api-version="${escapeXmlAttribute(spec.apiVersion)}" editor-version="2.0" restartMode="1" resumeFromFailedMode="0">`,
     `  <display-name>${cdata(spec.name)}</display-name>`,
     `  <description>${cdata(spec.description)}</description>`,
+    // Start-node position. Items are laid out left-to-right; vRO's editor
+    // rejects workflows whose items overlap (all at 0,0), so emit distinct
+    // coordinates for the start node, each task, and the end item.
+    `  ${position(itemX(-1))}`,
     renderParameterSection("input", spec.inputs),
     renderParameterSection("output", spec.outputs),
     renderAttributes(spec.attributes),
     ...spec.tasks.map((task, index) =>
-      renderTask(task, spec.tasks[index + 1]?.name ?? endItemName),
+      renderTask(task, spec.tasks[index + 1]?.name ?? endItemName, index),
     ),
-    renderEndItem(endItemName),
+    renderEndItem(endItemName, spec.tasks.length),
     renderPresentation(spec.inputs),
-    "  <workflow-note />",
     "</workflow>",
   ].filter((line) => line !== "");
   return `${lines.join("\n")}\n`;
+}
+
+/** Horizontal layout: start node, tasks, then the end item, left to right. */
+function itemX(index: number): number {
+  return 60 + (index + 1) * 130;
+}
+
+function position(x: number): string {
+  return `<position y="60.0" x="${x.toFixed(1)}" />`;
 }
 
 /** Picks an end-item name that does not collide with any task name. */
@@ -410,10 +425,13 @@ function uniqueEndItemName(taskNames: Set<string>): string {
   return candidate;
 }
 
-function renderEndItem(name: string): string {
+function renderEndItem(name: string, taskCount: number): string {
   return [
     `  <workflow-item name="${escapeXmlAttribute(name)}" type="end" end-mode="0">`,
-    '    <position y="0.0" x="0.0" />',
+    // vRO's v2 editor requires the end item to carry an (empty) in-binding;
+    // without it the workflow imports and runs but fails to open in the editor.
+    "    <in-binding />",
+    `    ${position(itemX(taskCount))}`,
     "  </workflow-item>",
   ].join("\n");
 }
@@ -426,11 +444,15 @@ function renderParameterSection(
     return `  <${elementName} />`;
   }
 
+  // Emit bare <param> elements like vRO's editor does. A <description> child
+  // here, combined with the workflow-level <description>, makes the v2 editor
+  // fail to open the workflow; the parameter description is carried by the
+  // <presentation> and input_form_ instead.
   return [
     `  <${elementName}>`,
     ...parameters.map(
       (parameter) =>
-        `    <param name="${escapeXmlAttribute(parameter.name)}" type="${escapeXmlAttribute(parameter.type)}"><description>${cdata(parameter.description ?? "")}</description></param>`,
+        `    <param name="${escapeXmlAttribute(parameter.name)}" type="${escapeXmlAttribute(parameter.type)}" />`,
     ),
     `  </${elementName}>`,
   ].join("\n");
@@ -455,18 +477,23 @@ function renderAttributes(attributes: WorkflowArtifactParameter[]): string {
 function renderTask(
   task: NormalizedWorkflowArtifactTask,
   nextItemName: string,
+  index: number,
 ): string {
   const flowAttrs = ` out-name="${escapeXmlAttribute(nextItemName)}"`;
   const scriptModuleAttr = task.scriptModule
     ? ` script-module="${escapeXmlAttribute(task.scriptModule)}"`
     : "";
+  // vRO's editor drops an empty task description on import, and then the v2
+  // editor fails to open the workflow. Always emit a non-empty description.
+  const taskDescription = nonEmpty(task.description) ?? task.displayName;
   return [
     `  <workflow-item name="${escapeXmlAttribute(task.name)}" type="task"${scriptModuleAttr}${flowAttrs}>`,
     `    <display-name>${cdata(task.displayName)}</display-name>`,
-    `    <description>${cdata(task.description)}</description>`,
+    `    <description>${cdata(taskDescription)}</description>`,
     renderBindings("in-binding", task.inBindings, "source"),
     renderBindings("out-binding", task.outBindings, "target"),
     `    <script encoded="false">${cdata(task.script)}</script>`,
+    `    ${position(itemX(index))}`,
     "  </workflow-item>",
   ].join("\n");
 }

--- a/test/artifact-preflight.test.mjs
+++ b/test/artifact-preflight.test.mjs
@@ -59,7 +59,7 @@ test("preflightWorkflowFile accepts generated workflow artifacts and reports act
 
     assert.equal(report.valid, true);
     assert.equal(report.errors.length, 0);
-    assert.match(report.metadata.name, /Generated Workflow/);
+    assert.match(report.metadata["display-name"], /Generated Workflow/);
     assert.deepEqual(report.parameters, [
       { name: "message", type: "string", scope: "input" },
       { name: "result", type: "string", scope: "output" },
@@ -134,11 +134,12 @@ function nativeActionContentXml(scriptModule) {
     "  <output>",
     '    <param name="result" type="string" />',
     "  </output>",
-    `  <workflow-item name="item1" type="task" script-module="${scriptModule}" end-mode="1">`,
+    `  <workflow-item name="item1" type="task" script-module="${scriptModule}" out-name="end0">`,
     '    <in-binding><bind name="message" type="string" export-name="message" /></in-binding>',
     '    <out-binding><bind name="actionResult" type="string" export-name="result" /></out-binding>',
     '    <script>actionResult = System.getModule("com.example.actions").echo(message);</script>',
     "  </workflow-item>",
+    '  <workflow-item name="end0" type="end" end-mode="0" />',
     "</workflow>",
   ].join("\n");
 }
@@ -153,10 +154,8 @@ test("preflightWorkflowFile rejects malformed native action script-module values
     await writeFile(
       join(workflowDir, fileName),
       zipSync({
-        "workflow-info": new TextEncoder().encode(
-          '<workflow-info id="workflow-1" name="Bad Native Action" />',
-        ),
-        "workflow-content": utf16LeWithBom(nativeActionContentXml(scriptModule)),
+        "workflow-info": propertiesInfo(),
+        "workflow-content": utf16BeWithBom(nativeActionContentXml(scriptModule)),
       }),
     );
   }
@@ -187,17 +186,13 @@ test("preflightWorkflowFile reports malformed ZIPs, missing entries, and bad enc
   await writeFile(
     join(workflowDir, "missing.workflow"),
     zipSync({
-      "workflow-info": new TextEncoder().encode(
-        '<workflow-info id="workflow-1" name="Missing" />',
-      ),
+      "workflow-info": propertiesInfo(),
     }),
   );
   await writeFile(
     join(workflowDir, "utf8.workflow"),
     zipSync({
-      "workflow-info": new TextEncoder().encode(
-        '<workflow-info id="workflow-1" name="UTF8" />',
-      ),
+      "workflow-info": propertiesInfo(),
       "workflow-content": new TextEncoder().encode("<workflow />"),
     }),
   );
@@ -217,10 +212,8 @@ test("preflightWorkflowFile reports malformed ZIPs, missing entries, and bad enc
   await writeFile(
     join(workflowDir, "malformed.workflow"),
     zipSync({
-      "workflow-info": new TextEncoder().encode(
-        '<workflow-info id="workflow-1" name="Malformed" />',
-      ),
-      "workflow-content": utf16LeWithBom(malformedXml),
+      "workflow-info": propertiesInfo(),
+      "workflow-content": utf16BeWithBom(malformedXml),
     }),
   );
 
@@ -238,7 +231,7 @@ test("preflightWorkflowFile reports malformed ZIPs, missing entries, and bad enc
 
     const utf8 = await preflightWorkflowFile(workflowDir, "utf8.workflow");
     assert.equal(utf8.valid, false);
-    assert.match(utf8.errors.join("\n"), /UTF-16 XML with a BOM/);
+    assert.match(utf8.errors.join("\n"), /UTF-16BE XML with a BOM/);
 
     const malformed = await preflightWorkflowFile(
       workflowDir,
@@ -274,10 +267,8 @@ test("preflightWorkflowFile reports binding and parameter validation errors", as
   await writeFile(
     join(workflowDir, "invalid.workflow"),
     zipSync({
-      "workflow-info": new TextEncoder().encode(
-        '<workflow-info id="workflow-1" name="Invalid" />',
-      ),
-      "workflow-content": utf16LeWithBom(invalidXml),
+      "workflow-info": propertiesInfo(),
+      "workflow-content": utf16BeWithBom(invalidXml),
     }),
   );
 
@@ -291,6 +282,95 @@ test("preflightWorkflowFile reports binding and parameter validation errors", as
     assert.match(errors, /references unknown source unknown/);
     assert.match(errors, /type string does not match result type number/);
     assert.match(errors, /missing script content/);
+  } finally {
+    await rm(workflowDir, { recursive: true, force: true });
+  }
+});
+
+test("preflightWorkflowFile rejects the legacy scaffold container format", async () => {
+  const workflowDir = await mkdtemp(join(tmpdir(), "vcfa-preflight-"));
+  // Pre-VCFO-060 scaffold: XML workflow-info + UTF-16LE workflow-content.
+  const legacyXml = [
+    '<?xml version="1.0" encoding="UTF-16"?>',
+    '<workflow id="wf-legacy" root-name="item0">',
+    "  <input /><output /><attrib />",
+    '  <workflow-item name="item0" type="task" end-mode="1">',
+    "    <in-binding /><out-binding />",
+    "    <script>System.log('x');</script>",
+    "  </workflow-item>",
+    "</workflow>",
+  ].join("\n");
+  await writeFile(
+    join(workflowDir, "legacy.workflow"),
+    zipSync({
+      "workflow-info": new TextEncoder().encode(
+        '<workflow-info id="wf-legacy" name="Legacy" />',
+      ),
+      "workflow-content": utf16LeWithBom(legacyXml),
+    }),
+  );
+  // Properties info + BE content, but the terminal task still uses end-mode="1"
+  // instead of an explicit end item — should be flagged once it parses.
+  await writeFile(
+    join(workflowDir, "legacy-end.workflow"),
+    zipSync({
+      "workflow-info": propertiesInfo(),
+      "workflow-content": utf16BeWithBom(legacyXml),
+    }),
+  );
+
+  try {
+    const legacy = await preflightWorkflowFile(workflowDir, "legacy.workflow");
+    assert.equal(legacy.valid, false);
+    const legacyErrors = legacy.errors.join("\n");
+    assert.match(legacyErrors, /workflow-info must be a Java properties file/);
+    assert.match(legacyErrors, /must be UTF-16BE.*found a UTF-16LE BOM/);
+
+    const legacyEnd = await preflightWorkflowFile(
+      workflowDir,
+      "legacy-end.workflow",
+    );
+    assert.equal(legacyEnd.valid, false);
+    const endErrors = legacyEnd.errors.join("\n");
+    assert.match(endErrors, /unsupported end-mode attribute/);
+    assert.match(endErrors, /no terminal item/);
+  } finally {
+    await rm(workflowDir, { recursive: true, force: true });
+  }
+});
+
+test("preflightWorkflowFile accepts a real-export-shaped workflow container", async () => {
+  const workflowDir = await mkdtemp(join(tmpdir(), "vcfa-preflight-"));
+  // Mirrors vRO's own export: properties workflow-info, UTF-16BE content,
+  // explicit type="end" item, and no input_form_ entry.
+  const exportXml = [
+    '<?xml version="1.0" encoding="UTF-16"?>',
+    '<workflow xmlns="http://vmware.com/vco/workflow" root-name="item0" object-name="Workflow:name=generic" id="wf-export-1" version="1.0.0" api-version="6.0.0" allowed-operations="vf">',
+    "  <display-name><![CDATA[Export Shaped]]></display-name>",
+    '  <input><param name="message" type="string" /></input>',
+    '  <output><param name="result" type="string" /></output>',
+    "  <attrib />",
+    '  <workflow-item name="item0" type="task" out-name="end0">',
+    '    <in-binding><bind name="message" type="string" export-name="message" /></in-binding>',
+    '    <out-binding><bind name="result" type="string" export-name="result" /></out-binding>',
+    "    <script>result = message;</script>",
+    "  </workflow-item>",
+    '  <workflow-item name="end0" type="end" end-mode="0"><position y="0.0" x="0.0" /></workflow-item>',
+    "</workflow>",
+  ].join("\n");
+  await writeFile(
+    join(workflowDir, "export.workflow"),
+    zipSync({
+      "workflow-info": propertiesInfo(),
+      "workflow-content": utf16BeWithBom(exportXml),
+    }),
+  );
+
+  try {
+    const report = await preflightWorkflowFile(workflowDir, "export.workflow");
+    assert.equal(report.errors.join("\n"), "");
+    assert.equal(report.valid, true);
+    assert.match(report.metadata["display-name"], /Export Shaped/);
   } finally {
     await rm(workflowDir, { recursive: true, force: true });
   }
@@ -747,6 +827,12 @@ test("malformed imports fail preflight before authentication or upload", async (
   }
 });
 
+function propertiesInfo() {
+  return new TextEncoder().encode(
+    "#\nowner=\ncharset=UTF-16\ncreator=www.dunes.ch\nunicode=true\ntype=workflow\nversion=2.0\n",
+  );
+}
+
 function utf16LeWithBom(value) {
   return new Uint8Array([0xff, 0xfe, ...Buffer.from(value, "utf16le")]);
 }
@@ -773,18 +859,17 @@ function workflowArchiveWithFlow(outName) {
     "    <out-binding />",
     "    <script>System.log('one');</script>",
     "  </workflow-item>",
-    `  <workflow-item name="${outName}" type="task" end-mode="1">`,
+    `  <workflow-item name="${outName}" type="task" out-name="end0">`,
     "    <in-binding />",
     "    <out-binding />",
     "    <script>System.log('two');</script>",
     "  </workflow-item>",
+    '  <workflow-item name="end0" type="end" end-mode="0" />',
     "</workflow>",
   ].join("\n");
   return zipSync({
-    "workflow-info": new TextEncoder().encode(
-      '<workflow-info id="workflow-1" name="Flow" />',
-    ),
-    "workflow-content": utf16LeWithBom(xml),
+    "workflow-info": propertiesInfo(),
+    "workflow-content": utf16BeWithBom(xml),
   });
 }
 

--- a/test/artifact-preflight.test.mjs
+++ b/test/artifact-preflight.test.mjs
@@ -376,6 +376,61 @@ test("preflightWorkflowFile accepts a real-export-shaped workflow container", as
   }
 });
 
+test("preflightWorkflowFile accepts vRO attribute and Any binding shapes", async () => {
+  const workflowDir = await mkdtemp(join(tmpdir(), "vcfa-preflight-"));
+  // Mirrors the createSnapshot reference export: attributes as repeated
+  // top-level <attrib name type> elements (referenced by item bindings), and a
+  // generic action returning type="Any" bound to a concretely typed output.
+  const exportXml = [
+    '<?xml version="1.0" encoding="UTF-16"?>',
+    '<workflow xmlns="http://vmware.com/vco/workflow" root-name="item0" object-name="Workflow:name=generic" id="wf-attr-1" version="1.0.0" api-version="6.0.0" allowed-operations="vf">',
+    "  <display-name><![CDATA[Attr Export Shaped]]></display-name>",
+    '  <input><param name="vm" type="VC:VirtualMachine" /></input>',
+    '  <output><param name="snapshot" type="VC:VirtualMachineSnapshot" /></output>',
+    '  <attrib name="task" type="VC:Task" read-only="false"><value encoded="n"><![CDATA[__NULL__]]></value></attrib>',
+    '  <attrib name="progress" type="boolean" read-only="false"><value encoded="n"><![CDATA[false]]></value></attrib>',
+    '  <workflow-item name="item0" out-name="item1" type="task" script-module="com.vmware.library.vc.vm.snapshot/createSnapshot">',
+    '    <in-binding><bind name="vm" type="VC:VirtualMachine" export-name="vm" /></in-binding>',
+    '    <out-binding><bind name="actionResult" type="VC:Task" export-name="task" /></out-binding>',
+    "    <script>actionResult = System.getModule(&quot;com.vmware.library.vc.vm.snapshot&quot;).createSnapshot(vm);</script>",
+    "  </workflow-item>",
+    '  <workflow-item name="item1" out-name="end0" type="task" script-module="com.vmware.library.vc.basic/vim3WaitTaskEnd">',
+    "    <in-binding>",
+    '      <bind name="task" type="VC:Task" export-name="task" />',
+    '      <bind name="progress" type="boolean" export-name="progress" />',
+    "    </in-binding>",
+    '    <out-binding><bind name="actionResult" type="Any" export-name="snapshot" /></out-binding>',
+    "    <script>actionResult = System.getModule(&quot;com.vmware.library.vc.basic&quot;).vim3WaitTaskEnd(task,progress);</script>",
+    "  </workflow-item>",
+    '  <workflow-item name="end0" type="end" end-mode="0" />',
+    "</workflow>",
+  ].join("\n");
+  await writeFile(
+    join(workflowDir, "attr-export.workflow"),
+    zipSync({
+      "workflow-info": propertiesInfo(),
+      "workflow-content": utf16BeWithBom(exportXml),
+    }),
+  );
+
+  try {
+    const report = await preflightWorkflowFile(
+      workflowDir,
+      "attr-export.workflow",
+    );
+    assert.equal(report.errors.join("\n"), "");
+    assert.equal(report.valid, true);
+    // Attributes parsed from the repeated <attrib> shape are reported.
+    const attrs = report.parameters
+      .filter((p) => p.scope === "attribute")
+      .map((p) => p.name)
+      .sort();
+    assert.deepEqual(attrs, ["progress", "task"]);
+  } finally {
+    await rm(workflowDir, { recursive: true, force: true });
+  }
+});
+
 test("preflightWorkflowFile rejects unsafe file and archive paths", async () => {
   const workflowDir = await mkdtemp(join(tmpdir(), "vcfa-preflight-"));
   const outsideFile = join(tmpdir(), `outside-${Date.now()}.workflow`);

--- a/test/artifact-preflight.test.mjs
+++ b/test/artifact-preflight.test.mjs
@@ -431,6 +431,48 @@ test("preflightWorkflowFile accepts vRO attribute and Any binding shapes", async
   }
 });
 
+test("preflightWorkflowFile warns about editor-incompatible shapes that still import", async () => {
+  const workflowDir = await mkdtemp(join(tmpdir(), "vcfa-preflight-"));
+  // Imports and runs, but the VCF 9.x editor would 500 on opening it:
+  // encoding="UTF-16" declaration, a <param> description child, no item
+  // positions, an empty task description, and an end item with no in-binding.
+  const xml = [
+    '<?xml version="1.0" encoding="UTF-16"?>',
+    '<workflow xmlns="http://vmware.com/vco/workflow" root-name="step" object-name="workflow:name=generic" id="wf-warn-1" version="1.0.0" api-version="6.0.0">',
+    "  <display-name><![CDATA[Warn WF]]></display-name>",
+    '  <input><param name="message" type="string"><description><![CDATA[Msg]]></description></param></input>',
+    '  <output><param name="result" type="string" /></output>',
+    '  <workflow-item name="step" type="task" out-name="end0">',
+    '    <in-binding><bind name="message" type="string" export-name="message" /></in-binding>',
+    '    <out-binding><bind name="result" type="string" export-name="result" /></out-binding>',
+    "    <script>result = message;</script>",
+    "  </workflow-item>",
+    '  <workflow-item name="end0" type="end" end-mode="0" />',
+    "</workflow>",
+  ].join("\n");
+  await writeFile(
+    join(workflowDir, "warn.workflow"),
+    zipSync({
+      "workflow-info": propertiesInfo(),
+      "workflow-content": utf16BeWithBom(xml),
+    }),
+  );
+
+  try {
+    const report = await preflightWorkflowFile(workflowDir, "warn.workflow");
+    // Editor-incompatibility is advisory: import/run still work, so it stays valid.
+    assert.equal(report.valid, true);
+    const warnings = report.warnings.join("\n");
+    assert.match(warnings, /declaration uses encoding="UTF-16"/);
+    assert.match(warnings, /input parameter message has a <description> child/);
+    assert.match(warnings, /item step has no <position>/);
+    assert.match(warnings, /End item end0 is missing an <in-binding\/>/);
+    assert.match(warnings, /Task step has no <description>/);
+  } finally {
+    await rm(workflowDir, { recursive: true, force: true });
+  }
+});
+
 test("preflightWorkflowFile rejects unsafe file and archive paths", async () => {
   const workflowDir = await mkdtemp(join(tmpdir(), "vcfa-preflight-"));
   const outsideFile = join(tmpdir(), `outside-${Date.now()}.workflow`);

--- a/test/workflow-artifact.test.mjs
+++ b/test/workflow-artifact.test.mjs
@@ -79,7 +79,11 @@ test("buildWorkflowContent creates UTF-16BE workflow XML with metadata and bindi
   );
   assert.match(xml, /<param name="projectName" type="string">/);
   assert.match(xml, /<param name="vmCount" type="number">/);
-  assert.match(xml, /<param name="runningTotal" type="number" scope="local">/);
+  assert.match(
+    xml,
+    /<attrib name="runningTotal" type="number" read-only="false">/,
+  );
+  assert.match(xml, /<value encoded="n"><!\[CDATA\[__NULL__\]\]><\/value>/);
   assert.match(
     xml,
     /<workflow-item name="item1" type="task" out-name="finish">/,

--- a/test/workflow-artifact.test.mjs
+++ b/test/workflow-artifact.test.mjs
@@ -63,6 +63,9 @@ test("buildWorkflowContent creates UTF-16BE workflow XML with metadata and bindi
   assert.equal(content[1], 0xff);
 
   const xml = new TextDecoder("utf-16be").decode(content);
+  // vRO writes encoding='UTF-8' (single quotes) even though the bytes are
+  // UTF-16BE; the v2 editor refuses to open a workflow declaring UTF-16.
+  assert.match(xml, /^<\?xml version='1\.0' encoding='UTF-8'\?>/);
   assert.match(xml, /<workflow /);
   assert.match(xml, /id="workflow-1"/);
   assert.match(xml, /version="1\.0\.0"/);
@@ -77,8 +80,11 @@ test("buildWorkflowContent creates UTF-16BE workflow XML with metadata and bindi
     xml,
     /<display-name><!\[CDATA\[Provision <VM>\]\]><\/display-name>/,
   );
-  assert.match(xml, /<param name="projectName" type="string">/);
-  assert.match(xml, /<param name="vmCount" type="number">/);
+  // Parameters are bare <param/> elements (descriptions live in presentation /
+  // input_form_); a <description> child here breaks the v2 editor.
+  assert.match(xml, /<param name="projectName" type="string" \/>/);
+  assert.match(xml, /<param name="vmCount" type="number" \/>/);
+  assert.doesNotMatch(xml, /<param[^>]*>\s*<description>/);
   assert.match(
     xml,
     /<attrib name="runningTotal" type="number" read-only="false">/,
@@ -98,6 +104,18 @@ test("buildWorkflowContent creates UTF-16BE workflow XML with metadata and bindi
     xml,
     /<workflow-item name="item_end" type="end" end-mode="0">/,
   );
+  // The v2 editor requires the end item to carry an empty in-binding, and
+  // every item needs a distinct position (overlapping at 0,0 breaks the
+  // editor's schema renderer).
+  assert.match(
+    xml,
+    /<workflow-item name="item_end" type="end" end-mode="0">\s*<in-binding \/>/,
+  );
+  const positions = [...xml.matchAll(/<position y="[^"]*" x="([^"]*)" \/>/g)].map(
+    (m) => m[1],
+  );
+  assert.equal(positions.length, 4); // start + 2 tasks + end
+  assert.equal(new Set(positions).size, 4); // all distinct
   assert.match(
     xml,
     /<bind name="projectName" type="string" export-name="projectName" \/>/,

--- a/test/workflow-artifact.test.mjs
+++ b/test/workflow-artifact.test.mjs
@@ -57,16 +57,22 @@ const workflow = {
   ],
 };
 
-test("buildWorkflowContent creates UTF-16LE workflow XML with metadata and bindings", () => {
+test("buildWorkflowContent creates UTF-16BE workflow XML with metadata and bindings", () => {
   const content = buildWorkflowContent(workflow);
-  assert.equal(content[0], 0xff);
-  assert.equal(content[1], 0xfe);
+  assert.equal(content[0], 0xfe);
+  assert.equal(content[1], 0xff);
 
-  const xml = new TextDecoder("utf-16le").decode(content);
+  const xml = new TextDecoder("utf-16be").decode(content);
   assert.match(xml, /<workflow /);
   assert.match(xml, /id="workflow-1"/);
   assert.match(xml, /version="1\.0\.0"/);
   assert.match(xml, /api-version="6\.0\.0"/);
+  // Editable user workflow: lowercase object-name, editor-version, and NO
+  // allowed-operations (that flag marks read-only Library workflows and makes
+  // the vRO editor refuse to open the workflow).
+  assert.match(xml, /object-name="workflow:name=generic"/);
+  assert.match(xml, /editor-version="2\.0"/);
+  assert.doesNotMatch(xml, /allowed-operations/);
   assert.match(
     xml,
     /<display-name><!\[CDATA\[Provision <VM>\]\]><\/display-name>/,
@@ -78,7 +84,16 @@ test("buildWorkflowContent creates UTF-16LE workflow XML with metadata and bindi
     xml,
     /<workflow-item name="item1" type="task" out-name="finish">/,
   );
-  assert.match(xml, /<workflow-item name="finish" type="task" end-mode="1">/);
+  // Last task chains to an explicit end item; no end-mode on tasks.
+  assert.match(
+    xml,
+    /<workflow-item name="finish" type="task" out-name="item_end">/,
+  );
+  assert.doesNotMatch(xml, /type="task"[^>]*end-mode/);
+  assert.match(
+    xml,
+    /<workflow-item name="item_end" type="end" end-mode="0">/,
+  );
   assert.match(
     xml,
     /<bind name="projectName" type="string" export-name="projectName" \/>/,
@@ -94,13 +109,19 @@ test("buildWorkflowArtifact creates a .workflow zip with required entries", () =
   assert.ok(files["workflow-content"]);
   assert.ok(files["input_form_"]);
 
+  // workflow-info is a Java properties file, not XML; identity lives in content.
   const info = new TextDecoder().decode(files["workflow-info"]);
-  assert.match(info, /workflow-info id="workflow-1"/);
+  assert.match(info, /^type=workflow$/m);
+  assert.match(info, /^version=2\.0$/m);
+  assert.match(info, /^charset=UTF-16$/m);
+  assert.match(info, /^unicode=true$/m);
+  assert.match(info, /^creator=www\.dunes\.ch$/m);
+  assert.doesNotMatch(info, /</);
 
   const content = files["workflow-content"];
-  assert.equal(content[0], 0xff);
-  assert.equal(content[1], 0xfe);
-  const xml = new TextDecoder("utf-16le").decode(content);
+  assert.equal(content[0], 0xfe);
+  assert.equal(content[1], 0xff);
+  const xml = new TextDecoder("utf-16be").decode(content);
   assert.match(xml, /<script encoded="false"><!\[CDATA\[/);
   assert.match(xml, /<presentation>/);
 
@@ -134,6 +155,19 @@ test("buildWorkflowArtifact creates a .workflow zip with required entries", () =
   assert.deepEqual(inputForm.options, { externalValidations: [] });
 });
 
+test("buildWorkflowArtifact omits input_form_ when the workflow has no inputs", () => {
+  const files = unzipSync(
+    buildWorkflowArtifact({
+      name: "Inputless",
+      tasks: [{ name: "only", script: "x = 1;" }],
+    }),
+  );
+
+  assert.ok(files["workflow-info"]);
+  assert.ok(files["workflow-content"]);
+  assert.equal(files["input_form_"], undefined);
+});
+
 const actionWorkflow = {
   id: "workflow-action-1",
   name: "Echo Message",
@@ -153,13 +187,13 @@ const actionWorkflow = {
 };
 
 test("buildWorkflowContent renders a native action workflow item", () => {
-  const xml = new TextDecoder("utf-16le").decode(
+  const xml = new TextDecoder("utf-16be").decode(
     buildWorkflowContent(actionWorkflow),
   );
 
   assert.match(
     xml,
-    /<workflow-item name="item1" type="task" script-module="com\.example\.actions\/echo" end-mode="1">/,
+    /<workflow-item name="item1" type="task" script-module="com\.example\.actions\/echo" out-name="item_end">/,
   );
   assert.match(
     xml,
@@ -176,7 +210,7 @@ test("buildWorkflowContent renders a native action workflow item", () => {
 });
 
 test("native action item with no resultBinding omits actionResult and out-binding", () => {
-  const xml = new TextDecoder("utf-16le").decode(
+  const xml = new TextDecoder("utf-16be").decode(
     buildWorkflowContent({
       ...actionWorkflow,
       outputs: [],
@@ -194,7 +228,7 @@ test("native action item with no resultBinding omits actionResult and out-bindin
 
   assert.match(
     xml,
-    /<workflow-item name="item1" type="task" script-module="com\.example\.actions\/logIt" end-mode="1">/,
+    /<workflow-item name="item1" type="task" script-module="com\.example\.actions\/logIt" out-name="item_end">/,
   );
   assert.match(
     xml,
@@ -260,17 +294,17 @@ test("buildWorkflowInputFormJson maps common vRO input types", () => {
   assert.equal(inputForm.layout.pages[0].sections[0].fields[2].display, "passwordField");
 });
 
-test("buildWorkflowArtifact reuses generated workflow ID across archive entries", () => {
+test("buildWorkflowArtifact generates a workflow ID in workflow-content", () => {
   const archive = buildWorkflowArtifact({ ...workflow, id: undefined });
   const files = unzipSync(archive);
-  const info = new TextDecoder().decode(files["workflow-info"]);
-  const xml = new TextDecoder("utf-16le").decode(files["workflow-content"]);
+  const xml = new TextDecoder("utf-16be").decode(files["workflow-content"]);
 
-  const infoId = info.match(/id="([^"]+)"/)?.[1];
   const contentId = xml.match(/ id="([^"]+)"/)?.[1];
 
-  assert.ok(infoId);
-  assert.equal(contentId, infoId);
+  assert.match(
+    contentId ?? "",
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+  );
 });
 
 test("workflow artifact builder rejects structural validation errors", () => {


### PR DESCRIPTION
## Summary

Scaffolded `.workflow` artifacts (`scaffold-workflow-file` / `buildWorkflowArtifact`) were rejected by live vRO 9.1 import, and once that was fixed, the imported workflows could not be opened in the VCF 9.x Orchestrate editor. This PR makes scaffolded workflows **import, open in the editor, and run** — verified end to end against the lab — and fixes preflight/diff handling of real vRO exports.

All findings were pinned down by byte-diffing builder output against real vRO exports (both read-only Library workflows and editable user workflows) and by live import/open/run cycles in the lab.

### VCFO-060 — container format (import)
- `workflow-info`: emit the Java **properties** file vRO writes (not XML); workflow identity lives in `workflow-content`.
- `workflow-content`: encode **UTF-16BE** (BOM `0xFE 0xFF`).
- Explicit terminal `<workflow-item type="end" end-mode="0">` chained via `out-name` instead of `end-mode="1"` on the last task.
- `input_form_` only when the workflow has inputs.
- Editable-workflow root attrs: `editor-version="2.0"`, lowercase `object-name="workflow:name=generic"`, and **no** `allowed-operations` (that flag is vRO's read-only/locked marker — it made the editor show *Details* instead of *Open* and 500 on open).

### VCFO-060 — editor compatibility (open)
- **`workflow-content` XML declaration must be `<?xml version='1.0' encoding='UTF-8'?>`** (single quotes, `UTF-8`) even though the bytes are UTF-16BE (the BOM drives decoding). The v2 editor returns **500** on a declaration saying `encoding="UTF-16"`. This was the primary editor-open root cause.
- End item carries an empty `<in-binding/>`.
- Every item (start node, each task, end item) gets a **distinct `<position>`** (omitted positions default to `0,0`, overlap, and break the schema renderer).
- `<param>` elements are **bare** (no `<description>` child — combined with the workflow `<description>` it breaks the editor; descriptions live in `<presentation>`/`input_form_`).
- Tasks always carry a non-empty `<description>`; dropped the empty `<workflow-note>`.

### VCFO-061 — preflight/diff for real vRO exports
- Parse vRO's repeated `<attrib name type read-only>` attribute shape (not just the scaffold's wrapped `<attrib><param>`); the builder now emits the vRO shape too, so scaffolds and exports round-trip identically.
- Tolerate `Any` in binding type-match checks (vRO's generic actions return `Any`).
- Preflight hardening: parse `workflow-info` as properties, require UTF-16BE content, reject the legacy `end-mode="1"` pattern; surface the human name from `workflow-content`'s `display-name`.

## Testing
- `npm run validate` green: 291 tests, coverage 92.51/82.14/93.13, docs drift, package contents.
- **Live-verified in the lab**: scaffold → preflight → import (no 400) → **open in the v2 editor** (no 500) → run, for a workflow with input, output, attribute, and a scriptable task; plus export round-trip and preflight of the real `reference-create-snapshot` export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)