### PR TITLE
chore: release 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.2.1 - 2026-06-14
+
+This release completes and hardens scaffolded-workflow support so generated `.workflow` artifacts import, open in the editor, and run in live vRO 9.1, and lets the scaffolder emit native vRO action workflow items.
+
+### Added
+
+- `scaffold-workflow-file` can emit **native vRO action workflow items** via an optional `kind: "action"` task discriminator (`module`, `actionName`, ordered `inputs`, `resultBinding`), generating the `actionResult = System.getModule("<module>").<actionName>(...)` script and a `type="task" script-module="<module>/<actionName>"` item; void actions omit `resultBinding` and emit a bare call. Tasks without `kind` behave exactly as before. `preflight-workflow-file` validates the `<module>/<actionName>` form and `diff-workflow-file` surfaces native-action item changes (VCFO-046, VCFO-059).
+
+### Fixed
+
+- Scaffolded `.workflow` artifacts now **import, open in the VCF 9.x Orchestrate editor, and run** in live vRO 9.1. The builder emits `workflow-info` as a Java properties file (not XML), encodes `workflow-content` as UTF-16BE with a `UTF-8` XML declaration (the BOM drives decoding; the v2 editor returns 500 on a declaration saying `UTF-16`), chains an explicit terminal `<workflow-item type="end">` (replacing `end-mode="1"` on the last task), writes `input_form_` only when the workflow has inputs, drops the read-only `allowed-operations` marker that made the editor refuse to open the workflow, and gives every item a distinct `<position>` with bare `<param>` elements (VCFO-060).
+- `preflight-workflow-file` and `diff-workflow-file` now parse vRO's native repeated `<attrib name type read-only>` attribute shape (not just the scaffold's wrapped form), so scaffolds and real exports round-trip identically; binding type-match tolerates vRO's generic `Any`; and preflight parses `workflow-info` as properties, requires UTF-16BE content, and rejects the legacy `end-mode="1"` pattern (VCFO-061).
+
 ## 2.2.0 - 2026-06-12
 
 This release adds VCF Automation 9.1 support with automatic API version negotiation, provider/system administrator logins, and fixes workflow and configuration parameter payloads to use the canonical vRO type keys the REST API expects.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mgovedarov/mcp-vcf-orchestrator",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mgovedarov/mcp-vcf-orchestrator",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mgovedarov/mcp-vcf-orchestrator",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "MCP server for VCF Automation Orchestrator — manage workflows, actions, configuration elements, and extensibility subscriptions via AI assistants",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release **2.2.1** — completes and hardens scaffolded-workflow support and lets the scaffolder emit native vRO action workflow items. Release-PR-only flow (feature PRs #102/#103 already merged with no CHANGELOG entries).

Touches only `CHANGELOG.md`, `package.json`, `package-lock.json`.

## Changelog (2.2.1)

### Added
- `scaffold-workflow-file` can emit **native vRO action workflow items** via an optional `kind: "action"` task discriminator; `preflight-workflow-file`/`diff-workflow-file` are aware of them (VCFO-046, VCFO-059).

### Fixed
- Scaffolded `.workflow` artifacts now **import, open in the VCF 9.x editor, and run** in live vRO 9.1 — container format, UTF-16BE content with UTF-8 declaration, terminal `end` item, distinct positions, dropped `allowed-operations` (VCFO-060).
- Preflight/diff parse vRO's native `<attrib>` shape and round-trip with real exports; tolerate `Any`; reject legacy `end-mode="1"` (VCFO-061).

## Validation
`npm run validate` green: build, 291 tests, coverage 92.54/82.16/93.14 (≥80/70/80), docs/examples drift, VitePress build, package contents (208 files). No live VCFA contact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)